### PR TITLE
Fix Telegram update parsing: map 'from' JSON field to from_user

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,26 @@ configure_logging()
 logger = structlog.get_logger(__name__)
 
 
+def _sanitize_webhook_url(url):
+    """Recover from a common paste mistake: 'TELEGRAM_WEBHOOK_URL=https://...'.
+
+    If the value does not start with http(s) but contains an URL, take the URL
+    part and log a warning so the misconfiguration is visible.
+    """
+    if not url:
+        return url
+    url = url.strip()
+    if not url.startswith("http") and "http" in url:
+        fixed = url[url.index("http") :]
+        logger.warning(
+            "TELEGRAM_WEBHOOK_URL contained extra prefix, using URL part only",
+            original=url,
+            fixed=fixed,
+        )
+        return fixed
+    return url
+
+
 async def _register_telegram_webhook() -> None:
     """Point the Telegram webhook at this deployment.
 
@@ -44,7 +64,7 @@ async def _register_telegram_webhook() -> None:
             logger.warning("Telegram bot token not configured, skipping webhook setup")
             return
 
-        webhook_url = settings.telegram.webhook_url
+        webhook_url = _sanitize_webhook_url(settings.telegram.webhook_url)
         if not webhook_url:
             public_domain = os.getenv("RAILWAY_PUBLIC_DOMAIN") or os.getenv(
                 "RENDER_EXTERNAL_HOSTNAME"

--- a/app/models/telegram.py
+++ b/app/models/telegram.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class TelegramUser(BaseModel):
@@ -31,8 +31,13 @@ class TelegramChat(BaseModel):
 class TelegramMessage(BaseModel):
     """Telegram message model."""
 
+    # Telegram sends the sender as "from" (a Python keyword), hence the alias
+    model_config = ConfigDict(populate_by_name=True)
+
     message_id: int = Field(description="Message ID")
-    from_user: Optional[TelegramUser] = Field(default=None, description="From user")
+    from_user: Optional[TelegramUser] = Field(
+        default=None, alias="from", description="From user"
+    )
     chat: TelegramChat = Field(description="Chat")
     date: int = Field(description="Message date")
     text: Optional[str] = Field(default=None, description="Message text")
@@ -42,8 +47,10 @@ class TelegramMessage(BaseModel):
 class TelegramCallbackQuery(BaseModel):
     """Telegram callback query model."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     id: str = Field(description="Callback query ID")
-    from_user: TelegramUser = Field(description="From user")
+    from_user: TelegramUser = Field(alias="from", description="From user")
     message: Optional[TelegramMessage] = Field(default=None, description="Message")
     data: Optional[str] = Field(default=None, description="Callback data")
 


### PR DESCRIPTION
## What does this PR do?
Fixes the last blocker for bot commands: Telegram sends the message sender under the JSON key "from" (a Python keyword). Without an alias, Pydantic silently dropped it, so every webhook update crashed with "'NoneType' object has no attribute 'id'" and /start never answered.

- Add alias="from" (+ populate_by_name) to TelegramMessage.from_user and TelegramCallbackQuery.from_user
- Sanitize TELEGRAM_WEBHOOK_URL against an accidentally pasted "TELEGRAM_WEBHOOK_URL=https://..." value (seen in production logs)

## How was this tested?
Parsed a real-world Telegram payload shape (sender under "from") and verified construction by field name still works; 53 unit tests pass locally. Verified against the production error traceback from Railway logs.

Generated with Claude Code