### PR TITLE
Strategy quality upgrades: M5 cadence, TP fallback, H4 reclaim, crypto FVG scope, signal journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,20 @@ Default watched pairs: **ETHUSD + USDJPY** (change with `/pairs` or `SMC_PAIRS`)
 | `/pairs` | inline keyboard — toggle watched pairs on/off |
 | `/status` | enabled pairs, current session, last verdicts |
 | `/check` | run the full strategy check right now |
+| `/stats` | signal journal: setups, TP/SL outcomes, winrate per pair |
 | `/help` | command list |
 
-## Strategy checklist (per pair, every 15 min)
+## Signal journal
+
+Every approved setup is recorded and tracked automatically against M5 candles:
+pending (limit not reached) → open (entry touched) → **tp / sl** (whichever hit
+first; both in one candle counts as sl, conservative). A pending order that
+outlives its session becomes **expired** (Rule 10). `/stats` shows counts,
+winrate and per-pair breakdown — the data basis for tuning the strategy.
+On Railway attach a volume and set `SMC_JOURNAL_FILE=/data/journal.json` if you
+want the journal to survive redeploys.
+
+## Strategy checklist (per pair, every 5 min in session)
 
 1. **Session filter** — entries only inside Frankfurt/London & NY windows
    (Prague time, DST-aware). Closed forex market is detected automatically.
@@ -84,7 +95,8 @@ Key ones:
 | Variable | Default | Meaning |
 |---|---|---|
 | `SMC_PAIRS` | `ETHUSD,USDJPY` | initial pairs (runtime changes via `/pairs`) |
-| `SMC_INTERVAL_MINUTES` | `15` | check cadence |
+| `SMC_SESSION_INTERVAL_MINUTES` | `5` | check cadence inside sessions (M5 close) |
+| `SMC_INTERVAL_MINUTES` | `15` | check cadence outside sessions |
 | `SMC_DEPOSIT` | — | deposit in USD for lot hints |
 | `SMC_NOTIFY_NO_SETUP` | `false` | opt-in 15-min heartbeat messages |
 | `SMC_ENFORCE_SESSIONS` | `true` | only trade session windows |

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -35,7 +35,13 @@ class SMCSettings(BaseSettings):
         default="ETHUSD,USDJPY",
         description="Comma-separated default pairs (runtime changes via /pairs)",
     )
-    interval_minutes: int = Field(default=15, description="Check interval in minutes")
+    interval_minutes: int = Field(
+        default=15, description="Check interval outside sessions, minutes"
+    )
+    session_interval_minutes: int = Field(
+        default=5,
+        description="Check interval inside session windows (M5 cadence), minutes",
+    )
     min_rr: float = Field(default=2.0, description="Minimum risk/reward ratio")
     risk_pct: float = Field(default=2.0, description="Risk percent per trade")
     deposit: Optional[float] = Field(

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -195,7 +195,11 @@ class TripleSyncEngine:
         # impulse leg that breaks structure, so the 3-candle window may end on
         # the CHoCH candle itself (hence choch - 2), but never before the touch.
         fvg = select_valid_fvg(
-            m5, direction, max(touch, choch - 2), self.min_fvg_size
+            m5,
+            direction,
+            max(touch, choch - 2),
+            self.min_fvg_size,
+            same_day_scope=self.instrument.source == "crypto",
         )
         if fvg is None:
             result.verdict = Verdict.WATCH
@@ -228,24 +232,35 @@ class TripleSyncEngine:
             result.reasons.append("Некорректная геометрия сделки: SL на уровне входа")
             return result
 
-        # Rule 7 — TP at the nearest untested opposite zone (H1, fallback H4)
-        target = find_target_zone(h1, direction, entry) or find_target_zone(
-            h4, direction, entry
-        )
-        if target is None:
-            result.verdict = Verdict.SKIP
-            result.reasons.append(
-                "Нет непротестированной противоположной зоны H1/H4 для тейк-профита"
-            )
-            return result
-        take_profit = target.bottom if direction == Direction.LONG else target.top
+        # Rule 7 — TP at the nearest untested opposite zone. The rule allows
+        # both H1 and H4 targets: if the nearest H1 zone is too close for the
+        # minimum RR, the H4 zone behind it is still a valid target.
+        take_profit = None
+        rr = 0.0
+        best_rr = 0.0
+        for tf_candles in (h1, h4):
+            target = find_target_zone(tf_candles, direction, entry)
+            if target is None:
+                continue
+            tp = target.bottom if direction == Direction.LONG else target.top
+            candidate_rr = abs(tp - entry) / risk
+            best_rr = max(best_rr, candidate_rr)
+            if candidate_rr >= self.min_rr:
+                take_profit = tp
+                rr = candidate_rr
+                break
 
-        rr = abs(take_profit - entry) / risk
-        if rr < self.min_rr:
+        if take_profit is None:
             result.verdict = Verdict.SKIP
-            result.reasons.append(
-                f"RR 1:{rr:.1f} < минимума 1:{self.min_rr:.0f} — сделка математически невыгодна"
-            )
+            if best_rr > 0:
+                result.reasons.append(
+                    f"RR 1:{best_rr:.1f} < минимума 1:{self.min_rr:.0f} "
+                    "до ближайших зон H1/H4 — сделка математически невыгодна"
+                )
+            else:
+                result.reasons.append(
+                    "Нет непротестированной противоположной зоны H1/H4 для тейк-профита"
+                )
             return result
 
         # Rule 8 — position size hint

--- a/app/services/smc/fvg.py
+++ b/app/services/smc/fvg.py
@@ -3,7 +3,7 @@
 from typing import List, Optional
 
 from app.services.smc.models import Candle, Direction, FVG
-from app.services.smc.sessions import same_session
+from app.services.smc.sessions import same_session, same_trading_day
 
 
 def find_fvgs(
@@ -69,21 +69,26 @@ def select_valid_fvg(
     from_index: int,
     min_size: float,
     max_fill: float = 0.5,
+    same_day_scope: bool = False,
 ) -> Optional[FVG]:
     """Return the first FVG of the impulse passing all Rule 4 validations.
 
     The earliest gap of the impulse leg is the trigger (best entry price).
-    Checks: minimum size, fill < max_fill, not closed through, formed in the
-    same session as the latest candle (no London -> NY carry-over).
+    Checks: minimum size, fill < max_fill, not closed through, session scope.
+
+    Session scope: forex FVGs must be formed in the same session as the
+    latest candle (no London -> NY carry-over); for 24/7 crypto pass
+    same_day_scope=True — the FVG stays valid for the whole Prague day.
     """
     now = candles[-1].timestamp
+    in_scope = same_trading_day if same_day_scope else same_session
     for fvg in find_fvgs(candles, direction, from_index):
         if fvg.size < min_size:
             continue
         fvg = measure_fill(candles, fvg)
         if fvg.closed_through or fvg.fill_pct >= max_fill:
             continue
-        if not same_session(fvg.timestamp, now):
+        if not in_scope(fvg.timestamp, now):
             continue
         return fvg
     return None

--- a/app/services/smc/journal.py
+++ b/app/services/smc/journal.py
@@ -1,0 +1,211 @@
+"""Signal journal: records every APPROVED setup and tracks its outcome.
+
+Lifecycle of a signal:
+
+    pending  — limit order waiting for price to reach the entry
+    open     — entry touched, position "live"
+    tp / sl  — take-profit or stop-loss hit first (same candle -> sl,
+               conservative)
+    expired  — entry never touched before the session ended (Rule 10:
+               a pending order does not survive its session)
+    timeout  — open too long without resolution (safety valve)
+
+Everything is stored in one JSON file; outcomes are evaluated from closed M5
+candles, incrementally per cycle.
+"""
+
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+
+import structlog
+
+from app.services.smc.models import AnalysisResult, Candle, Direction
+from app.services.smc.sessions import session_end_utc
+
+logger = structlog.get_logger(__name__)
+
+OPEN_TIMEOUT = timedelta(days=5)
+
+
+def _parse(ts: str) -> datetime:
+    return datetime.fromisoformat(ts)
+
+
+def evaluate_signal(signal: Dict, candles: List[Candle], now: datetime) -> Dict:
+    """Advance one signal's state using closed candles. Returns the signal.
+
+    Only candles that finished after the last evaluation are considered.
+    """
+    if signal["status"] not in ("pending", "open"):
+        return signal
+
+    is_long = signal["direction"] == Direction.LONG.value
+    entry, sl, tp = signal["entry"], signal["stop_loss"], signal["take_profit"]
+    watermark = _parse(signal.get("checked_until") or signal["created_at"])
+
+    for candle in candles:
+        candle_end = candle.timestamp + timedelta(minutes=5)
+        if candle_end <= watermark:
+            continue
+
+        if signal["status"] == "pending":
+            touched = candle.low <= entry if is_long else candle.high >= entry
+            if touched:
+                signal["status"] = "open"
+                signal["filled_at"] = candle.timestamp.isoformat()
+            else:
+                continue
+
+        if signal["status"] == "open":
+            hit_sl = candle.low <= sl if is_long else candle.high >= sl
+            hit_tp = candle.high >= tp if is_long else candle.low <= tp
+            if hit_sl:  # both in one candle -> conservative: count the stop
+                signal["status"] = "sl"
+            elif hit_tp:
+                signal["status"] = "tp"
+            if signal["status"] in ("tp", "sl"):
+                signal["resolved_at"] = candle.timestamp.isoformat()
+                break
+
+    if candles:
+        signal["checked_until"] = (
+            candles[-1].timestamp + timedelta(minutes=5)
+        ).isoformat()
+
+    # Expiry rules
+    if signal["status"] == "pending":
+        expires = signal.get("expires_at")
+        if expires and now > _parse(expires):
+            signal["status"] = "expired"
+            signal["resolved_at"] = now.isoformat()
+    elif signal["status"] == "open":
+        if now - _parse(signal["created_at"]) > OPEN_TIMEOUT:
+            signal["status"] = "timeout"
+            signal["resolved_at"] = now.isoformat()
+    return signal
+
+
+class SignalJournal:
+    """JSON-backed list of signals with summary statistics."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self.signals: List[Dict] = []
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            with open(self.path, "r", encoding="utf-8") as f:
+                self.signals = json.load(f)
+        except (OSError, ValueError):
+            self.signals = []
+
+    def save(self) -> None:
+        try:
+            with open(self.path, "w", encoding="utf-8") as f:
+                json.dump(self.signals, f, ensure_ascii=False, indent=1)
+        except OSError as e:
+            logger.warning("Failed to persist journal", error=str(e))
+
+    def record(self, result: AnalysisResult) -> Dict:
+        """Store a freshly approved setup."""
+        setup = result.setup
+        expires = session_end_utc(result.checked_at)
+        signal = {
+            "id": uuid.uuid4().hex[:10],
+            "pair": result.symbol,
+            "direction": setup.direction.value,
+            "entry": setup.entry,
+            "stop_loss": setup.stop_loss,
+            "take_profit": setup.take_profit,
+            "rr": setup.rr,
+            "session": result.session_name,
+            "created_at": result.checked_at.isoformat(),
+            "expires_at": expires.isoformat() if expires else None,
+            # market entries are considered filled immediately
+            "status": "open" if setup.entry_is_market else "pending",
+            "filled_at": (
+                result.checked_at.isoformat() if setup.entry_is_market else None
+            ),
+            "resolved_at": None,
+            "checked_until": None,
+        }
+        self.signals.append(signal)
+        self.save()
+        logger.info("Signal recorded", id=signal["id"], pair=signal["pair"])
+        return signal
+
+    def unresolved_pairs(self) -> List[str]:
+        return sorted(
+            {
+                s["pair"]
+                for s in self.signals
+                if s["status"] in ("pending", "open")
+            }
+        )
+
+    def update_pair(self, pair: str, candles: List[Candle]) -> List[Dict]:
+        """Evaluate all unresolved signals of a pair; returns newly resolved."""
+        now = datetime.now(tz=timezone.utc)
+        resolved = []
+        for signal in self.signals:
+            if signal["pair"] != pair or signal["status"] not in ("pending", "open"):
+                continue
+            before = signal["status"]
+            evaluate_signal(signal, candles, now)
+            if signal["status"] != before and signal["status"] not in (
+                "pending",
+                "open",
+            ):
+                resolved.append(signal)
+                logger.info(
+                    "Signal resolved",
+                    id=signal["id"],
+                    pair=pair,
+                    outcome=signal["status"],
+                )
+        if resolved:
+            self.save()
+        return resolved
+
+    def stats_text(self, days: int = 30) -> str:
+        """Human summary for /stats."""
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(days=days)
+        recent = [s for s in self.signals if _parse(s["created_at"]) >= cutoff]
+        if not recent:
+            return (
+                f"📒 Журнал пуст за последние {days} дн. — "
+                "ни одного сетапа ещё не было."
+            )
+
+        def count(status):
+            return sum(1 for s in recent if s["status"] == status)
+
+        tp, sl = count("tp"), count("sl")
+        closed = tp + sl
+        winrate = f"{tp / closed * 100:.0f}%" if closed else "—"
+        lines = [
+            f"📒 <b>Журнал сигналов за {days} дн.</b>",
+            f"Всего сетапов: {len(recent)}",
+            f"🎯 TP: {tp} | 🛑 SL: {sl} | винрейт: {winrate}",
+            f"⏳ Активных: {count('pending') + count('open')} "
+            f"(ждут входа: {count('pending')}, в позиции: {count('open')})",
+            f"🗑 Не исполнились (сессия истекла): {count('expired')}",
+        ]
+        by_pair: Dict[str, List[Dict]] = {}
+        for s in recent:
+            by_pair.setdefault(s["pair"], []).append(s)
+        lines.append("")
+        lines.append("<b>По парам:</b>")
+        for pair in sorted(by_pair):
+            group = by_pair[pair]
+            g_tp = sum(1 for s in group if s["status"] == "tp")
+            g_sl = sum(1 for s in group if s["status"] == "sl")
+            lines.append(f"• {pair}: {len(group)} сетапов, TP {g_tp} / SL {g_sl}")
+        avg_rr = sum(s["rr"] for s in recent) / len(recent)
+        lines.append("")
+        lines.append(f"Средний плановый RR: 1:{avg_rr:.1f}")
+        return "\n".join(lines)

--- a/app/services/smc/sessions.py
+++ b/app/services/smc/sessions.py
@@ -44,6 +44,32 @@ def active_session(utc_dt: datetime) -> Optional[str]:
     return None
 
 
+def same_trading_day(utc_a: datetime, utc_b: datetime) -> bool:
+    """True if both instants fall on the same Prague calendar day.
+
+    Used as the FVG session scope for crypto: 24/7 markets have no
+    London/NY liquidity reset, so an FVG stays valid for the whole day.
+    """
+    return to_prague(utc_a).date() == to_prague(utc_b).date()
+
+
+def session_end_utc(utc_dt: datetime) -> Optional[datetime]:
+    """End (UTC) of the session window containing utc_dt, or None if outside.
+
+    Used for pending-order expiry: a limit order lives only until the end of
+    the session it was created in.
+    """
+    local = to_prague(utc_dt)
+    now = local.time()
+    for start, end, _ in _windows_for(local):
+        if start <= now < end:
+            end_local = PRAGUE.localize(
+                datetime.combine(local.date(), end), is_dst=None
+            )
+            return end_local.astimezone(pytz.UTC)
+    return None
+
+
 def same_session(utc_a: datetime, utc_b: datetime) -> bool:
     """True if both instants fall inside the same session window on the same day.
 

--- a/app/services/smc/structure.py
+++ b/app/services/smc/structure.py
@@ -48,25 +48,35 @@ def detect_trend(candles: List[Candle]) -> Trend:
     ll = lows[-1].price < lows[-2].price
 
     if hh and hl:
-        # CHoCH check: a body close below the last HL breaks the uptrend.
-        if _body_closed_beyond(candles, lows[-1], below=True):
+        # CHoCH check: a body close below the last HL breaks the uptrend —
+        # but only while price still holds beyond the level. A fakeout that
+        # was reclaimed does not kill the trend forever.
+        if _break_still_holds(candles, lows[-1], below=True):
             return Trend.FLAT
         return Trend.UP
     if lh and ll:
-        if _body_closed_beyond(candles, highs[-1], below=False):
+        if _break_still_holds(candles, highs[-1], below=False):
             return Trend.FLAT
         return Trend.DOWN
     return Trend.FLAT
 
 
-def _body_closed_beyond(candles: List[Candle], pivot: Pivot, below: bool) -> bool:
-    """True if any candle after the pivot closed its body beyond the pivot level."""
+def _break_still_holds(candles: List[Candle], pivot: Pivot, below: bool) -> bool:
+    """True if a body closed beyond the pivot level and price has not
+    reclaimed it since (the structural break is still in force)."""
+    broken = False
     for c in candles[pivot.index + 1 :]:
-        if below and c.body_low < pivot.price and c.close < pivot.price:
-            return True
-        if not below and c.body_high > pivot.price and c.close > pivot.price:
-            return True
-    return False
+        if below:
+            if c.close < pivot.price and c.body_low < pivot.price:
+                broken = True
+            elif broken and c.close > pivot.price:
+                broken = False  # level reclaimed
+        else:
+            if c.close > pivot.price and c.body_high > pivot.price:
+                broken = True
+            elif broken and c.close < pivot.price:
+                broken = False
+    return broken
 
 
 def build_zone(candles: List[Candle], pivot: Pivot) -> Zone:

--- a/app/services/smc/telegram_bot.py
+++ b/app/services/smc/telegram_bot.py
@@ -30,6 +30,7 @@ HELP_TEXT = (
     "/pairs — выбрать валютные пары\n"
     "/status — текущие настройки и последние вердикты\n"
     "/check — проверить сетапы прямо сейчас\n"
+    "/stats — журнал сигналов: сколько сетапов, TP/SL, винрейт\n"
     "/help — эта справка"
 )
 
@@ -44,12 +45,14 @@ class TelegramCommandBot:
         state: WatcherState,
         run_cycle: Callable[[], Awaitable[str]],
         status_text: Callable[[], str],
+        stats_text: Optional[Callable[[], str]] = None,
     ):
         self.base_url = f"https://api.telegram.org/bot{bot_token}"
         self.owner_chat_id = str(owner_chat_id)
         self.state = state
         self.run_cycle = run_cycle
         self.status_text = status_text
+        self.stats_text = stats_text
         self._offset: Optional[int] = None
 
     # ------------------------------------------------------------- transport
@@ -131,6 +134,11 @@ class TelegramCommandBot:
             )
         elif command == "/status":
             await self.send(self.status_text())
+        elif command == "/stats":
+            if self.stats_text:
+                await self.send(self.stats_text())
+            else:
+                await self.send("Журнал недоступен.")
         elif command == "/check":
             await self.send("⏳ Проверяю сетапы, секунду...")
             summary = await self.run_cycle()

--- a/env.example
+++ b/env.example
@@ -11,7 +11,8 @@ TELEGRAM_CHAT_ID=your_telegram_chat_id_here
 
 # --- SMC Strategy Watcher ---
 SMC_PAIRS=ETHUSD,USDJPY           # default pairs; change at runtime via /pairs
-SMC_INTERVAL_MINUTES=15
+SMC_SESSION_INTERVAL_MINUTES=5    # check cadence inside session windows
+SMC_INTERVAL_MINUTES=15           # check cadence outside sessions
 SMC_MIN_RR=2.0
 SMC_RISK_PCT=2.0
 # SMC_DEPOSIT=1000                # deposit in USD for automatic lot hints

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -30,6 +30,7 @@ from app.core.logging import configure_logging
 from app.services.smc.data import BinanceDataFetcher
 from app.services.smc.engine import TripleSyncEngine
 from app.services.smc.instruments import INSTRUMENTS, Instrument, get_instrument
+from app.services.smc.journal import SignalJournal
 from app.services.smc.models import AnalysisResult, Direction, Verdict
 from app.services.smc.notifier import (
     TelegramNotifier,
@@ -50,6 +51,7 @@ if sys.stdout and hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 STATE_FILE = os.getenv("SMC_STATE_FILE", ".smc_watcher_state.json")
+JOURNAL_FILE = os.getenv("SMC_JOURNAL_FILE", ".smc_journal.json")
 
 APPROVED = (Verdict.APPROVED_LIMIT, Verdict.APPROVED_MARKET)
 
@@ -127,12 +129,14 @@ class Watcher:
         if not chat_id:
             raise RuntimeError("Set TELEGRAM_CHAT_ID (or SMC_CHAT_ID)")
         self.notifier = TelegramNotifier(bot_token=token, chat_id=chat_id)
+        self.journal = SignalJournal(JOURNAL_FILE)
         self.bot = TelegramCommandBot(
             bot_token=token,
             owner_chat_id=chat_id,
             state=self.state,
             run_cycle=self.run_cycle,
             status_text=self.status_text,
+            stats_text=self.journal.stats_text,
         )
         self.last_results: Dict[str, AnalysisResult] = {}
         # apply env default on first ever start (state file wins afterwards)
@@ -184,12 +188,15 @@ class Watcher:
                     if await self.notifier.send(format_result(result)):
                         self.state.last_setup[key] = fingerprint
                         self.state.save()
+                    self.journal.record(result)
                     heartbeat_lines.append(f"🚨 {key}: СЕТАП НАЙДЕН — детали выше!")
             else:
                 heartbeat_lines.append(line)
 
         for warning in _correlation_warnings(approved):
             await self.notifier.send(warning)
+
+        await self._track_journal()
 
         time_str = datetime.now(tz=timezone.utc).strftime("%H:%M UTC")
         summary = f"🔍 <b>Проверка {time_str}</b>\n" + "\n".join(heartbeat_lines)
@@ -198,6 +205,17 @@ class Watcher:
         if settings.smc.notify_no_setup and not approved:
             await self.notifier.send(summary)
         return summary
+
+    async def _track_journal(self) -> None:
+        """Advance unresolved journal signals using fresh M5 candles."""
+        for pair in self.journal.unresolved_pairs():
+            try:
+                fetcher = _build_fetcher(get_instrument(pair))
+                candles = await fetcher.fetch_candles("5m", limit=400)
+            except Exception as e:
+                logger.warning("Journal update failed", pair=pair, error=str(e))
+                continue
+            self.journal.update_pair(pair, candles)
 
     # ---------------------------------------------------------------- status
 
@@ -221,16 +239,25 @@ class Watcher:
     # ------------------------------------------------------------- scheduler
 
     async def scheduler_loop(self) -> None:
-        interval = settings.smc.interval_minutes
+        session_interval = settings.smc.session_interval_minutes
+        off_interval = settings.smc.interval_minutes
         logger.info(
-            "SMC watcher started", pairs=self.state.pairs, interval_minutes=interval
+            "SMC watcher started",
+            pairs=self.state.pairs,
+            session_interval_minutes=session_interval,
+            off_session_interval_minutes=off_interval,
         )
         while True:
             try:
                 await self.run_cycle()
             except Exception as e:
                 logger.error("SMC cycle failed", error=str(e), exc_info=True)
-            await asyncio.sleep(_seconds_until_next_slot(interval))
+            # M5 cadence inside sessions, relaxed outside. Session windows
+            # start on the hour, so the coarse grid never misses an open.
+            now = datetime.now(tz=timezone.utc)
+            interval = session_interval if active_session(now) else off_interval
+            # +10s so the just-closed M5 candle is already served by the APIs
+            await asyncio.sleep(_seconds_until_next_slot(interval) + 10)
 
     async def run_forever(self) -> None:
         await asyncio.gather(self.scheduler_loop(), self.bot.run())

--- a/tests/test_smc/test_improvements.py
+++ b/tests/test_smc/test_improvements.py
@@ -1,0 +1,202 @@
+"""Tests for the five strategy-quality improvements."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.services.smc.engine import TripleSyncEngine
+from app.services.smc.fvg import select_valid_fvg
+from app.services.smc.journal import SignalJournal, evaluate_signal
+from app.services.smc.models import (
+    AnalysisResult,
+    Direction,
+    Trend,
+    Verdict,
+)
+from app.services.smc.sessions import same_trading_day, session_end_utc
+from app.services.smc.structure import detect_trend
+from tests.test_smc.helpers import (
+    H1_PULLBACK_CLOSES,
+    H4_UPTREND_CLOSES,
+    candle,
+    m5_long_trigger,
+    make_candles,
+)
+
+
+def _fresh_result() -> AnalysisResult:
+    return AnalysisResult(
+        symbol="ETHUSD",
+        verdict=Verdict.SKIP,
+        checked_at=datetime(2026, 7, 6, 15, 40, tzinfo=timezone.utc),
+    )
+
+
+class TestH4Reclaim:
+    """Item 3: a reclaimed fakeout below the last HL must not kill the trend."""
+
+    def test_fakeout_reclaimed_keeps_uptrend(self):
+        # One body close below the last HL (3119) immediately reclaimed.
+        # (Once the dip survives long enough to confirm a lower pivot low,
+        # the structure is legitimately broken — that case stays FLAT.)
+        closes = H4_UPTREND_CLOSES + [3110, 3140]
+        assert detect_trend(make_candles(closes)) == Trend.UP
+
+    def test_break_still_held_is_flat(self):
+        closes = H4_UPTREND_CLOSES + [3110, 3100, 3090, 3080]
+        assert detect_trend(make_candles(closes)) == Trend.FLAT
+
+
+class TestTpFallback:
+    """Item 2: if the H1 target fails min RR, the H4 target is still valid."""
+
+    def test_h4_target_used_when_h1_rr_too_low(self):
+        # min_rr=7: H1 supply at 3200 gives RR ~5.3 (fails), H4 zone at 3250
+        # gives RR ~9.6 (passes) -> trade approved with the H4 target.
+        result = TripleSyncEngine(min_rr=7.0).evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(),
+            result=_fresh_result(),
+        )
+        assert result.verdict == Verdict.APPROVED_LIMIT
+        assert result.setup.take_profit == 3250.0
+
+    def test_h1_target_still_preferred_when_valid(self):
+        result = TripleSyncEngine(min_rr=2.0).evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(),
+            result=_fresh_result(),
+        )
+        assert result.setup.take_profit == 3200.0
+
+
+class TestCryptoSessionScope:
+    """Item 4: crypto FVG stays valid across London->NY within one day."""
+
+    @staticmethod
+    def _cross_window_candles():
+        # FVG formed in the London window (11:4x UTC), price checked in NY
+        london = datetime(2026, 7, 6, 11, 40, tzinfo=timezone.utc)
+        ny = datetime(2026, 7, 6, 13, 30, tzinfo=timezone.utc)
+        return [
+            candle(3130, 3132, 3128, 3131, start=london, index=0),
+            candle(3131, 3140, 3130, 3139, start=london, index=1),
+            candle(3139, 3143, 3138, 3142, start=london, index=2),  # gap 3132-3138
+            candle(3142, 3144, 3140, 3143, start=ny, index=0),
+            candle(3143, 3145, 3141, 3144, start=ny, index=1),
+        ]
+
+    def test_forex_scope_rejects_cross_session_fvg(self):
+        candles = self._cross_window_candles()
+        assert (
+            select_valid_fvg(candles, Direction.LONG, 0, min_size=2.0) is None
+        )
+
+    def test_crypto_day_scope_accepts_it(self):
+        candles = self._cross_window_candles()
+        fvg = select_valid_fvg(
+            candles, Direction.LONG, 0, min_size=2.0, same_day_scope=True
+        )
+        assert fvg is not None
+        assert fvg.bottom == 3132.0 and fvg.top == 3138.0
+
+
+class TestSessions:
+    def test_same_trading_day(self):
+        a = datetime(2026, 7, 6, 8, 0, tzinfo=timezone.utc)
+        b = datetime(2026, 7, 6, 19, 0, tzinfo=timezone.utc)
+        c = datetime(2026, 7, 6, 23, 0, tzinfo=timezone.utc)  # 01:00 Prague next day
+        assert same_trading_day(a, b)
+        assert not same_trading_day(b, c)
+
+    def test_session_end_utc(self):
+        # 16:00 Prague summer (14:00 UTC) is in the NY window ending 22:00 CEST
+        dt = datetime(2026, 7, 6, 14, 0, tzinfo=timezone.utc)
+        end = session_end_utc(dt)
+        assert end == datetime(2026, 7, 6, 20, 0, tzinfo=timezone.utc)
+
+
+class TestJournal:
+    """Item 5: signal lifecycle and stats."""
+
+    @staticmethod
+    def _signal(status="pending", entry=100.0, sl=95.0, tp=110.0):
+        created = datetime(2026, 7, 6, 14, 0, tzinfo=timezone.utc)
+        return {
+            "id": "test",
+            "pair": "ETHUSD",
+            "direction": "long",
+            "entry": entry,
+            "stop_loss": sl,
+            "take_profit": tp,
+            "rr": 2.0,
+            "created_at": created.isoformat(),
+            "expires_at": (created + timedelta(hours=6)).isoformat(),
+            "status": status,
+            "filled_at": None,
+            "resolved_at": None,
+            "checked_until": None,
+        }
+
+    @staticmethod
+    def _c(index, o, h, low, c):
+        start = datetime(2026, 7, 6, 14, 0, tzinfo=timezone.utc)
+        return candle(o, h, low, c, start=start, index=index)
+
+    def test_fill_then_tp(self):
+        signal = self._signal()
+        candles = [
+            self._c(1, 103, 104, 99.5, 101),  # touches entry 100 -> open
+            self._c(2, 101, 105, 100.5, 104),
+            self._c(3, 104, 111, 103, 110),  # hits TP 110
+        ]
+        now = datetime(2026, 7, 6, 15, 0, tzinfo=timezone.utc)
+        assert evaluate_signal(signal, candles, now)["status"] == "tp"
+
+    def test_fill_then_sl(self):
+        signal = self._signal()
+        candles = [
+            self._c(1, 103, 104, 99.5, 101),
+            self._c(2, 101, 102, 94.5, 96),  # hits SL 95
+        ]
+        now = datetime(2026, 7, 6, 15, 0, tzinfo=timezone.utc)
+        assert evaluate_signal(signal, candles, now)["status"] == "sl"
+
+    def test_same_candle_tp_and_sl_counts_sl(self):
+        signal = self._signal(status="open")
+        candles = [self._c(1, 100, 111, 94, 105)]  # touches both
+        now = datetime(2026, 7, 6, 15, 0, tzinfo=timezone.utc)
+        assert evaluate_signal(signal, candles, now)["status"] == "sl"
+
+    def test_pending_expires_after_session(self):
+        signal = self._signal()
+        candles = [self._c(1, 103, 104, 101, 102)]  # never touches entry
+        now = datetime(2026, 7, 6, 21, 0, tzinfo=timezone.utc)  # past expiry
+        assert evaluate_signal(signal, candles, now)["status"] == "expired"
+
+    def test_incremental_check_does_not_rescan(self):
+        signal = self._signal(status="open")
+        candles = [self._c(1, 100, 101, 94, 96)]  # SL candle
+        now = datetime(2026, 7, 6, 15, 0, tzinfo=timezone.utc)
+        evaluate_signal(signal, candles, now)
+        assert signal["status"] == "sl"
+        # watermark advanced past the candle
+        assert signal["checked_until"] is not None
+
+    def test_journal_records_and_reports(self, tmp_path):
+        journal = SignalJournal(str(tmp_path / "journal.json"))
+        result = _fresh_result()
+        result.session_name = "New York"
+        engine = TripleSyncEngine(min_rr=2.0)
+        result = engine.evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(),
+            result=result,
+        )
+        signal = journal.record(result)
+        assert signal["status"] == "pending"
+        assert "Всего сетапов: 1" in journal.stats_text()
+
+        reloaded = SignalJournal(str(tmp_path / "journal.json"))
+        assert len(reloaded.signals) == 1


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Five improvements aimed at the owner's goal of 2-3 quality trades/day across three pairs — by removing implementation over-strictness and adding measurement, **not** by diluting the core rules:

1. **Adaptive cadence** — checks every **5 minutes inside session windows** (aligned to M5 candle close +10s), 15 minutes outside. The M5 trigger (CHoCH + FVG) lives 2-3 candles; the old 15-min cycle arrived too late for part of the setups.
2. **Rule 7 TP fallback** — if the nearest untested H1 zone fails min RR, the H4 zone behind it is evaluated before skipping (the written rule allows both H1/H4 targets; previously H4 was only used when H1 had none).
3. **H4 trend reclaim** — a fakeout body-close beyond the last HL/LH no longer marks the trend flat forever; the break only counts while price still holds beyond the level. A dip that survives long enough to confirm a lower pivot still flips to flat legitimately.
4. **Crypto FVG session scope** — ETHUSD has no London→NY liquidity reset, so its FVG stays valid for the whole Prague day; forex keeps the strict same-session rule.
5. **Signal journal + `/stats`** — every APPROVED setup is recorded and auto-tracked on M5 candles: pending → open (entry touched) → tp/sl (same-candle ambiguity counts as **sl**, conservative); pending orders expire with their session (Rule 10). `/stats` shows totals, winrate, per-pair breakdown — the data basis for all future tuning.

### How was this tested?
- [x] Unit tests added/updated — **59 pass** (H4 reclaim vs held break, H1→H4 TP fallback, cross-window FVG for crypto vs forex, journal lifecycle: fill→tp, fill→sl, same-candle sl, session expiry, persistence)
- [x] Manual testing performed — live `--once` smoke on real Binance + Yahoo data, flake8 clean

### Breaking Changes
None. New env vars: `SMC_SESSION_INTERVAL_MINUTES` (default 5), `SMC_JOURNAL_FILE`. Journal note: attach a Railway volume to persist stats across redeploys (optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)