### PR TITLE
Forex Factory red-news filter: blackout windows, morning digest, Rule 0.4 alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,19 @@ Default watched pairs: **ETHUSD + USDJPY** (change with `/pairs` or `SMC_PAIRS`)
 | `/status` | enabled pairs, current session, last verdicts |
 | `/check` | run the full strategy check right now |
 | `/stats` | signal journal: setups, TP/SL outcomes, winrate per pair |
+| `/news` | today's red news (Forex Factory) and blackout windows |
 | `/help` | command list |
+
+## Red-news filter (Forex Factory)
+
+The official FF weekly JSON feed is fetched every morning (and every ~6h).
+Entries are blocked **60 min before** and **15 min after** every high-impact
+event: forex pairs react to news for either of their currencies, ETHUSD only
+to USD news. A morning digest of today's red news is sent at ~07:15 Prague
+(`SMC_NEWS_DIGEST=false` to disable). Rule 0.4: if a journal signal is active
+(pending/open) and red news is ≤30 min away, the bot sends a "SL to breakeven /
+pull the order" warning. Tunables: `SMC_NEWS_BLACKOUT_BEFORE_MIN` (60),
+`SMC_NEWS_BLACKOUT_AFTER_MIN` (15), `SMC_NEWS_ENABLED` (true).
 
 ## Signal journal
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -59,6 +59,18 @@ class SMCSettings(BaseSettings):
         default=None,
         description="Telegram chat id override (falls back to TELEGRAM_CHAT_ID)",
     )
+    news_enabled: bool = Field(
+        default=True, description="Block entries around Forex Factory red news"
+    )
+    news_digest: bool = Field(
+        default=True, description="Send a morning red-news digest (~07:15 Prague)"
+    )
+    news_blackout_before_min: int = Field(
+        default=60, description="No-entry window before a red news release, minutes"
+    )
+    news_blackout_after_min: int = Field(
+        default=15, description="No-entry window after a red news release, minutes"
+    )
 
     def default_pairs(self) -> list[str]:
         return [p.strip().upper() for p in self.pairs.split(",") if p.strip()]

--- a/app/services/smc/news.py
+++ b/app/services/smc/news.py
@@ -1,0 +1,168 @@
+"""Forex Factory red-news filter (Rules -1, 0.3, 0.4).
+
+Uses the official Forex Factory weekly JSON feed (no key, no scraping).
+Entries are blocked in a window around every high-impact event:
+`before` minutes ahead of the release and `after` minutes past it.
+
+Currency relevance: a forex pair is affected by news for either of its two
+currencies; crypto (ETHUSD) is affected only by USD news.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Set
+
+import httpx
+import structlog
+
+from app.services.smc.instruments import Instrument
+from app.services.smc.sessions import to_prague
+
+logger = structlog.get_logger(__name__)
+
+FEED_URL = "https://nfs.faireconomy.media/ff_calendar_thisweek.json"
+HEADERS = {"User-Agent": "Mozilla/5.0 (SMC-Watcher)"}
+
+
+@dataclass
+class NewsEvent:
+    time: datetime  # UTC
+    currency: str
+    title: str
+
+    def prague_hhmm(self) -> str:
+        return to_prague(self.time).strftime("%H:%M")
+
+
+def relevant_currencies(instrument: Instrument) -> Set[str]:
+    """Currencies whose red news blocks this instrument."""
+    if instrument.source == "crypto":
+        return {"USD"}  # ETH is not a news currency; only the dollar leg counts
+    return {instrument.key[:3], instrument.key[3:]}
+
+
+def parse_feed(raw: List[dict]) -> List[NewsEvent]:
+    """Extract high-impact events from the FF weekly feed."""
+    events = []
+    for item in raw:
+        if item.get("impact") != "High":
+            continue
+        try:
+            when = datetime.fromisoformat(item["date"]).astimezone(timezone.utc)
+        except (KeyError, ValueError):
+            continue
+        events.append(
+            NewsEvent(
+                time=when,
+                currency=str(item.get("country", "")).upper(),
+                title=str(item.get("title", "")).strip(),
+            )
+        )
+    events.sort(key=lambda e: e.time)
+    return events
+
+
+class NewsCalendar:
+    """Cached red-news calendar with blackout checks."""
+
+    def __init__(
+        self,
+        before_minutes: int = 60,
+        after_minutes: int = 15,
+        timeout: float = 15.0,
+    ):
+        self.before = timedelta(minutes=before_minutes)
+        self.after = timedelta(minutes=after_minutes)
+        self.timeout = timeout
+        self.events: List[NewsEvent] = []
+        self.fetched_at: Optional[datetime] = None
+        self.fetch_error: Optional[str] = None
+
+    async def refresh_if_stale(self, max_age_hours: float = 6.0) -> None:
+        """Refetch the feed each morning / every few hours; keep old data on error."""
+        now = datetime.now(tz=timezone.utc)
+        if self.fetched_at is not None:
+            fresh = now - self.fetched_at < timedelta(hours=max_age_hours)
+            same_day = to_prague(self.fetched_at).date() == to_prague(now).date()
+            if fresh and same_day:
+                return
+        try:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, headers=HEADERS
+            ) as client:
+                response = await client.get(FEED_URL)
+                response.raise_for_status()
+                self.events = parse_feed(response.json())
+            self.fetched_at = now
+            self.fetch_error = None
+            logger.info(
+                "Forex Factory calendar refreshed", high_impact=len(self.events)
+            )
+        except (httpx.HTTPError, ValueError) as e:
+            self.fetch_error = str(e)
+            logger.warning("Forex Factory feed fetch failed", error=str(e))
+
+    def blackout(
+        self, currencies: Set[str], now: Optional[datetime] = None
+    ) -> Optional[NewsEvent]:
+        """The event whose no-trade window covers `now`, if any."""
+        now = now or datetime.now(tz=timezone.utc)
+        for event in self.events:
+            if event.currency not in currencies:
+                continue
+            if event.time - self.before <= now <= event.time + self.after:
+                return event
+        return None
+
+    def upcoming(
+        self, currencies: Set[str], within: timedelta, now: Optional[datetime] = None
+    ) -> List[NewsEvent]:
+        """Events for `currencies` starting within the given horizon."""
+        now = now or datetime.now(tz=timezone.utc)
+        return [
+            e
+            for e in self.events
+            if e.currency in currencies and now < e.time <= now + within
+        ]
+
+    def todays_events(
+        self, currencies: Set[str], now: Optional[datetime] = None
+    ) -> List[NewsEvent]:
+        now = now or datetime.now(tz=timezone.utc)
+        today = to_prague(now).date()
+        return [
+            e
+            for e in self.events
+            if e.currency in currencies and to_prague(e.time).date() == today
+        ]
+
+    def digest_text(
+        self, currencies: Set[str], now: Optional[datetime] = None
+    ) -> str:
+        """Morning digest in the spirit of Правило -1."""
+        now = now or datetime.now(tz=timezone.utc)
+        date_str = to_prague(now).strftime("%d.%m.%Y")
+        header = f"📅 <b>Forex Factory — {date_str}</b> (время Праги)"
+        if self.fetched_at is None:
+            return header + "\n⚠️ Календарь ещё не загружен" + (
+                f" ({self.fetch_error})" if self.fetch_error else ""
+            )
+        events = self.todays_events(currencies, now)
+        if not events:
+            return (
+                header
+                + f"\n✅ Красных новостей по твоим валютам ({', '.join(sorted(currencies))}) сегодня нет."
+            )
+        lines = [header, "🔴 Красные новости сегодня:"]
+        for e in events:
+            lines.append(f"• {e.prague_hhmm()} — {e.title} ({e.currency})")
+        nearest = next((e for e in events if e.time > now), None)
+        if nearest:
+            lines.append(
+                f"⚠️ Ближайшая: {nearest.prague_hhmm()} — {nearest.title} ({nearest.currency})"
+            )
+        lines.append(
+            f"⛔ Блэкаут входов: за {int(self.before.total_seconds() // 60)} мин до "
+            f"и {int(self.after.total_seconds() // 60)} мин после каждой."
+        )
+        return "\n".join(lines)

--- a/app/services/smc/state.py
+++ b/app/services/smc/state.py
@@ -18,6 +18,8 @@ class WatcherState:
         self.path = path
         self.pairs: List[str] = list(DEFAULT_PAIRS)
         self.last_setup: Dict[str, str] = {}  # pair -> fingerprint
+        self.last_digest_date: str = ""  # Prague date of the last morning digest
+        self.news_warned: Dict[str, str] = {}  # Rule 0.4 dedup: key -> iso time
         self._load()
 
     def _load(self) -> None:
@@ -30,11 +32,21 @@ class WatcherState:
         if pairs:
             self.pairs = pairs
         self.last_setup = dict(data.get("last_setup", {}))
+        self.last_digest_date = data.get("last_digest_date", "")
+        self.news_warned = dict(data.get("news_warned", {}))
 
     def save(self) -> None:
         try:
             with open(self.path, "w", encoding="utf-8") as f:
-                json.dump({"pairs": self.pairs, "last_setup": self.last_setup}, f)
+                json.dump(
+                    {
+                        "pairs": self.pairs,
+                        "last_setup": self.last_setup,
+                        "last_digest_date": self.last_digest_date,
+                        "news_warned": self.news_warned,
+                    },
+                    f,
+                )
         except OSError as e:
             logger.warning("Failed to persist watcher state", error=str(e))
 

--- a/app/services/smc/telegram_bot.py
+++ b/app/services/smc/telegram_bot.py
@@ -31,6 +31,7 @@ HELP_TEXT = (
     "/status — текущие настройки и последние вердикты\n"
     "/check — проверить сетапы прямо сейчас\n"
     "/stats — журнал сигналов: сколько сетапов, TP/SL, винрейт\n"
+    "/news — красные новости на сегодня (Forex Factory)\n"
     "/help — эта справка"
 )
 
@@ -46,6 +47,7 @@ class TelegramCommandBot:
         run_cycle: Callable[[], Awaitable[str]],
         status_text: Callable[[], str],
         stats_text: Optional[Callable[[], str]] = None,
+        news_text: Optional[Callable[[], str]] = None,
     ):
         self.base_url = f"https://api.telegram.org/bot{bot_token}"
         self.owner_chat_id = str(owner_chat_id)
@@ -53,6 +55,7 @@ class TelegramCommandBot:
         self.run_cycle = run_cycle
         self.status_text = status_text
         self.stats_text = stats_text
+        self.news_text = news_text
         self._offset: Optional[int] = None
 
     # ------------------------------------------------------------- transport
@@ -139,6 +142,11 @@ class TelegramCommandBot:
                 await self.send(self.stats_text())
             else:
                 await self.send("Журнал недоступен.")
+        elif command == "/news":
+            if self.news_text:
+                await self.send(self.news_text())
+            else:
+                await self.send("Новостной фильтр недоступен.")
         elif command == "/check":
             await self.send("⏳ Проверяю сетапы, секунду...")
             summary = await self.run_cycle()

--- a/env.example
+++ b/env.example
@@ -20,5 +20,11 @@ SMC_ENFORCE_SESSIONS=true
 SMC_NOTIFY_NO_SETUP=false         # true = also send 15-min "no setup" heartbeats
 # SMC_CHAT_ID=                    # override TELEGRAM_CHAT_ID for alerts
 
+# --- Red-news filter (Forex Factory) ---
+SMC_NEWS_ENABLED=true             # block entries around high-impact news
+SMC_NEWS_DIGEST=true              # morning digest of today's red news (~07:15 Prague)
+SMC_NEWS_BLACKOUT_BEFORE_MIN=60   # no entries N minutes before a red release
+SMC_NEWS_BLACKOUT_AFTER_MIN=15    # ...and N minutes after it
+
 # --- Logging ---
 LOG_LEVEL=INFO

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -20,7 +20,7 @@ import argparse
 import asyncio
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 
 import structlog
@@ -31,6 +31,7 @@ from app.services.smc.data import BinanceDataFetcher
 from app.services.smc.engine import TripleSyncEngine
 from app.services.smc.instruments import INSTRUMENTS, Instrument, get_instrument
 from app.services.smc.journal import SignalJournal
+from app.services.smc.news import NewsCalendar, relevant_currencies
 from app.services.smc.models import AnalysisResult, Direction, Verdict
 from app.services.smc.notifier import (
     TelegramNotifier,
@@ -39,7 +40,7 @@ from app.services.smc.notifier import (
 )
 from app.services.smc.oanda import OandaDataFetcher
 from app.services.smc.yahoo import YahooDataFetcher
-from app.services.smc.sessions import active_session
+from app.services.smc.sessions import active_session, to_prague
 from app.services.smc.state import WatcherState
 from app.services.smc.telegram_bot import TelegramCommandBot
 
@@ -130,6 +131,14 @@ class Watcher:
             raise RuntimeError("Set TELEGRAM_CHAT_ID (or SMC_CHAT_ID)")
         self.notifier = TelegramNotifier(bot_token=token, chat_id=chat_id)
         self.journal = SignalJournal(JOURNAL_FILE)
+        self.news = (
+            NewsCalendar(
+                before_minutes=settings.smc.news_blackout_before_min,
+                after_minutes=settings.smc.news_blackout_after_min,
+            )
+            if settings.smc.news_enabled
+            else None
+        )
         self.bot = TelegramCommandBot(
             bot_token=token,
             owner_chat_id=chat_id,
@@ -137,6 +146,7 @@ class Watcher:
             run_cycle=self.run_cycle,
             status_text=self.status_text,
             stats_text=self.journal.stats_text,
+            news_text=self.news_text,
         )
         self.last_results: Dict[str, AnalysisResult] = {}
         # apply env default on first ever start (state file wins afterwards)
@@ -172,10 +182,19 @@ class Watcher:
         if not self.state.pairs:
             return "⚠️ Нет активных пар — включи хотя бы одну через /pairs"
 
+        if self.news:
+            await self.news.refresh_if_stale()
+            await self._send_morning_digest()
+            await self._rule_04_warnings()
+
         heartbeat_lines: List[str] = []
         approved: List[AnalysisResult] = []
 
         for key in list(self.state.pairs):
+            blackout = self._news_blackout(key)
+            if blackout:
+                heartbeat_lines.append(blackout)
+                continue
             line, result = await self.check_pair(key)
             if result and result.verdict in APPROVED:
                 fingerprint = _setup_fingerprint(result)
@@ -205,6 +224,83 @@ class Watcher:
         if settings.smc.notify_no_setup and not approved:
             await self.notifier.send(summary)
         return summary
+
+    # ------------------------------------------------------------------ news
+
+    def _news_blackout(self, key: str) -> Optional[str]:
+        """Heartbeat line if the pair is inside a red-news blackout window."""
+        if not self.news:
+            return None
+        instrument = get_instrument(key)
+        event = self.news.blackout(relevant_currencies(instrument))
+        if not event:
+            return None
+        logger.info(
+            "News blackout", pair=key, event=event.title, currency=event.currency
+        )
+        return (
+            f"⛔ {key}: блэкаут — 🔴 {event.title} ({event.currency}) "
+            f"в {event.prague_hhmm()} Праги, входы запрещены"
+        )
+
+    async def _send_morning_digest(self) -> None:
+        """Once a day before the session: today's red news (Правило -1)."""
+        if not settings.smc.news_digest or self.news.fetched_at is None:
+            return
+        local = to_prague(datetime.now(tz=timezone.utc))
+        today = local.date().isoformat()
+        if self.state.last_digest_date == today or local.hour < 7:
+            return
+        currencies = set()
+        for key in self.state.pairs:
+            currencies |= relevant_currencies(get_instrument(key))
+        await self.notifier.send(self.news.digest_text(currencies))
+        self.state.last_digest_date = today
+        self.state.save()
+
+    async def _rule_04_warnings(self) -> None:
+        """Rule 0.4: active signal + red news soon -> SL to BU / pull the order."""
+        now = datetime.now(tz=timezone.utc)
+        horizon = timedelta(minutes=30)
+        for signal in self.journal.signals:
+            if signal["status"] not in ("pending", "open"):
+                continue
+            instrument = get_instrument(signal["pair"])
+            for event in self.news.upcoming(relevant_currencies(instrument), horizon):
+                warn_key = f"{signal['id']}:{event.time.isoformat()}"
+                if warn_key in self.state.news_warned:
+                    continue
+                minutes_left = int((event.time - now).total_seconds() // 60)
+                action = (
+                    "переведи SL в безубыток"
+                    if signal["status"] == "open"
+                    else "удали отложенный ордер"
+                )
+                await self.notifier.send(
+                    f"⚠️ <b>ПРАВИЛО 0.4:</b> {signal['pair']} — 🔴 {event.title} "
+                    f"({event.currency}) через {minutes_left} мин "
+                    f"({event.prague_hhmm()} Праги). У тебя "
+                    f"{'открытая позиция' if signal['status'] == 'open' else 'активная лимитка'} "
+                    f"— {action}!"
+                )
+                self.state.news_warned[warn_key] = now.isoformat()
+        # prune dedup keys older than 2 days
+        cutoff = now - timedelta(days=2)
+        self.state.news_warned = {
+            k: v
+            for k, v in self.state.news_warned.items()
+            if datetime.fromisoformat(v) > cutoff
+        }
+        self.state.save()
+
+    def news_text(self) -> str:
+        """/news command."""
+        if not self.news:
+            return "Новостной фильтр выключен (SMC_NEWS_ENABLED=false)."
+        currencies = set()
+        for key in self.state.pairs:
+            currencies |= relevant_currencies(get_instrument(key))
+        return self.news.digest_text(currencies)
 
     async def _track_journal(self) -> None:
         """Advance unresolved journal signals using fresh M5 candles."""

--- a/tests/test_smc/test_news.py
+++ b/tests/test_smc/test_news.py
@@ -1,0 +1,105 @@
+"""Tests for the Forex Factory red-news filter."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.services.smc.instruments import get_instrument
+from app.services.smc.news import NewsCalendar, parse_feed, relevant_currencies
+
+SAMPLE_FEED = [
+    {
+        "title": "CPI m/m",
+        "country": "USD",
+        "date": "2026-07-15T08:30:00-04:00",  # 12:30 UTC
+        "impact": "High",
+    },
+    {
+        "title": "BOE Gov Speaks",
+        "country": "GBP",
+        "date": "2026-07-15T16:00:00-04:00",  # 20:00 UTC
+        "impact": "High",
+    },
+    {
+        "title": "German ZEW",
+        "country": "EUR",
+        "date": "2026-07-15T05:00:00-04:00",
+        "impact": "Medium",  # not red -> ignored
+    },
+]
+
+
+def _calendar(before=60, after=15) -> NewsCalendar:
+    cal = NewsCalendar(before_minutes=before, after_minutes=after)
+    cal.events = parse_feed(SAMPLE_FEED)
+    cal.fetched_at = datetime(2026, 7, 15, 5, 0, tzinfo=timezone.utc)
+    return cal
+
+
+class TestParsing:
+    def test_only_high_impact_kept(self):
+        events = parse_feed(SAMPLE_FEED)
+        assert [e.currency for e in events] == ["USD", "GBP"]
+
+    def test_time_converted_to_utc(self):
+        events = parse_feed(SAMPLE_FEED)
+        assert events[0].time == datetime(2026, 7, 15, 12, 30, tzinfo=timezone.utc)
+
+
+class TestRelevance:
+    def test_forex_pair_uses_both_currencies(self):
+        assert relevant_currencies(get_instrument("USDJPY")) == {"USD", "JPY"}
+        assert relevant_currencies(get_instrument("GBPUSD")) == {"GBP", "USD"}
+
+    def test_crypto_only_usd(self):
+        assert relevant_currencies(get_instrument("ETHUSD")) == {"USD"}
+
+
+class TestBlackout:
+    def test_blocked_one_hour_before(self):
+        cal = _calendar()
+        now = datetime(2026, 7, 15, 11, 45, tzinfo=timezone.utc)  # 45m before CPI
+        assert cal.blackout({"USD"}, now) is not None
+
+    def test_blocked_shortly_after(self):
+        cal = _calendar()
+        now = datetime(2026, 7, 15, 12, 40, tzinfo=timezone.utc)  # 10m after CPI
+        assert cal.blackout({"USD"}, now) is not None
+
+    def test_free_outside_window(self):
+        cal = _calendar()
+        before = datetime(2026, 7, 15, 11, 20, tzinfo=timezone.utc)  # 70m before
+        after = datetime(2026, 7, 15, 12, 50, tzinfo=timezone.utc)  # 20m after
+        assert cal.blackout({"USD"}, before) is None
+        assert cal.blackout({"USD"}, after) is None
+
+    def test_crypto_ignores_non_usd_news(self):
+        cal = _calendar()
+        # 30 min before the GBP event: GBPUSD blocked, ETHUSD (USD-only) free
+        now = datetime(2026, 7, 15, 19, 30, tzinfo=timezone.utc)
+        assert cal.blackout(relevant_currencies(get_instrument("GBPUSD")), now)
+        assert cal.blackout(relevant_currencies(get_instrument("ETHUSD")), now) is None
+
+    def test_crypto_blocked_by_usd_news(self):
+        cal = _calendar()
+        now = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)  # 30m before CPI
+        assert cal.blackout(relevant_currencies(get_instrument("ETHUSD")), now)
+
+
+class TestUpcomingAndDigest:
+    def test_upcoming_horizon(self):
+        cal = _calendar()
+        now = datetime(2026, 7, 15, 12, 10, tzinfo=timezone.utc)
+        soon = cal.upcoming({"USD", "GBP"}, timedelta(minutes=30), now)
+        assert [e.title for e in soon] == ["CPI m/m"]
+
+    def test_digest_lists_todays_events_in_prague_time(self):
+        cal = _calendar()
+        now = datetime(2026, 7, 15, 5, 30, tzinfo=timezone.utc)
+        text = cal.digest_text({"USD", "GBP", "JPY"}, now)
+        assert "CPI m/m" in text and "14:30" in text  # 12:30 UTC = 14:30 Prague
+        assert "BOE Gov Speaks" in text and "22:00" in text
+        assert "Блэкаут" in text
+
+    def test_digest_when_quiet_day(self):
+        cal = _calendar()
+        now = datetime(2026, 7, 16, 5, 30, tzinfo=timezone.utc)  # next day
+        assert "нет" in cal.digest_text({"USD"}, now)


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Automates the strategy's news rules (Правило −1 / 0.3 / 0.4) using the **official Forex Factory weekly JSON feed** — no API key, no scraping:

- **Blackout windows**: entries are blocked **60 min before** and **15 min after** every high-impact event. Forex pairs react to news for either of their currencies; **ETHUSD reacts only to USD news** (per the owner's rule). Blocked pairs show up in `/check` and logs with the event name and Prague time. Tunable via `SMC_NEWS_BLACKOUT_BEFORE_MIN` / `SMC_NEWS_BLACKOUT_AFTER_MIN`.
- **Morning digest** (~07:15 Prague, once per day, deduped in state): today's red news for the watched currencies with Prague times — the Правило −1 pre-market check, automated. Disable with `SMC_NEWS_DIGEST=false`.
- **Rule 0.4 protection**: if a journal signal is active (pending limit or open position) and red news for its currencies is ≤30 min away, the bot sends a "переведи SL в безубыток / удали ордер" warning (deduped per signal+event).
- **/news command**: today's calendar and blackout settings on demand.
- Calendar is cached and refreshed each morning and every ~6h; on fetch errors the previous data is kept and the error is logged.

### How was this tested?
- [x] Unit tests added/updated — **71 pass** (feed parsing incl. impact filtering and UTC conversion, blackout windows before/after/outside, crypto USD-only relevance, upcoming horizon for Rule 0.4, digest rendering in Prague time, quiet-day digest)
- [x] Manual testing performed — live fetch of the real FF feed (14 high-impact events parsed), full `--once` smoke with the filter active; flake8 clean

### Breaking Changes
None. New env vars: `SMC_NEWS_ENABLED` (true), `SMC_NEWS_DIGEST` (true), `SMC_NEWS_BLACKOUT_BEFORE_MIN` (60), `SMC_NEWS_BLACKOUT_AFTER_MIN` (15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)