### PR TITLE
Fix crash-loop on Railway volume: run as root + DB fallback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 COPY app/ /app/app/
 COPY smc_watcher.py /app/
 
-RUN groupadd -r appuser && useradd -r -g appuser appuser \
-    && chown -R appuser:appuser /app
-USER appuser
+# Run as root: Railway volumes are mounted root-owned, and a non-root user
+# cannot write the SQLite database to them.
 
 CMD ["python", "smc_watcher.py"]

--- a/app/services/smc/db.py
+++ b/app/services/smc/db.py
@@ -36,9 +36,11 @@ SIGNAL_COLUMNS = [
 class Database:
     """Thin wrapper over sqlite3 with a signals table and a kv store."""
 
+    FALLBACK_PATH = ".smc_watcher.db"
+
     def __init__(self, path: str):
         self.path = path
-        self.conn = sqlite3.connect(path, check_same_thread=False)
+        self.conn = self._connect(path)
         self.conn.row_factory = sqlite3.Row
         with self.conn:
             self.conn.execute(
@@ -64,6 +66,32 @@ class Database:
             self.conn.execute(
                 "CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT)"
             )
+
+    def _connect(self, path: str) -> sqlite3.Connection:
+        """Open the database, creating parent dirs; fall back instead of dying.
+
+        A crash-looping watcher sends no alerts at all, so if the configured
+        path is unusable (typical case: a root-owned Railway volume and a
+        non-root container) we degrade to a local ephemeral file and log
+        loudly — alerts keep flowing, only persistence is reduced.
+        """
+        try:
+            directory = os.path.dirname(os.path.abspath(path))
+            os.makedirs(directory, exist_ok=True)
+            return sqlite3.connect(path, check_same_thread=False)
+        except (sqlite3.OperationalError, OSError) as e:
+            if path == self.FALLBACK_PATH:
+                raise
+            logger.error(
+                "Cannot open database at configured path — falling back to a "
+                "local ephemeral file (data will NOT survive redeploys). "
+                "Check volume mount and permissions.",
+                configured_path=path,
+                fallback=self.FALLBACK_PATH,
+                error=str(e),
+            )
+            self.path = self.FALLBACK_PATH
+            return sqlite3.connect(self.FALLBACK_PATH, check_same_thread=False)
 
     # ------------------------------------------------------------------- kv
 

--- a/tests/test_smc/test_db.py
+++ b/tests/test_smc/test_db.py
@@ -1,0 +1,22 @@
+"""Tests for SQLite database resilience."""
+
+from app.services.smc.db import Database
+
+
+class TestDatabaseOpen:
+    def test_creates_missing_parent_directories(self, tmp_path):
+        path = tmp_path / "nested" / "dirs" / "smc.db"
+        db = Database(str(path))
+        db.kv_set("probe", 1)
+        assert path.exists()
+        assert Database(str(path)).kv_get("probe") == 1
+
+    def test_falls_back_when_path_unusable(self, tmp_path, monkeypatch):
+        # A file where a directory is expected makes the path unusable.
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        monkeypatch.chdir(tmp_path)  # fallback file lands in tmp, not the repo
+        db = Database(str(blocker / "sub" / "smc.db"))
+        assert db.path == Database.FALLBACK_PATH
+        db.kv_set("probe", "ok")  # still functional
+        assert db.kv_get("probe") == "ok"


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Fixes the production crash-loop after attaching a Railway volume:

```
sqlite3.OperationalError: unable to open database file
```

**Root cause:** Railway mounts volumes owned by root, but the container ran as the non-root `appuser`, which cannot write `/data/smc.db`.

- **Dockerfile**: drop the non-root user — root is required to write to Railway volume mounts (standard practice for Railway workers).
- **db.py resilience**: create missing parent directories; if the configured `SMC_DB_FILE` path is still unusable, log a loud error and fall back to a local ephemeral database instead of dying — a crash-looping watcher sends no alerts at all, so degraded persistence beats a dead service.

### How was this tested?
- [x] Unit tests added/updated — **74 pass** (new: parent-dir creation, fallback path when the configured location is unusable while staying functional)
- [x] flake8 clean

### Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)