### PR TITLE
Escape HTML in dynamic Telegram texts (fix 400 on 'fill < 50%')

### DIFF
--- a/app/services/smc/news.py
+++ b/app/services/smc/news.py
@@ -154,13 +154,15 @@ class NewsCalendar:
                 + f"\n✅ No red news for your currencies "
                 f"({', '.join(sorted(currencies))}) today."
             )
+        from app.services.smc.notifier import escape_html
+
         lines = [header, "🔴 Red news today:"]
         for e in events:
-            lines.append(f"• {e.prague_hhmm()} — {e.title} ({e.currency})")
+            lines.append(f"• {e.prague_hhmm()} — {escape_html(e.title)} ({e.currency})")
         nearest = next((e for e in events if e.time > now), None)
         if nearest:
             lines.append(
-                f"⚠️ Next up: {nearest.prague_hhmm()} — {nearest.title} "
+                f"⚠️ Next up: {nearest.prague_hhmm()} — {escape_html(nearest.title)} "
                 f"({nearest.currency})"
             )
         lines.append(

--- a/app/services/smc/notifier.py
+++ b/app/services/smc/notifier.py
@@ -12,6 +12,17 @@ logger = structlog.get_logger(__name__)
 TREND_LABEL = {Trend.UP: "uptrend", Trend.DOWN: "downtrend", Trend.FLAT: "flat"}
 
 
+def escape_html(text: str) -> str:
+    """Escape <, > and & for Telegram parse_mode=HTML.
+
+    Plain strings (engine reasons like "fill < 50%", news titles like
+    "S&P Global PMI") would otherwise be rejected by Telegram as broken tags.
+    """
+    return (
+        str(text).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    )
+
+
 URGENT_HEADER = (
     "🚨🚨🚨 <b>URGENT! SETUP FOUND — READY TO TRADE!</b> 🚨🚨🚨"
 )
@@ -25,7 +36,7 @@ def format_no_setup(result: AnalysisResult) -> str:
             f"😴 {result.symbol} {time_str} — off session, entries are not "
             "allowed. Will check again on schedule."
         )
-    reason = result.reasons[0] if result.reasons else "conditions not met"
+    reason = escape_html(result.reasons[0] if result.reasons else "conditions not met")
     return f"🔍 {result.symbol} {time_str} — no setup. {reason}."
 
 
@@ -100,17 +111,17 @@ def format_result(result: AnalysisResult) -> str:
         lines.append("")
         lines.append("<b>No setup yet (Setup Watch):</b>")
         for reason in result.reasons:
-            lines.append(f"• {reason}")
+            lines.append(f"• {escape_html(reason)}")
         if result.watch_notes:
             lines.append("")
             lines.append("<b>What is needed for an entry:</b>")
             for note in result.watch_notes:
-                lines.append(f"→ {note}")
+                lines.append(f"→ {escape_html(note)}")
     else:
         lines.append("")
         lines.append("<b>Verdict:</b> ❌ SKIP")
         for reason in result.reasons:
-            lines.append(f"• {reason}")
+            lines.append(f"• {escape_html(reason)}")
 
     return "\n".join(lines)
 

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -36,6 +36,7 @@ from app.services.smc.news import NewsCalendar, relevant_currencies
 from app.services.smc.models import AnalysisResult, Direction, Verdict
 from app.services.smc.notifier import (
     TelegramNotifier,
+    escape_html,
     format_no_setup,
     format_result,
 )
@@ -244,7 +245,7 @@ class Watcher:
             "News blackout", pair=key, event=event.title, currency=event.currency
         )
         return (
-            f"⛔ {key}: blackout — 🔴 {event.title} ({event.currency}) "
+            f"⛔ {key}: blackout — 🔴 {escape_html(event.title)} ({event.currency}) "
             f"at {event.prague_hhmm()} Prague, entries blocked"
         )
 
@@ -289,7 +290,7 @@ class Watcher:
                     else "cancel the pending order"
                 )
                 await self.notifier.send(
-                    f"⚠️ <b>RULE 0.4:</b> {signal['pair']} — 🔴 {event.title} "
+                    f"⚠️ <b>RULE 0.4:</b> {signal['pair']} — 🔴 {escape_html(event.title)} "
                     f"({event.currency}) in {minutes_left} min "
                     f"({event.prague_hhmm()} Prague). You have "
                     f"{'an open position' if signal['status'] == 'open' else 'an active limit order'} "

--- a/tests/test_smc/test_html_escaping.py
+++ b/tests/test_smc/test_html_escaping.py
@@ -1,0 +1,70 @@
+"""Regression tests: Telegram HTML must not be broken by dynamic text.
+
+Production incident 2026-07-16: a /check summary containing the engine reason
+"fill < 50%" was rejected by Telegram with `can't parse entities: Unsupported
+start tag` because `<` was sent unescaped in parse_mode=HTML.
+"""
+
+import re
+from datetime import datetime, timezone
+
+from app.services.smc.models import AnalysisResult, Verdict
+from app.services.smc.news import NewsCalendar, parse_feed
+from app.services.smc.notifier import escape_html, format_no_setup, format_result
+
+
+def _assert_valid_telegram_html(text: str):
+    """Every '<' must start one of the tags we intentionally use."""
+    for match in re.finditer(r"<", text):
+        following = text[match.start():match.start() + 4]
+        assert re.match(r"</?b>", following), (
+            f"unescaped '<' near: ...{text[max(0, match.start() - 20):match.start() + 10]}..."
+        )
+    assert "&" not in re.sub(r"&(amp|lt|gt);", "", text), "unescaped '&'"
+
+
+def _result_with_reason(reason: str, verdict=Verdict.WATCH) -> AnalysisResult:
+    result = AnalysisResult(
+        symbol="USDJPY",
+        verdict=verdict,
+        checked_at=datetime(2026, 7, 16, 7, 12, tzinfo=timezone.utc),
+    )
+    result.reasons = [reason]
+    result.watch_notes = [reason]
+    return result
+
+
+class TestEscaping:
+    def test_escape_html_basics(self):
+        assert escape_html("fill < 50%") == "fill &lt; 50%"
+        assert escape_html("S&P Global PMI") == "S&amp;P Global PMI"
+        assert escape_html("a > b") == "a &gt; b"
+
+    def test_production_incident_fill_lt_50(self):
+        reason = "M5 CHoCH is there, but no valid FVG (size ≥ 5 pips, fill < 50%, current session)"
+        line = format_no_setup(_result_with_reason(reason))
+        _assert_valid_telegram_html(line)
+        assert "fill &lt; 50%" in line
+
+    def test_format_result_watch_and_skip_escaped(self):
+        reason = "RR 1:1.4 < minimum 1:2 to the nearest H1/H4 zones"
+        for verdict in (Verdict.WATCH, Verdict.SKIP):
+            text = format_result(_result_with_reason(reason, verdict))
+            _assert_valid_telegram_html(text)
+
+    def test_news_digest_titles_escaped(self):
+        cal = NewsCalendar()
+        cal.events = parse_feed(
+            [
+                {
+                    "title": "S&P Global Manufacturing PMI",
+                    "country": "USD",
+                    "date": "2026-07-16T09:45:00-04:00",
+                    "impact": "High",
+                }
+            ]
+        )
+        cal.fetched_at = datetime(2026, 7, 16, 5, 0, tzinfo=timezone.utc)
+        text = cal.digest_text({"USD"})
+        _assert_valid_telegram_html(text)
+        assert "S&amp;P" in text


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Fixes a production message-delivery failure seen in the logs:

```
sendMessage 400: can't parse entities: Unsupported start tag "" at byte offset 215
```

The `/check` summary contained the engine reason `fill < 50%` — with `parse_mode=HTML` Telegram read the raw `<` as a broken tag and rejected the whole message, so the reply never reached the owner.

- New `escape_html()` helper escapes `&`, `<`, `>` for Telegram HTML.
- Applied to all dynamic plain-text fragments embedded in HTML messages: engine reasons and watch notes (`format_result`, `format_no_setup` — which also feed the `/check` summary lines), and Forex Factory event titles in the morning digest, blackout lines and Rule 0.4 warnings (titles like **S&P Global Manufacturing PMI** would have hit the same bug).

### How was this tested?
- [x] Unit tests added/updated — **78 pass**, incl. a regression test reproducing the exact production string and a validator asserting every `<` in outgoing messages belongs to an intentional `<b>` tag
- [x] flake8 clean

### Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)