### PR TITLE
Prague time in messages; trading hours 08-20 Prague, forex Mon-Fri

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ redeploys.
 
 ## Strategy checklist (per pair, every 5 min in session)
 
-1. **Session filter** — entries only inside Frankfurt/London & NY windows
-   (Prague time, DST-aware). Closed forex market is detected automatically.
+1. **Session filter** — trading hours 08:00–20:00 Prague (Frankfurt/London
+   08–14, New York 14–20): crypto every day, forex Monday–Friday. A closed
+   forex market is also detected automatically. All message times are Prague.
 2. **H4 trend** — HH+HL / LH+LL with 2-closed-body pivot confirmation.
 3. **H1 zone** — latest untested Demand/Supply zone; invalidation by body close.
 4. **M5 trigger** — pullback into the zone → CHoCH in trend direction.

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -76,12 +76,17 @@ class TripleSyncEngine:
             price_decimals=self.instrument.price_decimals,
         )
 
-        # Rule 0.1 — session filter (entries only inside session windows)
-        result.session_name = active_session(now)
+        # Rule 0.1 — session filter: 08:00-20:00 Prague; forex only Mon-Fri,
+        # crypto every day
+        result.session_name = active_session(
+            now, require_weekday=self.instrument.source == "forex"
+        )
         if self.enforce_sessions and result.session_name is None:
             result.verdict = Verdict.OFF_SESSION
             result.reasons.append(
-                f"Outside session windows — no entries for {self.display_symbol}"
+                f"Outside trading hours (08-20 Prague"
+                f"{', Mon-Fri' if self.instrument.source == 'forex' else ''}) "
+                f"— no entries for {self.display_symbol}"
             )
             return result
 

--- a/app/services/smc/notifier.py
+++ b/app/services/smc/notifier.py
@@ -6,6 +6,7 @@ import httpx
 import structlog
 
 from app.services.smc.models import AnalysisResult, Direction, Trend, Verdict
+from app.services.smc.sessions import to_prague
 
 logger = structlog.get_logger(__name__)
 
@@ -29,8 +30,8 @@ URGENT_HEADER = (
 
 
 def format_no_setup(result: AnalysisResult) -> str:
-    """Compact 15-minute heartbeat when there is no setup."""
-    time_str = result.checked_at.strftime("%H:%M UTC")
+    """Compact heartbeat when there is no setup."""
+    time_str = to_prague(result.checked_at).strftime("%H:%M")
     if result.verdict == Verdict.OFF_SESSION:
         return (
             f"😴 {result.symbol} {time_str} — off session, entries are not "
@@ -42,7 +43,7 @@ def format_no_setup(result: AnalysisResult) -> str:
 
 def format_setup_still_active(result: AnalysisResult) -> str:
     """Short reminder when the previously reported setup is still valid."""
-    time_str = result.checked_at.strftime("%H:%M UTC")
+    time_str = to_prague(result.checked_at).strftime("%H:%M")
     return (
         f"⏳ {result.symbol} {time_str} — the setup reported earlier is still "
         "active. Nothing new."
@@ -57,7 +58,7 @@ def format_result(result: AnalysisResult) -> str:
         lines.append("")
     lines.append(f"<b>{result.symbol}</b> — Triple Sync + Imbalance")
     lines.append(
-        f"🕐 {result.checked_at.strftime('%d.%m.%Y %H:%M UTC')}"
+        f"🕐 {to_prague(result.checked_at).strftime('%d.%m.%Y %H:%M')} Prague"
         + (f" | Session: {result.session_name}" if result.session_name else "")
     )
     d = result.price_decimals

--- a/app/services/smc/sessions.py
+++ b/app/services/smc/sessions.py
@@ -1,4 +1,9 @@
-"""Session window filter (Rule 0.1) — Prague local time, DST aware."""
+"""Session window filter (Rule 0.1) — Prague local time, DST aware.
+
+Trading hours: 08:00-20:00 Prague. Crypto is watched every day, forex only
+Monday-Friday. The day is split into two adjacent blocks so the Rule 4
+"an FVG does not carry over between sessions" separation is preserved.
+"""
 
 from datetime import datetime, time
 from typing import List, Optional, Tuple
@@ -7,20 +12,11 @@ import pytz
 
 PRAGUE = pytz.timezone("Europe/Prague")
 
-# (start, end, name) in Prague local time. Summer per strategy spec;
-# winter windows are the same blocks shifted one hour back.
-SUMMER_WINDOWS = [
+# (start, end, name) in Prague local time, year-round (DST follows Prague).
+WINDOWS: List[Tuple[time, time, str]] = [
     (time(8, 0), time(14, 0), "Frankfurt/London"),
-    (time(15, 0), time(22, 0), "New York"),
+    (time(14, 0), time(20, 0), "New York"),
 ]
-WINTER_WINDOWS = [
-    (time(8, 0), time(13, 0), "Frankfurt/London"),
-    (time(14, 0), time(21, 0), "New York"),
-]
-
-
-def _is_dst(local_dt: datetime) -> bool:
-    return bool(local_dt.dst())
 
 
 def to_prague(utc_dt: datetime) -> datetime:
@@ -30,15 +26,17 @@ def to_prague(utc_dt: datetime) -> datetime:
     return utc_dt.astimezone(PRAGUE)
 
 
-def _windows_for(local_dt: datetime) -> List[Tuple[time, time, str]]:
-    return SUMMER_WINDOWS if _is_dst(local_dt) else WINTER_WINDOWS
+def active_session(utc_dt: datetime, require_weekday: bool = False) -> Optional[str]:
+    """Return the session name if utc_dt falls inside a trading window.
 
-
-def active_session(utc_dt: datetime) -> Optional[str]:
-    """Return the session name if utc_dt falls inside a trading window, else None."""
+    With require_weekday=True (forex) Saturday and Sunday return None;
+    crypto is watched seven days a week.
+    """
     local = to_prague(utc_dt)
+    if require_weekday and local.weekday() >= 5:
+        return None
     now = local.time()
-    for start, end, name in _windows_for(local):
+    for start, end, name in WINDOWS:
         if start <= now < end:
             return name
     return None
@@ -61,7 +59,7 @@ def session_end_utc(utc_dt: datetime) -> Optional[datetime]:
     """
     local = to_prague(utc_dt)
     now = local.time()
-    for start, end, _ in _windows_for(local):
+    for start, end, _ in WINDOWS:
         if start <= now < end:
             end_local = PRAGUE.localize(
                 datetime.combine(local.date(), end), is_dst=None
@@ -78,7 +76,7 @@ def same_session(utc_a: datetime, utc_b: datetime) -> bool:
     a, b = to_prague(utc_a), to_prague(utc_b)
     if a.date() != b.date():
         return False
-    for start, end, _ in _windows_for(a):
+    for start, end, _ in WINDOWS:
         a_in = start <= a.time() < end
         b_in = start <= b.time() < end
         if a_in or b_in:

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -223,8 +223,8 @@ class Watcher:
 
         await self._track_journal()
 
-        time_str = datetime.now(tz=timezone.utc).strftime("%H:%M UTC")
-        summary = f"🔍 <b>Check {time_str}</b>\n" + "\n".join(heartbeat_lines)
+        time_str = to_prague(datetime.now(tz=timezone.utc)).strftime("%H:%M")
+        summary = f"🔍 <b>Check {time_str} Prague</b>\n" + "\n".join(heartbeat_lines)
         logger.info("Cycle summary", summary=" | ".join(heartbeat_lines))
         # By default only setup alerts go to Telegram; the heartbeat is opt-in.
         if settings.smc.notify_no_setup and not approved:
@@ -343,7 +343,8 @@ class Watcher:
             lines.append("")
             lines.append("<b>Last check:</b>")
             for key, r in self.last_results.items():
-                lines.append(f"• {key}: {r.verdict.value} ({r.checked_at:%H:%M UTC})")
+                local = to_prague(r.checked_at)
+                lines.append(f"• {key}: {r.verdict.value} ({local:%H:%M} Prague)")
         return "\n".join(lines)
 
     # ------------------------------------------------------------- scheduler

--- a/tests/test_smc/test_improvements.py
+++ b/tests/test_smc/test_improvements.py
@@ -104,16 +104,38 @@ class TestCryptoSessionScope:
 class TestSessions:
     def test_same_trading_day(self):
         a = datetime(2026, 7, 6, 8, 0, tzinfo=timezone.utc)
-        b = datetime(2026, 7, 6, 19, 0, tzinfo=timezone.utc)
+        b = datetime(2026, 7, 6, 17, 0, tzinfo=timezone.utc)
         c = datetime(2026, 7, 6, 23, 0, tzinfo=timezone.utc)  # 01:00 Prague next day
         assert same_trading_day(a, b)
         assert not same_trading_day(b, c)
 
     def test_session_end_utc(self):
-        # 16:00 Prague summer (14:00 UTC) is in the NY window ending 22:00 CEST
+        # 16:00 Prague summer (14:00 UTC) is in the NY window ending 20:00 Prague
         dt = datetime(2026, 7, 6, 14, 0, tzinfo=timezone.utc)
         end = session_end_utc(dt)
-        assert end == datetime(2026, 7, 6, 20, 0, tzinfo=timezone.utc)
+        assert end == datetime(2026, 7, 6, 18, 0, tzinfo=timezone.utc)
+
+    def test_trading_hours_08_20_prague(self):
+        from app.services.smc.sessions import active_session
+
+        def at(hour, minute=0, day=8):  # Wed 2026-07-08, CEST = UTC+2
+            return datetime(2026, 7, day, hour - 2, minute, tzinfo=timezone.utc)
+
+        assert active_session(at(7, 59)) is None
+        assert active_session(at(8, 0)) == "Frankfurt/London"
+        assert active_session(at(13, 59)) == "Frankfurt/London"
+        assert active_session(at(14, 0)) == "New York"
+        assert active_session(at(19, 59)) == "New York"
+        assert active_session(at(20, 0)) is None
+
+    def test_forex_weekends_off_crypto_on(self):
+        from app.services.smc.sessions import active_session
+
+        saturday = datetime(2026, 7, 11, 8, 0, tzinfo=timezone.utc)  # 10:00 Prague
+        assert active_session(saturday) == "Frankfurt/London"  # crypto: every day
+        assert active_session(saturday, require_weekday=True) is None  # forex: off
+        friday = datetime(2026, 7, 10, 8, 0, tzinfo=timezone.utc)
+        assert active_session(friday, require_weekday=True) == "Frankfurt/London"
 
 
 class TestJournal:


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Two owner requests:

1. **Prague time everywhere.** All Telegram message timestamps (urgent alerts, heartbeats, `/check` summary, `/status`) now show Prague local time instead of UTC. The news digest was already Prague.
2. **Schedule per spec: 08:00–20:00 Prague.** Session windows simplified to two adjacent blocks — Frankfurt/London 08–14 and New York 14–20 — preserving the Rule 4 "FVG does not carry across sessions" separation. The old 14–15 lunch gap and the 20–22 tail are gone; the manual winter shift is replaced by plain Prague local time (DST handled by the timezone). **Forex pairs are checked Monday–Friday only** (`active_session(require_weekday=True)`), **crypto seven days a week**. Off-session reasons now say "Outside trading hours (08-20 Prague, Mon-Fri)".

### How was this tested?
- [x] Unit tests added/updated — **80 pass** (hour boundaries 07:59/08:00/13:59/14:00/19:59/20:00, Saturday off for forex / on for crypto, session-end expiry moved to 20:00 Prague)
- [x] Manual check of rendered message: `07:12 UTC → 09:12` Prague; flake8 clean

### Breaking Changes
Entry windows narrowed from 08–14 & 15–22 to 08–20 Prague per the owner's explicit spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)