### PR TITLE
FVG diagnostics, docs, and the visual upgrade pack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## What this project is
+
+A single-process Telegram bot that watches currency pairs for **Triple Sync +
+Imbalance** SMC (Smart Money Concepts) setups and sends an urgent alert when
+one is found. There is no web server, no Redis, no Postgres — one worker
+(`smc_watcher.py`) with a SQLite file. It runs on Railway.
+
+The **strategy specification is law**: rules −1 through 11 (H4 trend → H1 zone
+→ M5 CHoCH + FVG, RR ≥ 1:2, session windows, news blackouts, correlation
+limits) come from the owner's written trading system. Never relax or "improve"
+a strategy rule without the owner's explicit decision — implementation
+over-strictness may be fixed, the rules themselves may not. "Almost valid"
+does not exist in this system.
+
+## Commands
+
+```bash
+pytest tests/ -v                       # full test suite (fast, no network)
+flake8 app/ tests/ smc_watcher.py      # lint (config in .flake8)
+python smc_watcher.py --once           # live one-shot check (real market data)
+python smc_watcher.py --test-telegram  # sends test messages to the owner chat
+python smc_watcher.py                  # run forever: scheduler + command bot
+```
+
+Local runs need `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` (a dummy token
+like `123:dummy` works for `--once` — sends fail gracefully). Tests need
+nothing.
+
+## Architecture
+
+```
+smc_watcher.py            Watcher class: 5-min in-session scheduler (15-min
+                          off-session), per-pair cycle, alert dedup, morning
+                          news digest, Rule 0.4 warnings, journal tracking
+app/services/smc/
+├── engine.py             TripleSyncEngine: rules 0-8 checklist; pure
+│                         evaluate() is fully unit-testable on synthetic candles
+├── structure.py          fractal-5 pivots (2-closed-candle confirmation),
+│                         H4 trend HH+HL/LH+LL with fakeout-reclaim, H1 zones
+│                         (untested only), M5 CHoCH, TP target zones
+├── fvg.py                FVG detection, validation (size/fill/session) and
+│                         rejection diagnostics (best_rejected_fvg)
+├── sessions.py           trading hours 08:00-20:00 Prague, two blocks split
+│                         at 14:00 (London/NY FVG separation), forex Mon-Fri
+├── instruments.py        per-pair registry: source, min FVG, SL buffer, pip
+├── data.py / yahoo.py / oanda.py   candle fetchers (same interface):
+│                         crypto=Binance; forex=Yahoo keyless by default,
+│                         OANDA v20 when OANDA_API_TOKEN is set
+├── news.py               Forex Factory red-news calendar, blackout windows
+├── journal.py            signal lifecycle pending→open→tp/sl/expired,
+│                         auto-tracked on M5 candles; /stats source
+├── telegram_bot.py       long-polling commands (/pairs /status /check /stats
+│                         /news); serves ONLY the owner chat id
+├── notifier.py           message formatting + escape_html + sender
+├── state.py              runtime state (pairs, dedup keys) on SQLite kv
+└── db.py                 SQLite wrapper (signals + kv), legacy JSON migration,
+                          fallback to a local file if the volume is unwritable
+```
+
+Data flow per cycle: news refresh → per enabled pair: blackout check →
+fetch H4/H1/M5 → engine checklist → alert (dedup per session) / log →
+journal outcome tracking.
+
+## Conventions and gotchas
+
+- **All bot-facing text is English**; conversation with the owner is Russian
+  (address him as «Брат»). Message timestamps are **Prague time**.
+- **Telegram messages use parse_mode=HTML**: any dynamic string embedded in a
+  message MUST go through `notifier.escape_html` (a raw `<` in "fill < 50%"
+  once broke message delivery in production). Only `<b>` tags are used.
+- **Quiet mode is the default**: Telegram receives only found setups (and
+  Rule 9/0.4 warnings + the 07:45 digest). Everything else goes to logs.
+  Do not add chatty messages without being asked.
+- Engines see **closed candles only** — every fetcher drops the in-progress
+  candle; Yahoo H4 is resampled from 1h into 0/4/8/12/16/20 UTC buckets.
+- Per-instrument parameters (min FVG 5 pips forex / $2 ETH, SL buffer, pip,
+  decimals) live in `instruments.py` — never hardcode them elsewhere.
+- The container runs **as root** on purpose: Railway volumes are root-owned
+  (a non-root user caused a production crash-loop). `db.py` must never crash
+  the watcher — it falls back to an ephemeral local DB and logs loudly.
+- Journal outcome semantics: entry fill = candle touch; TP and SL in the same
+  candle counts as **SL** (conservative); pending orders expire with their
+  session (Rule 10).
+- pytest config: `pytest.ini` (asyncio_mode=auto). Tests build synthetic
+  candles via `tests/test_smc/helpers.py` (asymmetric wicks make turning
+  points strict fractal pivots). Keep tests network-free.
+
+## Workflow
+
+- Work on branch `feat/smc-watcher-railway`, PRs to `master` via `gh`
+  (installed at `C:\Program Files\GitHub CLI` on the owner's machine; add to
+  PATH in bash). The owner merges; Railway deploys master.
+- PR template lives in `.github/pull_request_template.md` — follow it.
+- Run `pytest` and `flake8` before every commit; add regression tests for
+  every production bug fixed.
+
+## Deployment (Railway)
+
+One service from this repo (Dockerfile default CMD). Required vars:
+`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`. Recommended: volume mounted at
+`/data` + `SMC_DB_FILE=/data/smc.db` (persistence), `SMC_DEPOSIT` (lot hints).
+Optional: `OANDA_API_TOKEN`/`OANDA_ENVIRONMENT` for better forex data.
+All tunables are documented in `env.example`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,9 @@ nothing.
 
 ```
 smc_watcher.py            Watcher class: 5-min in-session scheduler (15-min
-                          off-session), per-pair cycle, alert dedup, morning
-                          news digest, Rule 0.4 warnings, journal tracking
+                          off-session), per-pair cycle, alert dedup, live
+                          setup cards, discipline suppression, morning news
+                          digest, Rule 0.4 warnings, journal tracking
 app/services/smc/
 ├── engine.py             TripleSyncEngine: rules 0-8 checklist; pure
 │                         evaluate() is fully unit-testable on synthetic candles
@@ -50,20 +51,26 @@ app/services/smc/
 ├── data.py / yahoo.py / oanda.py   candle fetchers (same interface):
 │                         crypto=Binance; forex=Yahoo keyless by default,
 │                         OANDA v20 when OANDA_API_TOKEN is set
-├── news.py               Forex Factory red-news calendar, blackout windows
-├── journal.py            signal lifecycle pending→open→tp/sl/expired,
-│                         auto-tracked on M5 candles; /stats source
-├── telegram_bot.py       long-polling commands (/pairs /status /check /stats
-│                         /news); serves ONLY the owner chat id
-├── notifier.py           message formatting + escape_html + sender
+├── news.py               Forex Factory red-news calendar, blackout windows,
+│                         digest day-timeline
+├── journal.py            signal lifecycle pending→open→tp/sl/expired with
+│                         state-change events, taken marks (alert buttons),
+│                         discipline_block (Rule 10 / Rule 0.2), /stats
+├── chart.py              alert chart PNG: M5 candles + zone + FVG + levels
+│                         (matplotlib Agg, NO pandas — keep it that way)
+├── telegram_bot.py       long-polling commands, slash-menu registration,
+│                         Took/Skipped callbacks; serves ONLY the owner chat
+├── notifier.py           send/edit_message/pin/send_photo + escape_html
 ├── state.py              runtime state (pairs, dedup keys) on SQLite kv
-└── db.py                 SQLite wrapper (signals + kv), legacy JSON migration,
-                          fallback to a local file if the volume is unwritable
+└── db.py                 SQLite wrapper (signals + kv), column auto-migration,
+                          legacy JSON import, fallback to a local file if the
+                          volume is unwritable
 ```
 
 Data flow per cycle: news refresh → per enabled pair: blackout check →
-fetch H4/H1/M5 → engine checklist → alert (dedup per session) / log →
-journal outcome tracking.
+fetch H4/H1/M5 → engine checklist → discipline check → alert (buttons +
+pinned card + chart PNG, dedup per session) / log → journal outcome
+tracking → live-card edits on fill/TP/SL events.
 
 ## Conventions and gotchas
 
@@ -85,6 +92,14 @@ journal outcome tracking.
 - Journal outcome semantics: entry fill = candle touch; TP and SL in the same
   candle counts as **SL** (conservative); pending orders expire with their
   session (Rule 10).
+- **Discipline is driven by `taken` marks only** (the ✅/❌ alert buttons):
+  Rule 10 re-entry bans and the Rule 0.2 daily stop count taken stops, never
+  skipped or unanswered signals. Do not weaken this without the owner.
+- **Chart rendering must never block an alert** — `_send_alert` wraps it in
+  try/except; keep `chart.py` matplotlib-only (no pandas/mplfinance, image
+  size matters on Railway).
+- Adding a signal column? Extend `SIGNAL_COLUMNS`, the `CREATE TABLE` and the
+  migration list in `db.py` — existing production DBs are migrated in place.
 - pytest config: `pytest.ini` (asyncio_mode=auto). Tests build synthetic
   candles via `tests/test_smc/helpers.py` (asymmetric wicks make turning
   points strict fractal pivots). Keep tests network-free.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,22 @@ selected currency pairs — every 5 minutes during trading hours (08:00–20:00
 Prague), every 15 minutes outside them — and alerts you the moment a valid
 setup appears.
 
-- 🚨 **Urgent alert** when a setup is APPROVED (entry / SL / TP / RR / lot size)
+- 🚨 **Urgent alert** when a setup is APPROVED — entry / SL / TP / RR / lot
+  size, a **dark-style M5 chart PNG** (H1 zone, FVG box, ENTRY/SL/TP levels)
+  and **✅ Took it / ❌ Skipped buttons**
+- 📌 **Live setup card** — the alert is pinned and edited in place as the
+  signal evolves: `📈 Filled @ … → 🎯 TP HIT (+2.1R)`; unpinned on resolution
+- 🛡 **Discipline on autopilot** — trades you mark as taken enforce Rule 10
+  (no re-entry after a stop in the same session) and Rule 0.2 (two taken
+  stops close the trading day: alerts muted until tomorrow)
 - 🤫 **Silent otherwise** — checks without a setup only go to the logs, with
   precise reasons («best FVG candidate: 3.2 pips < required 5»); `/check`
   shows the current picture on demand
 - 💱 **Pairs are switchable at runtime** via Telegram: `/pairs`
 - 📅 **Forex Factory red-news filter** with a morning digest at 07:45 Prague
-- 📒 **Signal journal**: every alert is auto-tracked to its TP/SL outcome
+  (incl. a one-glance day timeline `🕗 08 ····🔴· │ ·🔴···· 20`)
+- 📒 **Signal journal**: every alert is auto-tracked to its TP/SL outcome;
+  `/stats` shows signal winrate and your personal (taken) winrate separately
 
 ## Supported pairs
 
@@ -31,12 +40,14 @@ Default watched pairs: **ETHUSD + USDJPY** (change with `/pairs` or `SMC_PAIRS`)
 
 ## Telegram commands
 
+Commands are registered in the bot's slash menu (type `/` in the chat).
+
 | Command | What it does |
 |---|---|
 | `/pairs` | inline keyboard — toggle watched pairs on/off |
 | `/status` | enabled pairs, current session, last verdicts |
 | `/check` | run the full strategy check right now |
-| `/stats` | signal journal: setups, TP/SL outcomes, winrate per pair |
+| `/stats` | journal: winrate bars, outcome sparkline, personal (taken) stats |
 | `/news` | today's red news (Forex Factory) and blackout windows |
 | `/help` | command list |
 
@@ -58,6 +69,12 @@ pending (limit not reached) → open (entry touched) → **tp / sl** (whichever 
 first; both in one candle counts as sl, conservative). A pending order that
 outlives its session becomes **expired** (Rule 10). `/stats` shows counts,
 winrate and per-pair breakdown — the data basis for tuning the strategy.
+
+Pressing **✅ Took it** on an alert marks the signal as a real trade: `/stats`
+then tracks your personal winrate, and the discipline kill-switches activate —
+a taken stop bans re-entry on that pair+direction for the session (Rule 10),
+and the second taken stop of the day suppresses all further alerts until
+tomorrow (Rule 0.2). Skipped signals never count against the limits.
 
 Signals and runtime state (selected pairs, dedup keys) live in one **SQLite
 database** (`SMC_DB_FILE`, default `.smc_watcher.db`; legacy JSON files are
@@ -138,7 +155,8 @@ pytest tests/ -v
 ## Project layout
 
 ```
-smc_watcher.py              # entry point: scheduler + alerts + news + journal
+smc_watcher.py              # entry point: scheduler, alerts, live cards,
+                            # news, journal tracking, discipline
 app/core/                   # config (pydantic-settings), logging, exceptions
 app/services/smc/
 ├── engine.py               # rules 0-8 orchestration (pure, testable)
@@ -149,19 +167,20 @@ app/services/smc/
 ├── data.py                 # Binance fetcher (ETHUSD)
 ├── yahoo.py                # Yahoo Finance fetcher (forex default, no key)
 ├── oanda.py                # OANDA v20 fetcher (forex, optional)
-├── news.py                 # Forex Factory red-news calendar & blackouts
-├── journal.py              # signal lifecycle & outcome tracking (/stats)
-├── telegram_bot.py         # long-polling commands (owner chat only)
-├── notifier.py             # message formatting, HTML escaping, delivery
+├── news.py                 # Forex Factory calendar, blackouts, day timeline
+├── journal.py              # signal lifecycle, taken marks, discipline, /stats
+├── chart.py                # setup chart PNG for alerts (matplotlib, no pandas)
+├── telegram_bot.py         # long-polling commands, slash menu, alert buttons
+├── notifier.py             # send/edit/pin/photo, HTML escaping, formatting
 ├── state.py                # runtime state on SQLite (pairs, dedup keys)
-├── db.py                   # SQLite wrapper + legacy JSON migration
+├── db.py                   # SQLite wrapper, column migrations, JSON import
 └── models.py               # Candle, Zone, FVG, TradeSetup, AnalysisResult
-tests/test_smc/             # 83 unit + end-to-end strategy tests
+tests/test_smc/             # 93 unit + end-to-end strategy tests
 CLAUDE.md                   # guidance for AI-assisted development
 ```
 
 ## Risk disclaimer
 
-The bot only **detects** setups by the strategy rules. Daily/weekly loss
-limits, max trades per day and actual order execution remain the trader's
-responsibility.
+The bot **detects** setups by the strategy rules and tracks discipline for
+trades you mark as taken. Actual order execution, weekly loss limits and
+final risk decisions remain the trader's responsibility.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # SMC Watcher — Triple Sync + Imbalance
 
-A Telegram bot that runs the **Triple Sync + Imbalance** SMC strategy every
-15 minutes for the selected currency pairs and alerts you the moment a valid
+A Telegram bot that runs the **Triple Sync + Imbalance** SMC strategy for the
+selected currency pairs — every 5 minutes during trading hours (08:00–20:00
+Prague), every 15 minutes outside them — and alerts you the moment a valid
 setup appears.
 
 - 🚨 **Urgent alert** when a setup is APPROVED (entry / SL / TP / RR / lot size)
-- 🤫 **Silent otherwise** — checks without a setup only go to the logs
-  (`/check` shows the current picture on demand; `SMC_NOTIFY_NO_SETUP=true`
-  enables 15-min heartbeat messages)
+- 🤫 **Silent otherwise** — checks without a setup only go to the logs, with
+  precise reasons («best FVG candidate: 3.2 pips < required 5»); `/check`
+  shows the current picture on demand
 - 💱 **Pairs are switchable at runtime** via Telegram: `/pairs`
+- 📅 **Forex Factory red-news filter** with a morning digest at 07:45 Prague
+- 📒 **Signal journal**: every alert is auto-tracked to its TP/SL outcome
 
 ## Supported pairs
 
@@ -67,12 +70,16 @@ redeploys.
 1. **Session filter** — trading hours 08:00–20:00 Prague (Frankfurt/London
    08–14, New York 14–20): crypto every day, forex Monday–Friday. A closed
    forex market is also detected automatically. All message times are Prague.
-2. **H4 trend** — HH+HL / LH+LL with 2-closed-body pivot confirmation.
+2. **H4 trend** — HH+HL / LH+LL with 2-closed-body pivot confirmation;
+   a reclaimed fakeout beyond the last HL/LH does not kill the trend.
 3. **H1 zone** — latest untested Demand/Supply zone; invalidation by body close.
 4. **M5 trigger** — pullback into the zone → CHoCH in trend direction.
-5. **FVG validation** — min size per instrument, fill < 50%, same session only.
+5. **FVG validation** — min size per instrument, fill < 50%; session scope:
+   forex per London/NY block, crypto per whole Prague day. Rejections are
+   explained in logs (best candidate size / fill / session).
 6. **SL** — behind the confirmed M5 pivot + buffer; **TP** — nearest untested
-   opposite zone; **RR ≥ 1:2** or SKIP.
+   opposite zone (H1, falling back to H4 if the H1 target fails min RR);
+   **RR ≥ 1:2** or SKIP.
 7. **Position size** — from `SMC_DEPOSIT` at 2% risk (crypto qty / forex lots).
 8. **Rule 9 correlation guard** — warns about forbidden USD combinations
    (e.g. EURUSD + GBPUSD in the same direction).
@@ -131,22 +138,26 @@ pytest tests/ -v
 ## Project layout
 
 ```
-smc_watcher.py              # entry point: scheduler + Telegram command bot
-app/core/                   # config, logging, exceptions
+smc_watcher.py              # entry point: scheduler + alerts + news + journal
+app/core/                   # config (pydantic-settings), logging, exceptions
 app/services/smc/
-├── engine.py               # rules 0-8 orchestration
+├── engine.py               # rules 0-8 orchestration (pure, testable)
 ├── structure.py            # pivots, trend, zones, BOS/CHoCH
-├── fvg.py                  # FVG detection & validation
-├── sessions.py             # Prague session windows
+├── fvg.py                  # FVG detection, validation & rejection diagnostics
+├── sessions.py             # 08-20 Prague trading hours, London/NY blocks
 ├── instruments.py          # per-pair parameters & data source registry
 ├── data.py                 # Binance fetcher (ETHUSD)
 ├── yahoo.py                # Yahoo Finance fetcher (forex default, no key)
 ├── oanda.py                # OANDA v20 fetcher (forex, optional)
-├── telegram_bot.py         # long-polling commands: /pairs /status /check
-├── notifier.py             # message formatting & delivery
-├── state.py                # persisted pairs & reported setups
+├── news.py                 # Forex Factory red-news calendar & blackouts
+├── journal.py              # signal lifecycle & outcome tracking (/stats)
+├── telegram_bot.py         # long-polling commands (owner chat only)
+├── notifier.py             # message formatting, HTML escaping, delivery
+├── state.py                # runtime state on SQLite (pairs, dedup keys)
+├── db.py                   # SQLite wrapper + legacy JSON migration
 └── models.py               # Candle, Zone, FVG, TradeSetup, AnalysisResult
-tests/test_smc/             # unit + end-to-end strategy tests
+tests/test_smc/             # 83 unit + end-to-end strategy tests
+CLAUDE.md                   # guidance for AI-assisted development
 ```
 
 ## Risk disclaimer

--- a/app/services/smc/chart.py
+++ b/app/services/smc/chart.py
@@ -1,0 +1,124 @@
+"""Setup chart rendering: M5 candles with zone, FVG and entry/SL/TP levels.
+
+Pure matplotlib (Agg backend, no pandas) — the PNG is attached to every
+urgent alert so the setup is visible at a glance without opening TradingView.
+Rendering failures must never block an alert: callers wrap in try/except.
+"""
+
+from io import BytesIO
+from typing import Optional
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.patches import Rectangle  # noqa: E402
+
+from app.services.smc.models import AnalysisResult, Direction  # noqa: E402
+from app.services.smc.sessions import to_prague  # noqa: E402
+
+UP_COLOR = "#26a69a"
+DOWN_COLOR = "#ef5350"
+BG = "#131722"
+FG = "#d1d4dc"
+GRID = "#2a2e39"
+
+
+def render_setup_chart(result: AnalysisResult, candles_back: int = 96) -> Optional[bytes]:
+    """Render the approved setup as a PNG (last ~8h of M5). None if no data."""
+    if not result.m5_candles or not result.setup:
+        return None
+    candles = result.m5_candles[-candles_back:]
+    setup = result.setup
+
+    fig, ax = plt.subplots(figsize=(10, 6), dpi=110)
+    fig.patch.set_facecolor(BG)
+    ax.set_facecolor(BG)
+
+    # Candles
+    for i, c in enumerate(candles):
+        color = UP_COLOR if c.close >= c.open else DOWN_COLOR
+        ax.plot([i, i], [c.low, c.high], color=color, linewidth=0.7, zorder=2)
+        body_bottom = min(c.open, c.close)
+        body_height = max(abs(c.close - c.open), (c.high - c.low) * 0.02 or 1e-9)
+        ax.add_patch(
+            Rectangle(
+                (i - 0.35, body_bottom),
+                0.7,
+                body_height,
+                facecolor=color,
+                edgecolor=color,
+                zorder=3,
+            )
+        )
+
+    x_right = len(candles) + 6
+
+    # H1 zone (demand/supply)
+    if result.h1_zone:
+        zone = result.h1_zone
+        zone_color = "#2962ff" if zone.is_demand else "#f23645"
+        ax.axhspan(zone.bottom, zone.top, color=zone_color, alpha=0.12, zorder=1)
+
+    # FVG box from its formation candle to the right edge
+    fvg = setup.fvg
+    fvg_start = max(0, len(candles) - (len(result.m5_candles) - fvg.index))
+    ax.add_patch(
+        Rectangle(
+            (fvg_start, fvg.bottom),
+            x_right - fvg_start,
+            fvg.size,
+            facecolor="#26a69a" if fvg.is_bullish else "#ef5350",
+            alpha=0.18,
+            edgecolor="none",
+            zorder=1,
+        )
+    )
+
+    # Entry / SL / TP levels
+    d = result.price_decimals
+    for price, color, label in (
+        (setup.entry, "#2962ff", f"ENTRY {setup.entry:.{d}f}"),
+        (setup.stop_loss, "#f23645", f"SL {setup.stop_loss:.{d}f}"),
+        (setup.take_profit, "#089981", f"TP {setup.take_profit:.{d}f}"),
+    ):
+        ax.axhline(price, color=color, linewidth=1.1, linestyle="--", zorder=4)
+        ax.text(
+            x_right,
+            price,
+            f" {label}",
+            color=color,
+            fontsize=9,
+            fontweight="bold",
+            va="center",
+            ha="left",
+        )
+
+    # Sparse Prague time labels on the x axis
+    ticks = list(range(0, len(candles), max(1, len(candles) // 8)))
+    ax.set_xticks(ticks)
+    ax.set_xticklabels(
+        [to_prague(candles[i].timestamp).strftime("%H:%M") for i in ticks],
+        color=FG,
+        fontsize=8,
+    )
+    ax.tick_params(colors=FG, labelsize=8)
+    for spine in ax.spines.values():
+        spine.set_color(GRID)
+    ax.grid(color=GRID, linewidth=0.4, alpha=0.6)
+    ax.set_xlim(-1, x_right + 8)
+
+    side = "LONG" if setup.direction == Direction.LONG else "SHORT"
+    ax.set_title(
+        f"{result.symbol} M5 — {side} setup | RR 1:{setup.rr:.1f} | "
+        f"{to_prague(result.checked_at).strftime('%d.%m %H:%M')} Prague",
+        color=FG,
+        fontsize=11,
+        fontweight="bold",
+    )
+
+    buffer = BytesIO()
+    fig.savefig(buffer, format="png", bbox_inches="tight", facecolor=BG)
+    plt.close(fig)
+    return buffer.getvalue()

--- a/app/services/smc/db.py
+++ b/app/services/smc/db.py
@@ -30,6 +30,9 @@ SIGNAL_COLUMNS = [
     "filled_at",
     "resolved_at",
     "checked_until",
+    "taken",  # None = unanswered, 1 = user took the trade, 0 = skipped
+    "message_id",  # Telegram message id of the alert (live setup card)
+    "alert_text",  # original alert body, re-used when editing the card
 ]
 
 
@@ -59,13 +62,30 @@ class Database:
                     status TEXT NOT NULL,
                     filled_at TEXT,
                     resolved_at TEXT,
-                    checked_until TEXT
+                    checked_until TEXT,
+                    taken INTEGER,
+                    message_id INTEGER,
+                    alert_text TEXT
                 )
                 """
             )
             self.conn.execute(
                 "CREATE TABLE IF NOT EXISTS kv (key TEXT PRIMARY KEY, value TEXT)"
             )
+            # Migrate databases created before these columns existed
+            existing = {
+                row["name"]
+                for row in self.conn.execute("PRAGMA table_info(signals)")
+            }
+            for column, sql_type in (
+                ("taken", "INTEGER"),
+                ("message_id", "INTEGER"),
+                ("alert_text", "TEXT"),
+            ):
+                if column not in existing:
+                    self.conn.execute(
+                        f"ALTER TABLE signals ADD COLUMN {column} {sql_type}"
+                    )
 
     def _connect(self, path: str) -> sqlite3.Connection:
         """Open the database, creating parent dirs; fall back instead of dying.

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -92,6 +92,7 @@ class TripleSyncEngine:
 
         data = await self.fetcher.fetch_all_timeframes()
         result.price = data["m5"][-1].close
+        result.m5_candles = data["m5"]  # kept for chart rendering
 
         # Closed market (forex weekend): the newest M5 candle is stale.
         age = now - data["m5"][-1].timestamp

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import structlog
 
 from app.services.smc.data import BinanceDataFetcher
-from app.services.smc.fvg import select_valid_fvg
+from app.services.smc.fvg import best_rejected_fvg, select_valid_fvg
 from app.services.smc.instruments import Instrument, get_instrument
 from app.services.smc.models import (
     AnalysisResult,
@@ -200,18 +200,19 @@ class TripleSyncEngine:
         # Rule 4 — valid FVG on/after the CHoCH. The imbalance belongs to the
         # impulse leg that breaks structure, so the 3-candle window may end on
         # the CHoCH candle itself (hence choch - 2), but never before the touch.
+        same_day = self.instrument.source == "crypto"
         fvg = select_valid_fvg(
             m5,
             direction,
             max(touch, choch - 2),
             self.min_fvg_size,
-            same_day_scope=self.instrument.source == "crypto",
+            same_day_scope=same_day,
         )
         if fvg is None:
             result.verdict = Verdict.WATCH
             result.reasons.append(
-                f"M5 CHoCH is there, but no valid FVG (size ≥ {self._fvg_size_label()}, "
-                "fill < 50%, current session)"
+                "M5 CHoCH is there, but no valid FVG — "
+                + self._fvg_rejection_detail(m5, direction, max(touch, choch - 2), same_day)
             )
             result.watch_notes.append("Wait for an impulse FVG to form on M5")
             return result
@@ -308,9 +309,38 @@ class TripleSyncEngine:
 
     def _fvg_size_label(self) -> str:
         """Human threshold: '$2.00' for crypto, '5 pips' for forex."""
+        return self._fmt_size(self.min_fvg_size, precise=False)
+
+    def _fmt_size(self, value: float, precise: bool = True) -> str:
+        """Format a price distance: dollars for crypto, pips for forex."""
         if self.instrument.source == "crypto":
-            return f"${self.min_fvg_size:.2f}"
-        return f"{self.min_fvg_size / self.instrument.pip:.0f} pips"
+            return f"${value:.2f}"
+        pips = value / self.instrument.pip
+        return f"{pips:.1f} pips" if precise else f"{pips:.0f} pips"
+
+    def _fvg_rejection_detail(
+        self, m5, direction: Direction, from_index: int, same_day: bool
+    ) -> str:
+        """Explain why Rule 4 rejected the impulse (for logs and /check)."""
+        rejected = best_rejected_fvg(
+            m5, direction, from_index, self.min_fvg_size, same_day_scope=same_day
+        )
+        if rejected is None:
+            return "no FVG has formed in the impulse yet"
+        candidate, problems = rejected
+        parts = []
+        if "size" in problems:
+            parts.append(
+                f"size {self._fmt_size(candidate.size)} < required "
+                f"{self._fvg_size_label()}"
+            )
+        if "closed" in problems:
+            parts.append("invalidated (body closed through the gap)")
+        elif "fill" in problems:
+            parts.append(f"{candidate.fill_pct * 100:.0f}% filled (max 50%)")
+        if "session" in problems:
+            parts.append("formed in a previous session")
+        return "best candidate: " + ", ".join(parts)
 
     def _lot_hint(self, entry: float, risk: float) -> Optional[str]:
         """Rule 8: position size from deposit and SL distance."""

--- a/app/services/smc/fvg.py
+++ b/app/services/smc/fvg.py
@@ -1,6 +1,6 @@
 """FVG detection and validation (Rule 4)."""
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from app.services.smc.models import Candle, Direction, FVG
 from app.services.smc.sessions import same_session, same_trading_day
@@ -92,3 +92,38 @@ def select_valid_fvg(
             continue
         return fvg
     return None
+
+
+def best_rejected_fvg(
+    candles: List[Candle],
+    direction: Direction,
+    from_index: int,
+    min_size: float,
+    max_fill: float = 0.5,
+    same_day_scope: bool = False,
+) -> Optional[Tuple[FVG, List[str]]]:
+    """Diagnostics: the candidate that came closest to passing Rule 4.
+
+    Returns (fvg, problems) where problems is a subset of
+    {"size", "fill", "closed", "session"}, or None when no gap formed at all.
+    Used to explain WATCH verdicts ("best candidate was 3.2 pips of 5").
+    """
+    now = candles[-1].timestamp
+    in_scope = same_trading_day if same_day_scope else same_session
+    best: Optional[Tuple[FVG, List[str]]] = None
+    best_key = None
+    for fvg in find_fvgs(candles, direction, from_index):
+        fvg = measure_fill(candles, fvg)
+        problems = []
+        if fvg.size < min_size:
+            problems.append("size")
+        if fvg.closed_through:
+            problems.append("closed")
+        elif fvg.fill_pct >= max_fill:
+            problems.append("fill")
+        if not in_scope(fvg.timestamp, now):
+            problems.append("session")
+        key = (len(problems), -fvg.size)  # fewest problems, then largest gap
+        if best_key is None or key < best_key:
+            best, best_key = (fvg, problems), key
+    return best

--- a/app/services/smc/journal.py
+++ b/app/services/smc/journal.py
@@ -16,13 +16,13 @@ closed M5 candles, incrementally per cycle.
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
 import structlog
 
 from app.services.smc.db import Database
 from app.services.smc.models import AnalysisResult, Candle, Direction
-from app.services.smc.sessions import session_end_utc
+from app.services.smc.sessions import session_end_utc, to_prague
 
 logger = structlog.get_logger(__name__)
 
@@ -120,11 +120,84 @@ class SignalJournal:
             ),
             "resolved_at": None,
             "checked_until": None,
+            "taken": None,
+            "message_id": None,
+            "alert_text": None,
         }
         self.signals.append(signal)
         self.save()
         logger.info("Signal recorded", id=signal["id"], pair=signal["pair"])
         return signal
+
+    def get(self, signal_id: str) -> Optional[Dict]:
+        for signal in self.signals:
+            if signal["id"] == signal_id:
+                return signal
+        return None
+
+    def attach_message(
+        self, signal_id: str, message_id: int, alert_text: str
+    ) -> None:
+        """Link the Telegram alert message to the signal (live setup card)."""
+        signal = self.get(signal_id)
+        if signal:
+            signal["message_id"] = message_id
+            signal["alert_text"] = alert_text
+            self.save()
+
+    def mark_taken(self, signal_id: str, taken: bool) -> Optional[Dict]:
+        """Owner pressed ✅ Took it / ❌ Skipped on the alert."""
+        signal = self.get(signal_id)
+        if signal:
+            signal["taken"] = 1 if taken else 0
+            self.save()
+            logger.info("Signal marked", id=signal_id, taken=taken)
+        return signal
+
+    # ---------------------------------------------------------- discipline
+
+    def discipline_block(
+        self, pair: str, direction: str, session: Optional[str], now: datetime
+    ) -> Optional[str]:
+        """Kill-switch proxies based on trades the owner marked as taken.
+
+        Rule 10: no re-entry on the same pair+direction in the same session
+        after a taken stop-loss. Rule 0.2: two taken stops in one day close
+        the trading day.
+        """
+        today = to_prague(now).date()
+        taken_sl_today = [
+            s
+            for s in self.signals
+            if s.get("taken") == 1
+            and s["status"] == "sl"
+            and s.get("resolved_at")
+            and to_prague(_parse(s["resolved_at"])).date() == today
+        ]
+        if len(taken_sl_today) >= 2:
+            return "Rule 0.2: two taken stop-losses today — trading day is closed"
+        for s in taken_sl_today:
+            if (
+                s["pair"] == pair
+                and s["direction"] == direction
+                and s.get("session") == session
+            ):
+                return (
+                    f"Rule 10: {pair} {direction} already stopped out this "
+                    "session — no re-entry"
+                )
+        return None
+
+    def taken_sl_count_today(self, now: datetime) -> int:
+        today = to_prague(now).date()
+        return sum(
+            1
+            for s in self.signals
+            if s.get("taken") == 1
+            and s["status"] == "sl"
+            and s.get("resolved_at")
+            and to_prague(_parse(s["resolved_at"])).date() == today
+        )
 
     def unresolved_pairs(self) -> List[str]:
         return sorted(
@@ -135,29 +208,31 @@ class SignalJournal:
             }
         )
 
-    def update_pair(self, pair: str, candles: List[Candle]) -> List[Dict]:
-        """Evaluate all unresolved signals of a pair; returns newly resolved."""
+    def update_pair(self, pair: str, candles: List[Candle]) -> List[Tuple[Dict, str]]:
+        """Evaluate all unresolved signals of a pair.
+
+        Returns state-change events as (signal, event) tuples, where event is
+        "filled", "tp", "sl", "expired" or "timeout" — used to live-update the
+        alert card in Telegram.
+        """
         now = datetime.now(tz=timezone.utc)
-        resolved = []
+        events: List[Tuple[Dict, str]] = []
         for signal in self.signals:
             if signal["pair"] != pair or signal["status"] not in ("pending", "open"):
                 continue
             before = signal["status"]
             evaluate_signal(signal, candles, now)
-            if signal["status"] != before and signal["status"] not in (
-                "pending",
-                "open",
-            ):
-                resolved.append(signal)
+            after = signal["status"]
+            if before == "pending" and after in ("open", "tp", "sl"):
+                events.append((signal, "filled"))
+            if after != before and after in ("tp", "sl", "expired", "timeout"):
+                events.append((signal, after))
                 logger.info(
-                    "Signal resolved",
-                    id=signal["id"],
-                    pair=pair,
-                    outcome=signal["status"],
+                    "Signal resolved", id=signal["id"], pair=pair, outcome=after
                 )
-        if resolved:
+        if events:
             self.save()
-        return resolved
+        return events
 
     def stats_text(self, days: int = 30) -> str:
         """Human summary for /stats."""
@@ -166,20 +241,26 @@ class SignalJournal:
         if not recent:
             return f"📒 Journal is empty for the last {days} days — no setups yet."
 
-        def count(status):
-            return sum(1 for s in recent if s["status"] == status)
+        def count(status, pool=recent):
+            return sum(1 for s in pool if s["status"] == status)
 
         tp, sl = count("tp"), count("sl")
-        closed = tp + sl
-        winrate = f"{tp / closed * 100:.0f}%" if closed else "—"
+        taken = [s for s in recent if s.get("taken") == 1]
+        t_tp, t_sl = count("tp", taken), count("sl", taken)
+
         lines = [
             f"📒 <b>Signal journal — last {days} days</b>",
-            f"Total setups: {len(recent)}",
-            f"🎯 TP: {tp} | 🛑 SL: {sl} | winrate: {winrate}",
-            f"⏳ Active: {count('pending') + count('open')} "
-            f"(awaiting fill: {count('pending')}, in position: {count('open')})",
-            f"🗑 Expired unfilled (session ended): {count('expired')}",
+            f"Signals: {len(recent)} | marked taken: {len(taken)}",
+            f"🎯 TP {tp} | 🛑 SL {sl} | ⏳ active "
+            f"{count('pending') + count('open')} | 🗑 expired {count('expired')}",
+            f"Winrate (signals): {_winrate_bar(tp, sl)}",
         ]
+        if t_tp + t_sl:
+            lines.append(f"Winrate (taken):   {_winrate_bar(t_tp, t_sl)}")
+        spark = _sparkline(recent)
+        if spark:
+            lines.append(f"Last outcomes: {spark}")
+
         by_pair: Dict[str, List[Dict]] = {}
         for s in recent:
             by_pair.setdefault(s["pair"], []).append(s)
@@ -187,10 +268,29 @@ class SignalJournal:
         lines.append("<b>By pair:</b>")
         for pair in sorted(by_pair):
             group = by_pair[pair]
-            g_tp = sum(1 for s in group if s["status"] == "tp")
-            g_sl = sum(1 for s in group if s["status"] == "sl")
-            lines.append(f"• {pair}: {len(group)} setups, TP {g_tp} / SL {g_sl}")
+            lines.append(
+                f"• {pair}: {len(group)} setups, "
+                f"TP {count('tp', group)} / SL {count('sl', group)}"
+            )
         avg_rr = sum(s["rr"] for s in recent) / len(recent)
         lines.append("")
         lines.append(f"Average planned RR: 1:{avg_rr:.1f}")
         return "\n".join(lines)
+
+
+def _winrate_bar(tp: int, sl: int) -> str:
+    """'57% ▰▰▰▰▰▱▱▱' or an em dash when nothing closed yet."""
+    closed = tp + sl
+    if not closed:
+        return "—"
+    pct = tp / closed * 100
+    filled = round(pct / 12.5)
+    return f"{pct:.0f}% {'▰' * filled}{'▱' * (8 - filled)}"
+
+
+def _sparkline(signals: List[Dict], limit: int = 10) -> str:
+    """Emoji strip of the most recent closed outcomes: 🟩 tp, 🟥 sl, ⬜ expired."""
+    icons = {"tp": "🟩", "sl": "🟥", "expired": "⬜", "timeout": "⬜"}
+    closed = [s for s in signals if s["status"] in icons]
+    closed.sort(key=lambda s: s.get("resolved_at") or s["created_at"])
+    return "".join(icons[s["status"]] for s in closed[-limit:])

--- a/app/services/smc/models.py
+++ b/app/services/smc/models.py
@@ -123,3 +123,5 @@ class AnalysisResult:
     watch_notes: List[str] = field(default_factory=list)
     session_name: Optional[str] = None
     price_decimals: int = 2
+    # last fetched M5 candles (in-memory only, used for chart rendering)
+    m5_candles: Optional[List[Candle]] = field(default=None, repr=False)

--- a/app/services/smc/news.py
+++ b/app/services/smc/news.py
@@ -62,6 +62,20 @@ def parse_feed(raw: List[dict]) -> List[NewsEvent]:
     return events
 
 
+def _day_timeline(events: List[NewsEvent]) -> str:
+    """One-glance map of the trading day: 08→20 Prague, 🔴 marks news hours.
+
+    Example: 🕗 08 ······🔴 │ ·🔴···· 20  (│ = London→NY handover at 14:00)
+    """
+    hours_with_news = {to_prague(e.time).hour for e in events}
+    cells = []
+    for hour in range(8, 20):
+        if hour == 14:
+            cells.append(" │ ")
+        cells.append("🔴" if hour in hours_with_news else "·")
+    return "🕗 08 " + "".join(cells) + " 20"
+
+
 class NewsCalendar:
     """Cached red-news calendar with blackout checks."""
 
@@ -165,6 +179,7 @@ class NewsCalendar:
                 f"⚠️ Next up: {nearest.prague_hhmm()} — {escape_html(nearest.title)} "
                 f"({nearest.currency})"
             )
+        lines.append(_day_timeline(events))
         lines.append(
             f"⛔ Entry blackout: {int(self.before.total_seconds() // 60)} min "
             f"before and {int(self.after.total_seconds() // 60)} min after each."

--- a/app/services/smc/notifier.py
+++ b/app/services/smc/notifier.py
@@ -134,19 +134,84 @@ class TelegramNotifier:
         self.chat_id = chat_id
         self.base_url = f"https://api.telegram.org/bot{bot_token}"
 
-    async def send(self, text: str) -> bool:
-        payload = {"chat_id": self.chat_id, "text": text, "parse_mode": "HTML"}
+    async def _api(self, method: str, **payload) -> Optional[dict]:
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.post(f"{self.base_url}/sendMessage", json=payload)
-                if response.status_code == 200:
-                    return True
+                response = await client.post(f"{self.base_url}/{method}", json=payload)
+                data = response.json()
+                if response.status_code == 200 and data.get("ok"):
+                    return data.get("result")
                 logger.error(
-                    "Telegram send failed",
+                    "Telegram API call failed",
+                    method=method,
                     status_code=response.status_code,
-                    response=response.text,
+                    response=response.text[:300],
                 )
-                return False
-        except httpx.HTTPError as e:
-            logger.error("Telegram send error", error=str(e))
-            return False
+                return None
+        except (httpx.HTTPError, ValueError) as e:
+            logger.error("Telegram API error", method=method, error=str(e))
+            return None
+
+    async def send(
+        self, text: str, reply_markup: Optional[dict] = None
+    ) -> Optional[int]:
+        """Send a message; returns its message_id or None on failure."""
+        payload = {"chat_id": self.chat_id, "text": text, "parse_mode": "HTML"}
+        if reply_markup:
+            payload["reply_markup"] = reply_markup
+        result = await self._api("sendMessage", **payload)
+        return result.get("message_id") if result else None
+
+    async def edit_message(
+        self, message_id: int, text: str, reply_markup: Optional[dict] = None
+    ) -> bool:
+        payload = {
+            "chat_id": self.chat_id,
+            "message_id": message_id,
+            "text": text,
+            "parse_mode": "HTML",
+        }
+        if reply_markup:
+            payload["reply_markup"] = reply_markup
+        return await self._api("editMessageText", **payload) is not None
+
+    async def send_photo(
+        self,
+        photo: bytes,
+        caption: Optional[str] = None,
+        reply_to: Optional[int] = None,
+    ) -> Optional[int]:
+        """Send a PNG photo (multipart); returns message_id or None."""
+        data = {"chat_id": self.chat_id}
+        if caption:
+            data["caption"] = caption
+        if reply_to:
+            data["reply_to_message_id"] = str(reply_to)
+        try:
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                response = await client.post(
+                    f"{self.base_url}/sendPhoto",
+                    data=data,
+                    files={"photo": ("setup.png", photo, "image/png")},
+                )
+                payload = response.json()
+                if response.status_code == 200 and payload.get("ok"):
+                    return payload["result"].get("message_id")
+                logger.error("Telegram sendPhoto failed", response=response.text[:300])
+                return None
+        except (httpx.HTTPError, ValueError) as e:
+            logger.error("Telegram sendPhoto error", error=str(e))
+            return None
+
+    async def pin(self, message_id: int) -> None:
+        await self._api(
+            "pinChatMessage",
+            chat_id=self.chat_id,
+            message_id=message_id,
+            disable_notification=True,
+        )
+
+    async def unpin(self, message_id: int) -> None:
+        await self._api(
+            "unpinChatMessage", chat_id=self.chat_id, message_id=message_id
+        )

--- a/app/services/smc/state.py
+++ b/app/services/smc/state.py
@@ -22,12 +22,14 @@ class WatcherState:
         self.last_setup: Dict[str, str] = db.kv_get("last_setup") or {}
         self.last_digest_date: str = db.kv_get("last_digest_date") or ""
         self.news_warned: Dict[str, str] = db.kv_get("news_warned") or {}
+        self.day_stop_notified: str = db.kv_get("day_stop_notified") or ""
 
     def save(self) -> None:
         self.db.kv_set("pairs", self.pairs)
         self.db.kv_set("last_setup", self.last_setup)
         self.db.kv_set("last_digest_date", self.last_digest_date)
         self.db.kv_set("news_warned", self.news_warned)
+        self.db.kv_set("day_stop_notified", self.day_stop_notified)
 
     def toggle_pair(self, key: str) -> bool:
         """Toggle a pair on/off. Returns True if the pair is now enabled."""

--- a/app/services/smc/telegram_bot.py
+++ b/app/services/smc/telegram_bot.py
@@ -48,6 +48,7 @@ class TelegramCommandBot:
         status_text: Callable[[], str],
         stats_text: Optional[Callable[[], str]] = None,
         news_text: Optional[Callable[[], str]] = None,
+        on_trade_mark: Optional[Callable[[str, bool], Awaitable[str]]] = None,
     ):
         self.base_url = f"https://api.telegram.org/bot{bot_token}"
         self.owner_chat_id = str(owner_chat_id)
@@ -56,6 +57,7 @@ class TelegramCommandBot:
         self.status_text = status_text
         self.stats_text = stats_text
         self.news_text = news_text
+        self.on_trade_mark = on_trade_mark
         self._offset: Optional[int] = None
 
     # ------------------------------------------------------------- transport
@@ -85,6 +87,7 @@ class TelegramCommandBot:
         # The old FastAPI bot registered a webhook; getUpdates conflicts with
         # it, so drop it (and any stale backlog) once at startup.
         await self._api("deleteWebhook", drop_pending_updates=True)
+        await self._setup_bot_profile()
         logger.info("Telegram command bot started (long polling)")
         while True:
             try:
@@ -106,6 +109,33 @@ class TelegramCommandBot:
                     await self._handle_update(update)
                 except Exception as e:
                     logger.error("Failed to handle update", error=str(e), exc_info=True)
+
+    async def _setup_bot_profile(self) -> None:
+        """Register the slash-command menu and profile texts (best effort)."""
+        await self._api(
+            "setMyCommands",
+            commands=[
+                {"command": "pairs", "description": "Choose currency pairs"},
+                {"command": "check", "description": "Run the strategy check now"},
+                {"command": "status", "description": "Settings and last verdicts"},
+                {"command": "stats", "description": "Signal journal and winrate"},
+                {"command": "news", "description": "Today's red news (Forex Factory)"},
+                {"command": "help", "description": "What this bot does"},
+            ],
+        )
+        await self._api(
+            "setMyShortDescription",
+            short_description="SMC Triple Sync + Imbalance setup alerts",
+        )
+        await self._api(
+            "setMyDescription",
+            description=(
+                "Watches ETHUSD and forex pairs for Triple Sync + Imbalance "
+                "setups (H4 trend → H1 zone → M5 CHoCH + FVG) and sends an "
+                "urgent alert with entry/SL/TP when everything lines up. "
+                "Trading hours 08-20 Prague."
+            ),
+        )
 
     # -------------------------------------------------------------- handlers
 
@@ -157,6 +187,27 @@ class TelegramCommandBot:
     async def _handle_callback(self, callback: Dict) -> None:
         data = callback.get("data", "")
         answer: Dict[str, Any] = {"callback_query_id": callback["id"]}
+        if data.startswith(("take_", "skip_")) and self.on_trade_mark:
+            taken = data.startswith("take_")
+            signal_id = data.split("_", 1)[1]
+            answer["text"] = await self.on_trade_mark(signal_id, taken)
+            # replace the buttons with the recorded choice
+            message = callback.get("message", {})
+            if message:
+                chosen = "✅ Taken — tracked in /stats" if taken else "❌ Skipped"
+                await self._api(
+                    "editMessageReplyMarkup",
+                    chat_id=message["chat"]["id"],
+                    message_id=message["message_id"],
+                    reply_markup={
+                        "inline_keyboard": [[{"text": chosen, "callback_data": "noop"}]]
+                    },
+                )
+            await self._api("answerCallbackQuery", **answer)
+            return
+        if data == "noop":
+            await self._api("answerCallbackQuery", **answer)
+            return
         if data.startswith("pair_"):
             key = data[5:]
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,9 @@ httpx>=0.27.0,<0.28.0
 structlog>=24.1.0,<25.0.0
 pytz>=2024.1
 
+# Setup chart rendering (PNG attached to alerts)
+matplotlib>=3.8.0,<4.0.0
+
 # Testing
 pytest>=8.2.0,<9.0.0
 pytest-asyncio>=0.23.0,<0.24.0

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -97,6 +97,33 @@ def _setup_fingerprint(result: AnalysisResult) -> str:
     )
 
 
+def _card_footer(signal: Dict) -> str:
+    """Status history appended to the alert message (live setup card)."""
+
+    def hhmm(iso: Optional[str]) -> str:
+        if not iso:
+            return ""
+        local = to_prague(datetime.fromisoformat(iso))
+        return f" ({local:%H:%M} Prague)"
+
+    lines = ["", "──────────────"]
+    if signal.get("filled_at"):
+        lines.append(f"📈 Filled @ {signal['entry']}{hhmm(signal['filled_at'])}")
+    status = signal["status"]
+    when = hhmm(signal.get("resolved_at"))
+    if status == "tp":
+        lines.append(f"🎯 <b>TP HIT</b>{when} — planned +{signal['rr']:.1f}R")
+    elif status == "sl":
+        lines.append(f"🛑 <b>SL HIT</b>{when} — −1R")
+    elif status == "expired":
+        lines.append("🗑 Expired unfilled — order dies with its session (Rule 10)")
+    elif status == "timeout":
+        lines.append("⌛ Timed out — untracked after 5 days")
+    elif status == "open":
+        lines.append("⏳ Position live — tracking TP/SL")
+    return "\n".join(lines)
+
+
 def _correlation_warnings(approved: List[AnalysisResult]) -> List[str]:
     """Rule 9.2: warn about forbidden simultaneous USD combinations."""
     warnings = []
@@ -153,6 +180,7 @@ class Watcher:
             status_text=self.status_text,
             stats_text=self.journal.stats_text,
             news_text=self.news_text,
+            on_trade_mark=self.mark_trade,
         )
         self.last_results: Dict[str, AnalysisResult] = {}
         # apply the env default on the very first start (DB wins afterwards)
@@ -208,13 +236,20 @@ class Watcher:
                     heartbeat_lines.append(
                         f"⏳ {key}: previously reported setup is still active"
                     )
-                else:
-                    approved.append(result)
-                    if await self.notifier.send(format_result(result)):
-                        self.state.last_setup[key] = fingerprint
-                        self.state.save()
-                    self.journal.record(result)
-                    heartbeat_lines.append(f"🚨 {key}: SETUP FOUND — details above!")
+                    continue
+                block = self.journal.discipline_block(
+                    key,
+                    result.setup.direction.value,
+                    result.session_name,
+                    result.checked_at,
+                )
+                if block:
+                    logger.info("Alert suppressed", pair=key, rule=block)
+                    heartbeat_lines.append(f"⛔ {key}: alert suppressed — {block}")
+                    continue
+                approved.append(result)
+                await self._send_alert(key, result, fingerprint)
+                heartbeat_lines.append(f"🚨 {key}: SETUP FOUND — details above!")
             else:
                 heartbeat_lines.append(line)
 
@@ -230,6 +265,98 @@ class Watcher:
         if settings.smc.notify_no_setup and not approved:
             await self.notifier.send(summary)
         return summary
+
+    # ---------------------------------------------------------------- alerts
+
+    async def _send_alert(
+        self, key: str, result: AnalysisResult, fingerprint: str
+    ) -> None:
+        """Urgent alert: message with Took/Skipped buttons + setup chart."""
+        signal = self.journal.record(result)
+        text = format_result(result)
+        keyboard = {
+            "inline_keyboard": [
+                [
+                    {"text": "✅ Took it", "callback_data": f"take_{signal['id']}"},
+                    {"text": "❌ Skipped", "callback_data": f"skip_{signal['id']}"},
+                ]
+            ]
+        }
+        message_id = await self.notifier.send(text, reply_markup=keyboard)
+        if message_id:
+            self.state.last_setup[key] = fingerprint
+            self.state.save()
+            self.journal.attach_message(signal["id"], message_id, text)
+            await self.notifier.pin(message_id)
+            await self._send_chart(result, message_id)
+
+    async def _send_chart(self, result: AnalysisResult, reply_to: int) -> None:
+        """Attach the setup chart PNG (must never block the alert)."""
+        try:
+            from app.services.smc.chart import render_setup_chart
+
+            png = render_setup_chart(result)
+            if png:
+                await self.notifier.send_photo(png, reply_to=reply_to)
+        except Exception as e:
+            logger.warning("Chart rendering failed", pair=result.symbol, error=str(e))
+
+    async def mark_trade(self, signal_id: str, taken: bool) -> str:
+        """Callback for the Took/Skipped buttons on alerts."""
+        signal = self.journal.mark_taken(signal_id, taken)
+        if not signal:
+            return "Signal not found (journal may have been reset)"
+        if taken:
+            return f"{signal['pair']} marked as taken — tracking your stats"
+        return f"{signal['pair']} marked as skipped"
+
+    async def _handle_journal_events(self, events) -> None:
+        """Live-update alert cards and enforce the daily stop notification."""
+        now = datetime.now(tz=timezone.utc)
+        for signal, event in events:
+            if signal.get("message_id") and signal.get("alert_text"):
+                footer = _card_footer(signal)
+                keep_buttons = signal.get("taken") is None
+                keyboard = (
+                    {
+                        "inline_keyboard": [
+                            [
+                                {
+                                    "text": "✅ Took it",
+                                    "callback_data": f"take_{signal['id']}",
+                                },
+                                {
+                                    "text": "❌ Skipped",
+                                    "callback_data": f"skip_{signal['id']}",
+                                },
+                            ]
+                        ]
+                    }
+                    if keep_buttons
+                    else None
+                )
+                await self.notifier.edit_message(
+                    signal["message_id"],
+                    signal["alert_text"] + footer,
+                    reply_markup=keyboard,
+                )
+                if event in ("tp", "sl", "expired", "timeout"):
+                    await self.notifier.unpin(signal["message_id"])
+            # Rule 0.2 proxy: the second taken stop of the day closes trading
+            if (
+                event == "sl"
+                and signal.get("taken") == 1
+                and self.journal.taken_sl_count_today(now) == 2
+            ):
+                today = to_prague(now).date().isoformat()
+                if self.state.day_stop_notified != today:
+                    self.state.day_stop_notified = today
+                    self.state.save()
+                    await self.notifier.send(
+                        "🛑 <b>RULE 0.2:</b> two taken stop-losses today — "
+                        "the trading day is CLOSED. No more alerts until "
+                        "tomorrow. A skipped bad day is a win."
+                    )
 
     # ------------------------------------------------------------------ news
 
@@ -324,7 +451,9 @@ class Watcher:
             except Exception as e:
                 logger.warning("Journal update failed", pair=pair, error=str(e))
                 continue
-            self.journal.update_pair(pair, candles)
+            events = self.journal.update_pair(pair, candles)
+            if events:
+                await self._handle_journal_events(events)
 
     # ---------------------------------------------------------------- status
 

--- a/tests/test_smc/test_fvg.py
+++ b/tests/test_smc/test_fvg.py
@@ -1,6 +1,11 @@
 """Tests for FVG detection and validation (Rule 4)."""
 
-from app.services.smc.fvg import find_fvgs, measure_fill, select_valid_fvg
+from app.services.smc.fvg import (
+    best_rejected_fvg,
+    find_fvgs,
+    measure_fill,
+    select_valid_fvg,
+)
 from app.services.smc.models import Direction
 from tests.test_smc.helpers import candle, m5_long_trigger
 
@@ -71,3 +76,28 @@ class TestValidation:
         m5 = m5_long_trigger()
         m5.append(candle(3150, 3150.5, 3136.5, 3145, index=len(m5)))  # >50% fill
         assert select_valid_fvg(m5, Direction.LONG, 14, min_size=2.0) is None
+
+
+class TestRejectionDiagnostics:
+    def test_reports_undersized_candidate(self):
+        m5 = m5_long_trigger()
+        rejected = best_rejected_fvg(m5, Direction.LONG, 14, min_size=5.0)
+        assert rejected is not None
+        fvg, problems = rejected
+        assert problems == ["size"]
+        assert fvg.size == 3.5  # the largest gap of the impulse
+
+    def test_reports_fill_when_size_is_fine(self):
+        m5 = m5_long_trigger()
+        m5.append(candle(3150, 3150.5, 3136.5, 3145, index=len(m5)))  # 86% fill
+        rejected = best_rejected_fvg(m5, Direction.LONG, 14, min_size=2.0)
+        fvg, problems = rejected
+        assert "fill" in problems and "size" not in problems
+
+    def test_none_when_no_gap_exists(self):
+        flat = [
+            candle(3130, 3135, 3128, 3134, index=0),
+            candle(3134, 3138, 3132, 3137, index=1),
+            candle(3137, 3140, 3134, 3139, index=2),
+        ]
+        assert best_rejected_fvg(flat, Direction.LONG, 0, min_size=2.0) is None

--- a/tests/test_smc/test_improvements.py
+++ b/tests/test_smc/test_improvements.py
@@ -221,7 +221,7 @@ class TestJournal:
         )
         signal = journal.record(result)
         assert signal["status"] == "pending"
-        assert "Total setups: 1" in journal.stats_text()
+        assert "Signals: 1" in journal.stats_text()
 
         reloaded = SignalJournal(Database(str(tmp_path / "smc.db")))
         assert len(reloaded.signals) == 1

--- a/tests/test_smc/test_visuals.py
+++ b/tests/test_smc/test_visuals.py
@@ -1,0 +1,178 @@
+"""Tests for the visual upgrade pack: DB migration, trade marks, discipline,
+live-card events, chart rendering, pretty stats, digest timeline."""
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from app.services.smc.db import Database
+from app.services.smc.engine import TripleSyncEngine
+from app.services.smc.journal import SignalJournal
+from app.services.smc.models import AnalysisResult, Verdict
+from tests.test_smc.helpers import (
+    H1_PULLBACK_CLOSES,
+    H4_UPTREND_CLOSES,
+    candle,
+    m5_long_trigger,
+    make_candles,
+)
+
+NOW = datetime(2026, 7, 16, 14, 0, tzinfo=timezone.utc)
+
+
+def _approved_result() -> AnalysisResult:
+    result = AnalysisResult(
+        symbol="ETHUSD",
+        verdict=Verdict.SKIP,
+        checked_at=datetime(2026, 7, 6, 15, 40, tzinfo=timezone.utc),
+    )
+    result.session_name = "New York"
+    result = TripleSyncEngine(min_rr=2.0).evaluate(
+        h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+        h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+        m5=m5_long_trigger(),
+        result=result,
+    )
+    result.m5_candles = m5_long_trigger()
+    assert result.verdict == Verdict.APPROVED_LIMIT
+    return result
+
+
+class TestDbMigration:
+    def test_old_schema_gets_new_columns(self, tmp_path):
+        path = str(tmp_path / "old.db")
+        conn = sqlite3.connect(path)
+        conn.execute(
+            """CREATE TABLE signals (
+                id TEXT PRIMARY KEY, pair TEXT NOT NULL, direction TEXT NOT NULL,
+                entry REAL NOT NULL, stop_loss REAL NOT NULL,
+                take_profit REAL NOT NULL, rr REAL NOT NULL, session TEXT,
+                created_at TEXT NOT NULL, expires_at TEXT, status TEXT NOT NULL,
+                filled_at TEXT, resolved_at TEXT, checked_until TEXT)"""
+        )
+        conn.commit()
+        conn.close()
+        db = Database(path)
+        columns = {r["name"] for r in db.conn.execute("PRAGMA table_info(signals)")}
+        assert {"taken", "message_id", "alert_text"} <= columns
+
+
+class TestTradeMarksAndDiscipline:
+    @staticmethod
+    def _journal(tmp_path) -> SignalJournal:
+        return SignalJournal(Database(str(tmp_path / "j.db")))
+
+    @staticmethod
+    def _sl_signal(journal, pair="ETHUSD", direction="long", taken=1):
+        signal = {
+            "id": f"sig{len(journal.signals)}",
+            "pair": pair,
+            "direction": direction,
+            "entry": 100.0,
+            "stop_loss": 95.0,
+            "take_profit": 110.0,
+            "rr": 2.0,
+            "session": "New York",
+            "created_at": NOW.isoformat(),
+            "expires_at": None,
+            "status": "sl",
+            "filled_at": NOW.isoformat(),
+            "resolved_at": NOW.isoformat(),
+            "checked_until": None,
+            "taken": taken,
+            "message_id": None,
+            "alert_text": None,
+        }
+        journal.signals.append(signal)
+        journal.save()
+        return signal
+
+    def test_mark_taken_persists(self, tmp_path):
+        journal = self._journal(tmp_path)
+        signal = self._sl_signal(journal, taken=None)
+        journal.mark_taken(signal["id"], True)
+        reloaded = SignalJournal(journal.db)
+        assert reloaded.get(signal["id"])["taken"] == 1
+
+    def test_rule_10_reentry_ban(self, tmp_path):
+        journal = self._journal(tmp_path)
+        self._sl_signal(journal, pair="USDJPY", direction="long")
+        block = journal.discipline_block("USDJPY", "long", "New York", NOW)
+        assert block and "Rule 10" in block
+        # different direction or pair is not blocked
+        assert journal.discipline_block("USDJPY", "short", "New York", NOW) is None
+        assert journal.discipline_block("GBPUSD", "long", "New York", NOW) is None
+
+    def test_rule_02_two_stops_close_the_day(self, tmp_path):
+        journal = self._journal(tmp_path)
+        self._sl_signal(journal, pair="USDJPY")
+        self._sl_signal(journal, pair="GBPUSD")
+        block = journal.discipline_block("ETHUSD", "long", "New York", NOW)
+        assert block and "Rule 0.2" in block
+
+    def test_skipped_stops_do_not_count(self, tmp_path):
+        journal = self._journal(tmp_path)
+        self._sl_signal(journal, pair="USDJPY", taken=0)
+        self._sl_signal(journal, pair="GBPUSD", taken=None)
+        assert journal.discipline_block("ETHUSD", "long", "New York", NOW) is None
+
+
+class TestLiveCardEvents:
+    def test_update_pair_reports_fill_and_tp(self, tmp_path):
+        journal = SignalJournal(Database(str(tmp_path / "j.db")))
+        result = _approved_result()
+        signal = journal.record(result)
+        start = datetime(2026, 7, 6, 15, 45, tzinfo=timezone.utc)
+        candles = [
+            candle(3142, 3143, 3139.0, 3141, start=start, index=0),  # fills 3139.5
+            candle(3141, 3205, 3140, 3201, start=start, index=1),  # hits TP 3200
+        ]
+        events = journal.update_pair("ETHUSD", candles)
+        assert [e for _, e in events] == ["filled", "tp"]
+        assert signal["status"] == "tp"
+
+
+class TestChart:
+    def test_renders_png(self):
+        from app.services.smc.chart import render_setup_chart
+
+        png = render_setup_chart(_approved_result())
+        assert png is not None and png[:4] == b"\x89PNG"
+
+    def test_returns_none_without_candles(self):
+        from app.services.smc.chart import render_setup_chart
+
+        result = _approved_result()
+        result.m5_candles = None
+        assert render_setup_chart(result) is None
+
+
+class TestPrettyStats:
+    def test_stats_contains_bars_and_sparkline(self, tmp_path):
+        journal = SignalJournal(Database(str(tmp_path / "j.db")))
+        TestTradeMarksAndDiscipline._sl_signal(journal, pair="ETHUSD")
+        tp = TestTradeMarksAndDiscipline._sl_signal(journal, pair="USDJPY")
+        tp["status"] = "tp"
+        journal.save()
+        text = journal.stats_text()
+        assert "▰" in text and "🟥" in text and "🟩" in text
+        assert "marked taken: 2" in text
+
+
+class TestDigestTimeline:
+    def test_timeline_marks_news_hours(self):
+        from app.services.smc.news import NewsCalendar, parse_feed
+
+        cal = NewsCalendar()
+        cal.events = parse_feed(
+            [
+                {
+                    "title": "CPI m/m",
+                    "country": "USD",
+                    "date": "2026-07-16T08:30:00-04:00",  # 14:30 Prague
+                    "impact": "High",
+                }
+            ]
+        )
+        cal.fetched_at = datetime(2026, 7, 16, 5, 0, tzinfo=timezone.utc)
+        text = cal.digest_text({"USD"}, datetime(2026, 7, 16, 6, 0, tzinfo=timezone.utc))
+        assert "🕗 08 " in text and "🔴" in text and "│" in text


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Three commits:

**1. FVG rejection diagnostics (`872deec`)** — WATCH reasons now name the best rejected gap and its exact failure (`best candidate: size 3.2 pips < required 5 pips` / `70% filled (max 50%)` / `no FVG has formed yet`). Groundwork for a data-driven decision on the 5-pip threshold; no strategy rules changed.

**2. Docs (`258bf3d`)** — new `CLAUDE.md` (project map, conventions, gotchas for AI-assisted work), refreshed README.

**3. Visual upgrade pack (`8db028a`)**:
- **Slash-command menu** (`setMyCommands`) + bot profile descriptions registered at startup
- **✅ Took it / ❌ Skipped buttons** on every alert feed the journal (new `taken`/`message_id`/`alert_text` DB columns with automatic migration). `/stats` shows the owner's personal winrate separately from signal winrate. **Discipline proxies on taken trades**: Rule 10 re-entry ban (same pair+direction+session after a taken SL) and Rule 0.2 daily stop (two taken SLs → alerts suppressed + one-time "trading day is CLOSED" notice)
- **Live setup card**: the alert is pinned and edited in place as the signal evolves — `📈 Filled @ … → 🎯 TP HIT (+2.1R)` with Prague times; unpinned on resolution
- **Setup chart PNG** attached to every alert: dark TradingView-style M5 candles with the H1 zone, FVG box and ENTRY/SL/TP levels (pure matplotlib, no pandas; rendering failure never blocks the alert)
- **Pretty `/stats`**: winrate bars `57% ▰▰▰▰▰▱▱▱`, last-outcomes sparkline `🟩🟥🟩`
- **Morning digest timeline**: `🕗 08 ····🔴· │ ·🔴···· 20` — the trading day at a glance

### How was this tested?
- [x] Unit tests — **93 pass** (old-schema DB migration, mark-taken persistence, Rule 10/0.2 blocking incl. skipped-trades-don't-count, fill→tp event stream, PNG magic bytes, stats markers, timeline rendering)
- [x] Live `--once` smoke on real market data; flake8 clean

### Breaking Changes
None. New dependency: matplotlib (chart rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)