### PR TITLE
Redesign news digest: session blocks with exact no-entry windows

### DIFF
--- a/app/services/smc/news.py
+++ b/app/services/smc/news.py
@@ -15,7 +15,7 @@ from typing import List, Optional, Set
 import httpx
 import structlog
 
-from app.services.smc.instruments import Instrument
+from app.services.smc.instruments import Instrument, get_instrument
 from app.services.smc.sessions import to_prague
 
 logger = structlog.get_logger(__name__)
@@ -60,20 +60,6 @@ def parse_feed(raw: List[dict]) -> List[NewsEvent]:
         )
     events.sort(key=lambda e: e.time)
     return events
-
-
-def _day_timeline(events: List[NewsEvent]) -> str:
-    """One-glance map of the trading day: 08→20 Prague, 🔴 marks news hours.
-
-    Example: 🕗 08 ······🔴 │ ·🔴···· 20  (│ = London→NY handover at 14:00)
-    """
-    hours_with_news = {to_prague(e.time).hour for e in events}
-    cells = []
-    for hour in range(8, 20):
-        if hour == 14:
-            cells.append(" │ ")
-        cells.append("🔴" if hour in hours_with_news else "·")
-    return "🕗 08 " + "".join(cells) + " 20"
 
 
 class NewsCalendar:
@@ -151,9 +137,15 @@ class NewsCalendar:
         ]
 
     def digest_text(
-        self, currencies: Set[str], now: Optional[datetime] = None
+        self, pairs: List[str], now: Optional[datetime] = None
     ) -> str:
-        """Morning digest (strategy Rule -1)."""
+        """Morning digest (strategy Rule -1), grouped by session block.
+
+        For every red event: Prague time, title, the watched pairs it hits
+        and the exact no-entry window — no abstract rulers to decode.
+        """
+        from app.services.smc.notifier import escape_html
+
         now = now or datetime.now(tz=timezone.utc)
         date_str = to_prague(now).strftime("%d.%m.%Y")
         header = f"📅 <b>Forex Factory — {date_str}</b> (Prague time)"
@@ -161,27 +153,57 @@ class NewsCalendar:
             return header + "\n⚠️ Calendar not loaded yet" + (
                 f" ({self.fetch_error})" if self.fetch_error else ""
             )
+
+        by_pair = {p: relevant_currencies(get_instrument(p)) for p in pairs}
+        currencies: Set[str] = set().union(*by_pair.values()) if by_pair else set()
         events = self.todays_events(currencies, now)
         if not events:
             return (
                 header
-                + f"\n✅ No red news for your currencies "
-                f"({', '.join(sorted(currencies))}) today."
+                + f"\n✅ No red news for your pairs "
+                f"({', '.join(pairs) if pairs else '—'}) today. Clean hunting."
             )
-        from app.services.smc.notifier import escape_html
 
-        lines = [header, "🔴 Red news today:"]
-        for e in events:
-            lines.append(f"• {e.prague_hhmm()} — {escape_html(e.title)} ({e.currency})")
-        nearest = next((e for e in events if e.time > now), None)
-        if nearest:
-            lines.append(
-                f"⚠️ Next up: {nearest.prague_hhmm()} — {escape_html(nearest.title)} "
-                f"({nearest.currency})"
-            )
-        lines.append(_day_timeline(events))
+        def block_of(event: NewsEvent) -> str:
+            hour = to_prague(event.time).hour
+            if 8 <= hour < 14:
+                return "london"
+            if 14 <= hour < 20:
+                return "ny"
+            return "off"
+
+        def event_lines(event: NewsEvent) -> List[str]:
+            hits = ", ".join(p for p, cur in by_pair.items() if event.currency in cur)
+            start = to_prague(event.time - self.before).strftime("%H:%M")
+            end = to_prague(event.time + self.after).strftime("%H:%M")
+            return [
+                f"🔴 {event.prague_hhmm()} {escape_html(event.title)} "
+                f"({event.currency}) → {hits or '—'}",
+                f"    ⛔ no entries {start}–{end}",
+            ]
+
+        lines = [header, ""]
+        for title, key in (
+            ("🌅 <b>London 08–14</b>", "london"),
+            ("🌇 <b>New York 14–20</b>", "ny"),
+        ):
+            lines.append(title)
+            block_events = [e for e in events if block_of(e) == key]
+            if block_events:
+                for event in block_events:
+                    lines.extend(event_lines(event))
+            else:
+                lines.append("✅ clear")
+        off_hours = [e for e in events if block_of(e) == "off"]
+        if off_hours:
+            lines.append("🌙 <b>Outside trading hours</b>")
+            for event in off_hours:
+                lines.extend(event_lines(event))
+
+        lines.append("")
         lines.append(
-            f"⛔ Entry blackout: {int(self.before.total_seconds() // 60)} min "
-            f"before and {int(self.after.total_seconds() // 60)} min after each."
+            f"⛔ Blackout rule: {int(self.before.total_seconds() // 60)} min "
+            f"before / {int(self.after.total_seconds() // 60)} min after "
+            "each release."
         )
         return "\n".join(lines)

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -391,10 +391,7 @@ class Watcher:
             digest_after = local.replace(hour=7, minute=45, second=0, microsecond=0)
         if self.state.last_digest_date == today or local < digest_after:
             return
-        currencies = set()
-        for key in self.state.pairs:
-            currencies |= relevant_currencies(get_instrument(key))
-        await self.notifier.send(self.news.digest_text(currencies))
+        await self.notifier.send(self.news.digest_text(self.state.pairs))
         self.state.last_digest_date = today
         self.state.save()
 
@@ -437,10 +434,7 @@ class Watcher:
         """/news command."""
         if not self.news:
             return "News filter is disabled (SMC_NEWS_ENABLED=false)."
-        currencies = set()
-        for key in self.state.pairs:
-            currencies |= relevant_currencies(get_instrument(key))
-        return self.news.digest_text(currencies)
+        return self.news.digest_text(self.state.pairs)
 
     async def _track_journal(self) -> None:
         """Advance unresolved journal signals using fresh M5 candles."""

--- a/tests/test_smc/test_html_escaping.py
+++ b/tests/test_smc/test_html_escaping.py
@@ -65,6 +65,8 @@ class TestEscaping:
             ]
         )
         cal.fetched_at = datetime(2026, 7, 16, 5, 0, tzinfo=timezone.utc)
-        text = cal.digest_text({"USD"})
+        text = cal.digest_text(
+            ["ETHUSD"], datetime(2026, 7, 16, 6, 0, tzinfo=timezone.utc)
+        )
         _assert_valid_telegram_html(text)
         assert "S&amp;P" in text

--- a/tests/test_smc/test_news.py
+++ b/tests/test_smc/test_news.py
@@ -91,15 +91,31 @@ class TestUpcomingAndDigest:
         soon = cal.upcoming({"USD", "GBP"}, timedelta(minutes=30), now)
         assert [e.title for e in soon] == ["CPI m/m"]
 
-    def test_digest_lists_todays_events_in_prague_time(self):
+    def test_digest_groups_by_session_block(self):
         cal = _calendar()
         now = datetime(2026, 7, 15, 5, 30, tzinfo=timezone.utc)
-        text = cal.digest_text({"USD", "GBP", "JPY"}, now)
-        assert "CPI m/m" in text and "14:30" in text  # 12:30 UTC = 14:30 Prague
-        assert "BOE Gov Speaks" in text and "22:00" in text
-        assert "blackout" in text.lower()
+        text = cal.digest_text(["GBPUSD", "USDJPY", "ETHUSD"], now)
+        # CPI 12:30 UTC = 14:30 Prague -> New York block, hits all USD pairs
+        assert "New York 14–20" in text
+        assert "🔴 14:30 CPI m/m (USD)" in text
+        assert "GBPUSD" in text and "USDJPY" in text and "ETHUSD" in text
+        # exact no-entry window: 60 min before, 15 after
+        assert "⛔ no entries 13:30–14:45" in text
+        # London block has nothing that day
+        assert "London 08–14" in text and "✅ clear" in text
+        # BOE speech 20:00 UTC = 22:00 Prague -> outside trading hours
+        assert "Outside trading hours" in text and "22:00 BOE Gov Speaks" in text
+        assert "Blackout rule" in text
+
+    def test_digest_hits_only_affected_pairs(self):
+        cal = _calendar()
+        now = datetime(2026, 7, 15, 5, 30, tzinfo=timezone.utc)
+        text = cal.digest_text(["USDJPY"], now)
+        # GBP-only event is not in USDJPY's currencies -> not listed at all
+        assert "BOE Gov Speaks" not in text
+        assert "CPI m/m" in text  # USD hits USDJPY
 
     def test_digest_when_quiet_day(self):
         cal = _calendar()
         now = datetime(2026, 7, 16, 5, 30, tzinfo=timezone.utc)  # next day
-        assert "No red news" in cal.digest_text({"USD"}, now)
+        assert "No red news" in cal.digest_text(["ETHUSD"], now)

--- a/tests/test_smc/test_visuals.py
+++ b/tests/test_smc/test_visuals.py
@@ -158,8 +158,8 @@ class TestPrettyStats:
         assert "marked taken: 2" in text
 
 
-class TestDigestTimeline:
-    def test_timeline_marks_news_hours(self):
+class TestDigestBlocks:
+    def test_digest_shows_session_block_and_no_entry_window(self):
         from app.services.smc.news import NewsCalendar, parse_feed
 
         cal = NewsCalendar()
@@ -174,5 +174,9 @@ class TestDigestTimeline:
             ]
         )
         cal.fetched_at = datetime(2026, 7, 16, 5, 0, tzinfo=timezone.utc)
-        text = cal.digest_text({"USD"}, datetime(2026, 7, 16, 6, 0, tzinfo=timezone.utc))
-        assert "🕗 08 " in text and "🔴" in text and "│" in text
+        text = cal.digest_text(
+            ["ETHUSD"], datetime(2026, 7, 16, 6, 0, tzinfo=timezone.utc)
+        )
+        assert "New York 14–20" in text
+        assert "🔴 14:30 CPI m/m (USD) → ETHUSD" in text
+        assert "⛔ no entries 13:30–14:45" in text


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
The dot-ruler timeline (`🕗 08 🔴····· │ ······ 20`) was cryptic — the owner asked for something readable. The digest now groups red news by session block and states, for every event, **which watched pairs it hits** and the **exact blackout interval**:

```
📅 Forex Factory — 16.07.2026 (Prague time)

🌅 London 08–14
🔴 08:00 GDP m/m (GBP) → GBPUSD
    ⛔ no entries 07:00–08:15
🌇 New York 14–20
🔴 14:30 Unemployment Claims (USD) → ETHUSD, USDJPY, GBPUSD
    ⛔ no entries 13:30–14:45

⛔ Blackout rule: 60 min before / 15 min after each release.
```

`digest_text()` now takes the watched pairs (not a currency set) so it can name affected pairs; events outside 08–20 land in an «Outside trading hours» block; a clean day reads `✅ clear` per block. Events irrelevant to the watched pairs are not listed at all.

### How was this tested?
- [x] Unit tests — **94 pass** (block grouping, exact no-entry window, affected-pairs filtering, quiet day, HTML escaping of titles)
- [x] Manual render preview of a two-event day; flake8 clean

### Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)