### PR TITLE
Skip the morning news digest on weekends

### DIFF
--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -381,6 +381,8 @@ class Watcher:
         if not settings.smc.news_digest or self.news.fetched_at is None:
             return
         local = to_prague(datetime.now(tz=timezone.utc))
+        if local.weekday() >= 5:
+            return  # Forex Factory has no weekend releases — nothing to digest
         today = local.date().isoformat()
         try:
             hh, mm = settings.smc.news_digest_time.split(":")

--- a/tests/test_smc/test_multipair.py
+++ b/tests/test_smc/test_multipair.py
@@ -1,6 +1,7 @@
 """Tests for instruments registry, OANDA parsing, state and correlation guard."""
 
 import json
+from datetime import datetime, timezone
 
 from app.services.smc.instruments import DEFAULT_PAIRS, INSTRUMENTS, get_instrument
 from app.services.smc.oanda import _parse_time
@@ -171,3 +172,74 @@ class TestCorrelationGuard:
             [self._approved("ETHUSD", "long"), self._approved("USDJPY", "long")]
         )
         assert warnings == []
+
+
+class TestMorningDigestSkipsWeekends:
+    """Forex Factory has no Saturday/Sunday releases — the 07:45 digest must
+    stay silent then instead of sending an empty 'no red news' message."""
+
+    class _FakeState:
+        def __init__(self):
+            self.last_digest_date = ""
+            self.pairs = ["ETHUSD", "USDJPY"]
+
+        def save(self):
+            pass
+
+    class _FakeNotifier:
+        def __init__(self):
+            self.sent = []
+
+        async def send(self, text, **kwargs):
+            self.sent.append(text)
+            return 1
+
+    def _watcher_stub(self):
+        from smc_watcher import Watcher
+        from app.services.smc.news import NewsCalendar
+
+        stub = Watcher.__new__(Watcher)
+        stub.state = self._FakeState()
+        stub.notifier = self._FakeNotifier()
+        stub.news = NewsCalendar()
+        stub.news.fetched_at = datetime(2026, 7, 16, 5, 0, tzinfo=timezone.utc)
+        return stub
+
+    def _freeze(self, monkeypatch, when):
+        import smc_watcher as sw
+
+        class _Frozen(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return when
+
+        monkeypatch.setattr(sw, "datetime", _Frozen)
+
+    def test_no_digest_on_saturday(self, monkeypatch):
+        import asyncio
+
+        # 2026-07-18 07:00 UTC = Saturday 09:00 Prague — well past digest_after
+        self._freeze(monkeypatch, datetime(2026, 7, 18, 7, 0, tzinfo=timezone.utc))
+        stub = self._watcher_stub()
+        asyncio.run(stub._send_morning_digest())
+        assert stub.notifier.sent == []
+        assert stub.state.last_digest_date == ""
+
+    def test_no_digest_on_sunday(self, monkeypatch):
+        import asyncio
+
+        # 2026-07-19 07:00 UTC = Sunday 09:00 Prague
+        self._freeze(monkeypatch, datetime(2026, 7, 19, 7, 0, tzinfo=timezone.utc))
+        stub = self._watcher_stub()
+        asyncio.run(stub._send_morning_digest())
+        assert stub.notifier.sent == []
+
+    def test_digest_still_sent_on_weekday(self, monkeypatch):
+        import asyncio
+
+        # 2026-07-16 07:00 UTC = Thursday 09:00 Prague
+        self._freeze(monkeypatch, datetime(2026, 7, 16, 7, 0, tzinfo=timezone.utc))
+        stub = self._watcher_stub()
+        asyncio.run(stub._send_morning_digest())
+        assert len(stub.notifier.sent) == 1
+        assert stub.state.last_digest_date == "2026-07-16"


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Adds a Prague-weekday guard to `Watcher._send_morning_digest` so the 07:45 Forex Factory news digest no longer fires on Saturday and Sunday.

### Why is this change needed?
Forex Factory publishes no high-impact economic releases on weekends, so the digest was sending an empty "✅ No red news for your pairs... Clean hunting" message every Saturday and Sunday — pure noise with no signal, since there was never going to be news to report on those days.

### How was this tested?
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Performance testing (if applicable)

Added `TestMorningDigestSkipsWeekends` in `tests/test_smc/test_multipair.py`: freezes `smc_watcher.datetime.now()` to a Saturday, a Sunday, and a Thursday, and asserts the digest stays silent on the weekend days but still sends (and records `last_digest_date`) on the weekday.

Full suite: `pytest tests/ -v` — 98 passed. `flake8 app/ tests/ smc_watcher.py` — clean.

### Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of the code has been performed
- [x] Tests pass locally
- [x] New and existing unit tests pass locally

### Breaking Changes
- [ ] This PR contains breaking changes

### Additional Notes
Found while auditing the codebase for bugs/improvements at the owner's request. Other findings from that audit (cross-cycle correlation warnings missing USDCAD, forex stale-guard measuring candle open instead of close time, pending-order fill-after-expiry, unescaped exception text in heartbeat lines, alert/journal write-order race) are tracked separately and not part of this PR.