### PR TITLE
Add Twelve Data as the recommended forex source (free, Railway-friendly)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,11 @@ app/services/smc/
 ├── sessions.py           trading hours 08:00-20:00 Prague, two blocks split
 │                         at 14:00 (London/NY FVG separation), forex Mon-Fri
 ├── instruments.py        per-pair registry: source, min FVG, SL buffer, pip
-├── data.py / yahoo.py / oanda.py   candle fetchers (same interface):
-│                         crypto=Binance; forex=Yahoo keyless by default,
-│                         OANDA v20 when OANDA_API_TOKEN is set
+├── data.py / twelvedata.py / yahoo.py / oanda.py   candle fetchers (same
+│                         interface): crypto=Binance always; forex source per
+│                         SMC_FOREX_SOURCE (auto = TwelveData key > OANDA token
+│                         > keyless Yahoo). Twelve Data caches H4/H1 to stay
+│                         under the free 800 req/day (see _TF_CACHE_TTL)
 ├── news.py               Forex Factory red-news calendar, blackout windows,
 │                         digest day-timeline
 ├── journal.py            signal lifecycle pending→open→tp/sl/expired with

--- a/README.md
+++ b/README.md
@@ -27,14 +27,18 @@ setup appears.
 | Pair | Data source | Min FVG | Notes |
 |---|---|---|---|
 | ETHUSD | Binance (no key needed) | $2.00 | 24/7, funding-rate advisory |
-| USDJPY | Yahoo Finance (free) / OANDA | 5 pips | no key needed by default |
-| EURUSD | Yahoo Finance (free) / OANDA | 5 pips | no key needed by default |
-| GBPUSD | Yahoo Finance (free) / OANDA | 5 pips | no key needed by default |
-| USDCAD | Yahoo Finance (free) / OANDA | 5 pips | no key needed by default |
+| USDJPY | Twelve Data / OANDA / Yahoo | 5 pips | free tier, no key needed by default |
+| EURUSD | Twelve Data / OANDA / Yahoo | 5 pips | free tier, no key needed by default |
+| GBPUSD | Twelve Data / OANDA / Yahoo | 5 pips | free tier, no key needed by default |
+| USDCAD | Twelve Data / OANDA / Yahoo | 5 pips | free tier, no key needed by default |
 
-Forex candles come from the keyless Yahoo Finance feed by default (5m/1h
-native, H4 resampled from 1h). If `OANDA_API_TOKEN` is set, OANDA v20 is used
-instead — slightly better data, same functionality.
+**Forex data source** (`SMC_FOREX_SOURCE`, default `auto`) resolves in this
+order: **Twelve Data** if `TWELVEDATA_API_KEY` is set → **OANDA** if
+`OANDA_API_TOKEN` is set → **Yahoo Finance** (keyless, always available).
+ETHUSD always uses Binance. Twelve Data is recommended: free 800 req/day,
+native 4h/1h/5min candles, runs on Railway; the higher timeframes are cached
+so 2–3 forex pairs stay comfortably within the free budget (~200 req/day/pair).
+Grab a free key at [twelvedata.com](https://twelvedata.com).
 
 Default watched pairs: **ETHUSD + USDJPY** (change with `/pairs` or `SMC_PAIRS`).
 
@@ -165,7 +169,8 @@ app/services/smc/
 ├── sessions.py             # 08-20 Prague trading hours, London/NY blocks
 ├── instruments.py          # per-pair parameters & data source registry
 ├── data.py                 # Binance fetcher (ETHUSD)
-├── yahoo.py                # Yahoo Finance fetcher (forex default, no key)
+├── twelvedata.py           # Twelve Data fetcher (forex, cached, free tier)
+├── yahoo.py                # Yahoo Finance fetcher (forex fallback, no key)
 ├── oanda.py                # OANDA v20 fetcher (forex, optional)
 ├── news.py                 # Forex Factory calendar, blackouts, day timeline
 ├── journal.py              # signal lifecycle, taken marks, discipline, /stats

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -28,6 +28,14 @@ class OandaSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="OANDA_")
 
 
+class TwelveDataSettings(BaseSettings):
+    """Twelve Data API configuration (forex + crypto market data)."""
+
+    api_key: Optional[str] = Field(default=None, description="Twelve Data API key")
+
+    model_config = SettingsConfigDict(env_prefix="TWELVEDATA_")
+
+
 class SMCSettings(BaseSettings):
     """Triple Sync + Imbalance strategy watcher configuration."""
 
@@ -49,6 +57,12 @@ class SMCSettings(BaseSettings):
     )
     enforce_sessions: bool = Field(
         default=True, description="Only look for entries inside session windows"
+    )
+    forex_source: str = Field(
+        default="auto",
+        description="Forex data source: auto | twelvedata | oanda | yahoo. "
+        "auto = Twelve Data if its key is set, else OANDA if its token is set, "
+        "else keyless Yahoo",
     )
     notify_no_setup: bool = Field(
         default=False,
@@ -106,6 +120,7 @@ class Settings(BaseSettings):
 
     telegram: TelegramSettings = Field(default_factory=TelegramSettings)
     oanda: OandaSettings = Field(default_factory=OandaSettings)
+    twelvedata: TwelveDataSettings = Field(default_factory=TwelveDataSettings)
     smc: SMCSettings = Field(default_factory=SMCSettings)
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
 

--- a/app/services/smc/twelvedata.py
+++ b/app/services/smc/twelvedata.py
@@ -1,0 +1,152 @@
+"""Twelve Data REST fetcher — free-tier alternative for forex/crypto candles.
+
+Runs anywhere (plain REST + API key, no desktop terminal), so it works on
+Railway unlike MetaTrader. The free tier allows 800 API credits/day, so the
+higher timeframes — which change slowly — are cached and only M5 is refetched
+every cycle. With 2-3 forex pairs this keeps the daily budget well under 800
+(≈200 credits/day per pair). Native 4h/1h/5min intervals — no resampling.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Tuple
+
+import httpx
+import structlog
+
+from app.core.exceptions import DataFetchError
+from app.services.smc.models import Candle
+
+logger = structlog.get_logger(__name__)
+
+BASE_URL = "https://api.twelvedata.com/time_series"
+
+# our interval -> Twelve Data interval string
+_INTERVAL = {"4h": "4h", "1h": "1h", "5m": "5min"}
+_CANDLE_MINUTES = {"4h": 240, "1h": 60, "5m": 5}
+
+# how long a fetched series stays fresh; higher TFs change slowly so caching
+# them keeps the daily request budget comfortably under the free-tier limit
+_TF_CACHE_TTL = {
+    "4h": timedelta(hours=1),
+    "1h": timedelta(minutes=15),
+    "5m": timedelta(seconds=60),
+}
+
+
+class _TimeframeCache:
+    """Process-wide cache keyed by (symbol, interval) — fetchers are rebuilt
+    every cycle, so the cache must outlive them."""
+
+    def __init__(self) -> None:
+        self._store: Dict[Tuple[str, str], Tuple[datetime, List[Candle]]] = {}
+
+    def get(self, key: Tuple[str, str], ttl: timedelta) -> Optional[List[Candle]]:
+        hit = self._store.get(key)
+        if hit and datetime.now(tz=timezone.utc) - hit[0] < ttl:
+            return hit[1]
+        return None
+
+    def put(self, key: Tuple[str, str], candles: List[Candle]) -> None:
+        self._store[key] = (datetime.now(tz=timezone.utc), candles)
+
+    def clear(self) -> None:
+        self._store.clear()
+
+
+_CACHE = _TimeframeCache()
+
+
+def td_symbol(pair_key: str) -> str:
+    """ETHUSD -> ETH/USD, USDJPY -> USD/JPY."""
+    return f"{pair_key[:3]}/{pair_key[3:]}"
+
+
+def parse_time_series(payload: dict, interval: str) -> List[Candle]:
+    """Parse a Twelve Data time_series response into closed UTC candles."""
+    if payload.get("status") == "error" or "code" in payload:
+        raise DataFetchError(
+            f"Twelve Data error: {payload.get('message', 'unknown')}"
+        )
+    values = payload.get("values")
+    if not values:
+        raise DataFetchError("Twelve Data returned no values")
+
+    candles: List[Candle] = []
+    for row in values:
+        try:
+            ts = datetime.fromisoformat(row["datetime"])
+        except (KeyError, ValueError):
+            continue
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        candles.append(
+            Candle(
+                timestamp=ts.astimezone(timezone.utc),
+                open=float(row["open"]),
+                high=float(row["high"]),
+                low=float(row["low"]),
+                close=float(row["close"]),
+                volume=float(row.get("volume") or 0),
+            )
+        )
+    candles.sort(key=lambda c: c.timestamp)  # Twelve Data returns newest-first
+
+    # Drop the still-forming candle
+    minutes = _CANDLE_MINUTES.get(interval, 5)
+    now = datetime.now(tz=timezone.utc)
+    if candles and candles[-1].timestamp + timedelta(minutes=minutes) > now:
+        candles = candles[:-1]
+    return candles
+
+
+class TwelveDataFetcher:
+    """Fetches candles from Twelve Data with higher-timeframe caching."""
+
+    def __init__(self, pair_key: str, api_key: str, timeout: float = 15.0):
+        self.symbol = td_symbol(pair_key)
+        self.api_key = api_key
+        self.timeout = timeout
+
+    async def fetch_candles(self, interval: str, limit: int = 400) -> List[Candle]:
+        td_interval = _INTERVAL.get(interval)
+        if not td_interval:
+            raise DataFetchError(f"Unsupported Twelve Data interval: {interval}")
+
+        cache_key = (self.symbol, interval)
+        cached = _CACHE.get(cache_key, _TF_CACHE_TTL[interval])
+        if cached is not None:
+            return cached
+
+        params = {
+            "symbol": self.symbol,
+            "interval": td_interval,
+            "outputsize": limit,
+            "timezone": "UTC",
+            "apikey": self.api_key,
+        }
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(BASE_URL, params=params)
+                response.raise_for_status()
+                payload = response.json()
+        except (httpx.HTTPError, ValueError) as e:
+            raise DataFetchError(f"Twelve Data request failed for {self.symbol}: {e}")
+
+        candles = parse_time_series(payload, interval)
+        if len(candles) < 2:
+            raise DataFetchError(
+                f"Twelve Data returned too few candles for {self.symbol}"
+            )
+        _CACHE.put(cache_key, candles)
+        return candles
+
+    async def fetch_all_timeframes(self) -> Dict[str, List[Candle]]:
+        return {
+            "h4": await self.fetch_candles("4h", limit=300),
+            "h1": await self.fetch_candles("1h", limit=400),
+            "m5": await self.fetch_candles("5m", limit=400),
+        }
+
+    async def fetch_funding_rate(self) -> Optional[float]:
+        """Forex has no funding rate."""
+        return None

--- a/env.example
+++ b/env.example
@@ -3,9 +3,15 @@ TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 TELEGRAM_CHAT_ID=your_telegram_chat_id_here
 
 # --- Forex data source ---
-# By default forex pairs (USDJPY, EURUSD, GBPUSD, USDCAD) use the free Yahoo
-# Finance feed — no key needed. Set an OANDA v20 token to use OANDA instead
-# (slightly better data): OANDA account -> Manage API Access.
+# Priority (SMC_FOREX_SOURCE=auto): Twelve Data key -> OANDA token -> Yahoo.
+# ETHUSD always uses Binance regardless.
+SMC_FOREX_SOURCE=auto             # auto | twelvedata | oanda | yahoo
+
+# Twelve Data — free tier 800 req/day, forex+crypto, works on Railway.
+# Get a key at twelvedata.com (free signup). Recommended forex source.
+# TWELVEDATA_API_KEY=
+
+# OANDA v20 (optional alternative): OANDA account -> Manage API Access.
 # OANDA_API_TOKEN=
 # OANDA_ENVIRONMENT=practice      # practice | live
 

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -41,6 +41,7 @@ from app.services.smc.notifier import (
     format_result,
 )
 from app.services.smc.oanda import OandaDataFetcher
+from app.services.smc.twelvedata import TwelveDataFetcher
 from app.services.smc.yahoo import YahooDataFetcher
 from app.services.smc.sessions import active_session, to_prague
 from app.services.smc.state import WatcherState
@@ -61,17 +62,32 @@ JOURNAL_FILE = os.getenv("SMC_JOURNAL_FILE", ".smc_journal.json")
 APPROVED = (Verdict.APPROVED_LIMIT, Verdict.APPROVED_MARKET)
 
 
+def _forex_source() -> str:
+    """Resolve the configured forex source, honouring 'auto'."""
+    source = settings.smc.forex_source.strip().lower()
+    if source != "auto":
+        return source
+    if settings.twelvedata.api_key:
+        return "twelvedata"
+    if settings.oanda.api_token:
+        return "oanda"
+    return "yahoo"
+
+
 def _build_fetcher(instrument: Instrument):
     if instrument.source == "crypto":
+        # ETHUSD stays on Binance: unlimited, deep history, funding rate.
         return BinanceDataFetcher(instrument.source_symbol)
-    # Forex: OANDA when a token is configured (better data), otherwise the
-    # free keyless Yahoo Finance feed.
-    if settings.oanda.api_token:
+    source = _forex_source()
+    if source == "twelvedata" and settings.twelvedata.api_key:
+        return TwelveDataFetcher(instrument.key, settings.twelvedata.api_key)
+    if source == "oanda" and settings.oanda.api_token:
         return OandaDataFetcher(
             symbol=instrument.source_symbol,
             api_token=settings.oanda.api_token,
             environment=settings.oanda.environment,
         )
+    # Default / fallback: free keyless Yahoo Finance feed.
     return YahooDataFetcher(symbol=f"{instrument.key}=X")
 
 
@@ -458,6 +474,7 @@ class Watcher:
         lines = [
             "<b>SMC Watcher — status</b>",
             f"Pairs: {', '.join(self.state.pairs) or 'none'}",
+            f"Forex data: {_forex_source()} | crypto: Binance",
             f"Session now: {session or 'off session'}",
             f"Cadence: {settings.smc.session_interval_minutes} min in session / "
             f"{settings.smc.interval_minutes} min off",

--- a/tests/test_smc/test_twelvedata.py
+++ b/tests/test_smc/test_twelvedata.py
@@ -1,0 +1,138 @@
+"""Tests for the Twelve Data fetcher: parsing, symbol mapping, source pick."""
+
+import pytest
+
+from app.core.exceptions import DataFetchError
+from app.services.smc import twelvedata as td
+from app.services.smc.twelvedata import parse_time_series, td_symbol
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    td._CACHE.clear()
+    yield
+    td._CACHE.clear()
+
+
+def _payload(rows):
+    return {"status": "ok", "values": rows}
+
+
+def _row(dt, o=1.10, h=1.11, low=1.09, c=1.105):
+    return {"datetime": dt, "open": o, "high": h, "low": low, "close": c, "volume": "0"}
+
+
+class TestSymbolMapping:
+    def test_forex_and_crypto(self):
+        assert td_symbol("USDJPY") == "USD/JPY"
+        assert td_symbol("GBPUSD") == "GBP/USD"
+        assert td_symbol("ETHUSD") == "ETH/USD"
+
+
+class TestParsing:
+    def test_orders_oldest_first(self):
+        # Twelve Data returns newest-first; parser must sort ascending
+        rows = [_row("2000-01-01 12:00:00"), _row("2000-01-01 11:00:00")]
+        candles = parse_time_series(_payload(rows), "1h")
+        assert candles[0].timestamp < candles[1].timestamp
+
+    def test_error_payload_raises(self):
+        with pytest.raises(DataFetchError):
+            parse_time_series(
+                {"status": "error", "code": 429, "message": "run out of credits"},
+                "5m",
+            )
+
+    def test_empty_values_raises(self):
+        with pytest.raises(DataFetchError):
+            parse_time_series({"status": "ok", "values": []}, "5m")
+
+    def test_drops_in_progress_candle(self):
+        from datetime import datetime, timedelta, timezone
+
+        now = datetime.now(tz=timezone.utc)
+        closed = (now - timedelta(hours=2)).strftime("%Y-%m-%d %H:00:00")
+        forming = now.strftime("%Y-%m-%d %H:00:00")
+        candles = parse_time_series(_payload([_row(forming), _row(closed)]), "1h")
+        # the just-started hour candle is dropped, the older one stays
+        assert len(candles) == 1
+
+
+class TestSourceSelection:
+    def test_auto_prefers_twelvedata_when_key_set(self, monkeypatch):
+        from app.core.config import settings
+        from app.services.smc.instruments import get_instrument
+        from smc_watcher import _build_fetcher
+        from app.services.smc.twelvedata import TwelveDataFetcher
+
+        monkeypatch.setattr(settings.smc, "forex_source", "auto")
+        monkeypatch.setattr(settings.twelvedata, "api_key", "KEY")
+        fetcher = _build_fetcher(get_instrument("USDJPY"))
+        assert isinstance(fetcher, TwelveDataFetcher)
+        assert fetcher.symbol == "USD/JPY"
+
+    def test_auto_falls_back_to_yahoo_without_keys(self, monkeypatch):
+        from app.core.config import settings
+        from app.services.smc.instruments import get_instrument
+        from smc_watcher import _build_fetcher
+        from app.services.smc.yahoo import YahooDataFetcher
+
+        monkeypatch.setattr(settings.smc, "forex_source", "auto")
+        monkeypatch.setattr(settings.twelvedata, "api_key", None)
+        monkeypatch.setattr(settings.oanda, "api_token", None)
+        assert isinstance(
+            _build_fetcher(get_instrument("GBPUSD")), YahooDataFetcher
+        )
+
+    def test_explicit_override_forces_yahoo(self, monkeypatch):
+        from app.core.config import settings
+        from app.services.smc.instruments import get_instrument
+        from smc_watcher import _build_fetcher
+        from app.services.smc.yahoo import YahooDataFetcher
+
+        monkeypatch.setattr(settings.smc, "forex_source", "yahoo")
+        monkeypatch.setattr(settings.twelvedata, "api_key", "KEY")
+        assert isinstance(
+            _build_fetcher(get_instrument("USDJPY")), YahooDataFetcher
+        )
+
+    def test_crypto_always_binance(self, monkeypatch):
+        from app.core.config import settings
+        from app.services.smc.instruments import get_instrument
+        from smc_watcher import _build_fetcher
+        from app.services.smc.data import BinanceDataFetcher
+
+        monkeypatch.setattr(settings.twelvedata, "api_key", "KEY")
+        assert isinstance(
+            _build_fetcher(get_instrument("ETHUSD")), BinanceDataFetcher
+        )
+
+
+class TestCache:
+    @pytest.mark.asyncio
+    async def test_second_call_hits_cache(self, monkeypatch):
+        from app.services.smc.twelvedata import TwelveDataFetcher
+
+        calls = {"n": 0}
+
+        async def fake_fetch(self, interval, limit=400):
+            # bypass HTTP: emulate the cache logic around a counted "network" hit
+            from app.services.smc.twelvedata import _CACHE, _TF_CACHE_TTL
+
+            key = (self.symbol, interval)
+            cached = _CACHE.get(key, _TF_CACHE_TTL[interval])
+            if cached is not None:
+                return cached
+            calls["n"] += 1
+            candles = parse_time_series(
+                _payload([_row("2000-01-01 10:00:00"), _row("2000-01-01 11:00:00")]),
+                interval,
+            )
+            _CACHE.put(key, candles)
+            return candles
+
+        monkeypatch.setattr(TwelveDataFetcher, "fetch_candles", fake_fetch)
+        f = TwelveDataFetcher("USDJPY", "KEY")
+        await f.fetch_candles("4h")
+        await f.fetch_candles("4h")
+        assert calls["n"] == 1  # second call served from cache


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Adds **Twelve Data** as a forex data source. MetaTrader5 was considered but it is Windows-only and needs a running desktop terminal, so it can't run on Railway. Twelve Data is a plain REST + API key service that works anywhere, covers forex + crypto, and has a free 800 requests/day tier.

- **`twelvedata.py`** — `TwelveDataFetcher` with the shared fetcher interface, native 4h/1h/5min candles (no resampling like Yahoo). A process-wide **timeframe cache** (H4 = 1h TTL, H1 = 15min, M5 = 60s) means the slow higher timeframes are not refetched every 5-minute cycle: ~200 req/day per pair, so 2–3 forex pairs stay comfortably under the free budget.
- **`SMC_FOREX_SOURCE`** (`auto|twelvedata|oanda|yahoo`) — `auto` prefers Twelve Data when `TWELVEDATA_API_KEY` is set, then OANDA token, then keyless Yahoo. ETHUSD always stays on Binance (funding rate, unlimited history). `/status` shows the active source.

### Why is this change needed?
The owner wanted a broker-quality forex feed. MT5 (their IC Markets terminal) can't run on Railway; Twelve Data is the pragmatic free alternative that keeps the whole bot on Railway with zero infra changes — just one env var.

### How was this tested?
- [x] Unit tests — **107 pass** (parsing incl. newest-first ordering and in-progress-candle drop, error/empty payloads, `USDJPY→USD/JPY` symbol mapping, source selection for all modes, cache-hit behaviour)
- [x] Manual: source resolves to Yahoo without a key, Twelve Data with a key, Binance for ETHUSD; flake8 clean

### Breaking Changes
None. Default `auto` with no key behaves exactly as before (Yahoo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)