### PR TITLE
Rate-limit Twelve Data to 8 req/min (fix cold-start 429)

### DIFF
--- a/app/services/smc/twelvedata.py
+++ b/app/services/smc/twelvedata.py
@@ -7,8 +7,12 @@ every cycle. With 2-3 forex pairs this keeps the daily budget well under 800
 (≈200 credits/day per pair). Native 4h/1h/5min intervals — no resampling.
 """
 
+import asyncio
+import os
+import time
+from collections import deque
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional, Tuple
+from typing import Awaitable, Callable, Deque, Dict, List, Optional, Tuple
 
 import httpx
 import structlog
@@ -19,6 +23,48 @@ from app.services.smc.models import Candle
 logger = structlog.get_logger(__name__)
 
 BASE_URL = "https://api.twelvedata.com/time_series"
+
+# Free tier allows 8 API credits per minute. A cold-start cycle fetches every
+# timeframe of every forex pair at once (3 pairs × 3 TF = 9) and would burst
+# past the limit, so requests pass through a sliding-window rate limiter.
+MAX_PER_MIN = int(os.getenv("TWELVEDATA_MAX_PER_MIN", "8"))
+
+
+class _RateLimiter:
+    """Allow at most `limit` acquisitions per `window` seconds (sliding)."""
+
+    def __init__(
+        self,
+        limit: int,
+        window: float = 60.0,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ):
+        self.limit = max(1, limit)
+        self.window = window
+        self._clock = clock
+        self._sleep = sleep
+        self._times: Deque[float] = deque()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        async with self._lock:
+            while True:
+                now = self._clock()
+                while self._times and now - self._times[0] >= self.window:
+                    self._times.popleft()
+                if len(self._times) < self.limit:
+                    self._times.append(now)
+                    return
+                wait = self.window - (now - self._times[0]) + 0.05
+                logger.info(
+                    "Twelve Data minute limit reached, throttling",
+                    seconds=round(wait, 1),
+                )
+                await self._sleep(wait)
+
+
+_LIMITER = _RateLimiter(MAX_PER_MIN)
 
 # our interval -> Twelve Data interval string
 _INTERVAL = {"4h": "4h", "1h": "1h", "5m": "5min"}
@@ -124,14 +170,7 @@ class TwelveDataFetcher:
             "timezone": "UTC",
             "apikey": self.api_key,
         }
-        try:
-            async with httpx.AsyncClient(timeout=self.timeout) as client:
-                response = await client.get(BASE_URL, params=params)
-                response.raise_for_status()
-                payload = response.json()
-        except (httpx.HTTPError, ValueError) as e:
-            raise DataFetchError(f"Twelve Data request failed for {self.symbol}: {e}")
-
+        payload = await self._request(params)
         candles = parse_time_series(payload, interval)
         if len(candles) < 2:
             raise DataFetchError(
@@ -139,6 +178,33 @@ class TwelveDataFetcher:
             )
         _CACHE.put(cache_key, candles)
         return candles
+
+    async def _request(self, params: dict) -> dict:
+        """GET with rate limiting and a single 429 back-off retry."""
+        for attempt in range(2):
+            await _LIMITER.acquire()
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    response = await client.get(BASE_URL, params=params)
+            except httpx.HTTPError as e:
+                raise DataFetchError(
+                    f"Twelve Data request failed for {self.symbol}: {e}"
+                )
+            if response.status_code == 429 and attempt == 0:
+                logger.warning(
+                    "Twelve Data 429 despite throttle, backing off",
+                    symbol=self.symbol,
+                )
+                await asyncio.sleep(20)
+                continue
+            try:
+                response.raise_for_status()
+                return response.json()
+            except (httpx.HTTPError, ValueError) as e:
+                raise DataFetchError(
+                    f"Twelve Data request failed for {self.symbol}: {e}"
+                )
+        raise DataFetchError(f"Twelve Data rate limited for {self.symbol}")
 
     async def fetch_all_timeframes(self) -> Dict[str, List[Candle]]:
         return {

--- a/env.example
+++ b/env.example
@@ -7,9 +7,12 @@ TELEGRAM_CHAT_ID=your_telegram_chat_id_here
 # ETHUSD always uses Binance regardless.
 SMC_FOREX_SOURCE=auto             # auto | twelvedata | oanda | yahoo
 
-# Twelve Data — free tier 800 req/day, forex+crypto, works on Railway.
-# Get a key at twelvedata.com (free signup). Recommended forex source.
+# Twelve Data — free tier 800 req/day + 8 req/min, forex+crypto, works on
+# Railway. Get a key at twelvedata.com (free signup). Recommended forex source.
+# Requests are auto-throttled to stay under the per-minute cap; lower this only
+# if your plan differs. Free tier comfortably covers 3 forex pairs.
 # TWELVEDATA_API_KEY=
+# TWELVEDATA_MAX_PER_MIN=8
 
 # OANDA v20 (optional alternative): OANDA account -> Manage API Access.
 # OANDA_API_TOKEN=

--- a/tests/test_smc/test_twelvedata.py
+++ b/tests/test_smc/test_twelvedata.py
@@ -108,6 +108,43 @@ class TestSourceSelection:
         )
 
 
+class TestRateLimiter:
+    @pytest.mark.asyncio
+    async def test_throttles_beyond_limit(self):
+        from app.services.smc.twelvedata import _RateLimiter
+
+        clock = {"t": 1000.0}
+        slept = []
+
+        async def fake_sleep(seconds):
+            slept.append(seconds)
+            clock["t"] += seconds  # advance so the window frees up
+
+        lim = _RateLimiter(
+            limit=8, window=60.0, clock=lambda: clock["t"], sleep=fake_sleep
+        )
+        # 8 immediate acquisitions, no sleep
+        for _ in range(8):
+            await lim.acquire()
+        assert slept == []
+        # the 9th must wait out the window (~60s)
+        await lim.acquire()
+        assert len(slept) == 1 and 59 < slept[0] < 61
+
+    @pytest.mark.asyncio
+    async def test_allows_after_window_passes(self):
+        from app.services.smc.twelvedata import _RateLimiter
+
+        clock = {"t": 0.0}
+        lim = _RateLimiter(
+            limit=2, window=60.0, clock=lambda: clock["t"], sleep=None
+        )
+        await lim.acquire()
+        await lim.acquire()
+        clock["t"] = 61.0  # both earlier calls aged out of the window
+        await lim.acquire()  # should not need to sleep (sleep=None would crash)
+
+
 class TestCache:
     @pytest.mark.asyncio
     async def test_second_call_hits_cache(self, monkeypatch):


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Fixes the `429 Too Many Requests` on Twelve Data seen in production. The dashboard confirmed the **daily** budget was fine (12/800 used) — the wall was the free tier's **8 requests per minute**. A cold-start cycle fetches every timeframe of every forex pair at once (3 pairs × 3 TF = **9 requests in one burst**), tripping the per-minute cap on the 9th (USDCAD 5min). Steady-state cycles (M5 only) were already fine.

- **Sliding-window rate limiter** (process-wide) spaces Twelve Data requests so no more than `TWELVEDATA_MAX_PER_MIN` (default 8) land in any 60-second window. Burst cycles — boot and the hourly higher-timeframe refresh — self-throttle over ~a minute instead of failing; the M5-only cycles are untouched.
- **Single 429 back-off retry** as a safety net.

No need to drop a pair: 3 forex pairs use ~610 credits/day, comfortably under 800; the only issue was the per-minute burst, now smoothed.

### How was this tested?
- [x] Unit tests — **109 pass** (limiter allows 8 immediate acquisitions then throttles the 9th by ~60s; releases without sleeping once the window ages out)
- [x] flake8 clean

### Breaking Changes
None. New optional env var `TWELVEDATA_MAX_PER_MIN` (default 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)