### PR TITLE
Mute a pair's alerts for 4h after 'Took it'

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ a taken stop bans re-entry on that pair+direction for the session (Rule 10),
 and the second taken stop of the day suppresses all further alerts until
 tomorrow (Rule 0.2). Skipped signals never count against the limits.
 
+Pressing **✅ Took it** also **mutes new alerts for that pair for 4 hours**
+(`SMC_TAKEN_COOLDOWN_HOURS`) — you are managing the position, not hunting a
+second one. The live card for the taken trade keeps updating; `/status` shows
+what's muted and for how long.
+
 Signals and runtime state (selected pairs, dedup keys) live in one **SQLite
 database** (`SMC_DB_FILE`, default `.smc_watcher.db`; legacy JSON files are
 imported automatically). On Railway attach a volume (e.g. mounted at `/data`)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -64,6 +64,11 @@ class SMCSettings(BaseSettings):
         "auto = Twelve Data if its key is set, else OANDA if its token is set, "
         "else keyless Yahoo",
     )
+    taken_cooldown_hours: float = Field(
+        default=4.0,
+        description="After you press 'Took it', mute new alerts for that pair "
+        "for this many hours (you are managing the position)",
+    )
     notify_no_setup: bool = Field(
         default=False,
         description="Send 15-min heartbeat messages when no setup is found "

--- a/app/services/smc/state.py
+++ b/app/services/smc/state.py
@@ -23,6 +23,8 @@ class WatcherState:
         self.last_digest_date: str = db.kv_get("last_digest_date") or ""
         self.news_warned: Dict[str, str] = db.kv_get("news_warned") or {}
         self.day_stop_notified: str = db.kv_get("day_stop_notified") or ""
+        # pair -> ISO expiry: no new alerts for the pair until then (Took it)
+        self.pair_cooldown: Dict[str, str] = db.kv_get("pair_cooldown") or {}
 
     def save(self) -> None:
         self.db.kv_set("pairs", self.pairs)
@@ -30,6 +32,7 @@ class WatcherState:
         self.db.kv_set("last_digest_date", self.last_digest_date)
         self.db.kv_set("news_warned", self.news_warned)
         self.db.kv_set("day_stop_notified", self.day_stop_notified)
+        self.db.kv_set("pair_cooldown", self.pair_cooldown)
 
     def toggle_pair(self, key: str) -> bool:
         """Toggle a pair on/off. Returns True if the pair is now enabled."""

--- a/env.example
+++ b/env.example
@@ -27,6 +27,7 @@ SMC_RISK_PCT=2.0
 # SMC_DEPOSIT=1000                # deposit in USD for automatic lot hints
 SMC_ENFORCE_SESSIONS=true
 SMC_NOTIFY_NO_SETUP=false         # true = also send 15-min "no setup" heartbeats
+SMC_TAKEN_COOLDOWN_HOURS=4        # after "Took it", mute that pair's alerts
 # SMC_CHAT_ID=                    # override TELEGRAM_CHAT_ID for alerts
 
 # --- Storage (SQLite: signals journal + runtime state) ---

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -263,6 +263,14 @@ class Watcher:
                     logger.info("Alert suppressed", pair=key, rule=block)
                     heartbeat_lines.append(f"⛔ {key}: alert suppressed — {block}")
                     continue
+                cooldown = self._cooldown_left(key)
+                if cooldown:
+                    logger.info("Alert muted (taken cooldown)", pair=key, left=cooldown)
+                    heartbeat_lines.append(
+                        f"🔕 {key}: setup found but muted — you took a trade "
+                        f"here, {cooldown} left"
+                    )
+                    continue
                 approved.append(result)
                 await self._send_alert(key, result, fingerprint)
                 heartbeat_lines.append(f"🚨 {key}: SETUP FOUND — details above!")
@@ -322,9 +330,34 @@ class Watcher:
         signal = self.journal.mark_taken(signal_id, taken)
         if not signal:
             return "Signal not found (journal may have been reset)"
-        if taken:
-            return f"{signal['pair']} marked as taken — tracking your stats"
-        return f"{signal['pair']} marked as skipped"
+        if not taken:
+            return f"{signal['pair']} marked as skipped"
+        # You are now managing this position: mute new alerts for the pair.
+        hours = settings.smc.taken_cooldown_hours
+        expiry = datetime.now(tz=timezone.utc) + timedelta(hours=hours)
+        self.state.pair_cooldown[signal["pair"]] = expiry.isoformat()
+        self.state.save()
+        return (
+            f"{signal['pair']} marked as taken — tracking your stats; "
+            f"muted for {hours:.0f}h"
+        )
+
+    def _cooldown_left(self, key: str) -> Optional[str]:
+        """Human 'Nh Mm' remaining on a taken-trade mute, or None if expired."""
+        expiry = self.state.pair_cooldown.get(key)
+        if not expiry:
+            return None
+        now = datetime.now(tz=timezone.utc)
+        try:
+            remaining = datetime.fromisoformat(expiry) - now
+        except ValueError:
+            return None
+        if remaining.total_seconds() <= 0:
+            del self.state.pair_cooldown[key]
+            self.state.save()
+            return None
+        total_min = int(remaining.total_seconds() // 60)
+        return f"{total_min // 60}h {total_min % 60}m"
 
     async def _handle_journal_events(self, events) -> None:
         """Live-update alert cards and enforce the daily stop notification."""
@@ -481,6 +514,13 @@ class Watcher:
             "Deposit for sizing: "
             + (f"${settings.smc.deposit:.0f}" if settings.smc.deposit else "not set"),
         ]
+        muted = [
+            f"{k} ({left})"
+            for k in self.state.pairs
+            if (left := self._cooldown_left(k))
+        ]
+        if muted:
+            lines.append(f"🔕 Muted (taken): {', '.join(muted)}")
         if self.last_results:
             lines.append("")
             lines.append("<b>Last check:</b>")

--- a/tests/test_smc/test_cooldown.py
+++ b/tests/test_smc/test_cooldown.py
@@ -1,0 +1,82 @@
+"""Tests for the taken-trade cooldown: after 'Took it', mute the pair 4h."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.core.config import settings
+from app.services.smc.db import Database
+
+
+@pytest.fixture
+def watcher(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings.telegram, "bot_token", "123:dummy")
+    monkeypatch.setattr(settings.telegram, "chat_id", "1")
+    monkeypatch.setattr(settings.smc, "chat_id", None)
+    monkeypatch.setenv("SMC_DB_FILE", str(tmp_path / "smc.db"))
+    import importlib
+
+    import smc_watcher
+
+    importlib.reload(smc_watcher)
+    monkeypatch.setattr(smc_watcher, "DB_FILE", str(tmp_path / "smc.db"))
+    return smc_watcher.Watcher()
+
+
+def _record_signal(watcher, pair="USDJPY"):
+    signal = {
+        "id": "sig1",
+        "pair": pair,
+        "direction": "long",
+        "entry": 100.0,
+        "stop_loss": 95.0,
+        "take_profit": 110.0,
+        "rr": 2.0,
+        "session": "New York",
+        "created_at": datetime.now(tz=timezone.utc).isoformat(),
+        "expires_at": None,
+        "status": "pending",
+        "filled_at": None,
+        "resolved_at": None,
+        "checked_until": None,
+        "taken": None,
+        "message_id": None,
+        "alert_text": None,
+    }
+    watcher.journal.signals.append(signal)
+    watcher.journal.save()
+    return signal
+
+
+@pytest.mark.asyncio
+async def test_taken_sets_cooldown(watcher):
+    _record_signal(watcher, "USDJPY")
+    reply = await watcher.mark_trade("sig1", taken=True)
+    assert "muted for 4h" in reply
+    left = watcher._cooldown_left("USDJPY")
+    assert left is not None and left.startswith("3h")  # ~3h59m
+
+
+@pytest.mark.asyncio
+async def test_skipped_sets_no_cooldown(watcher):
+    _record_signal(watcher, "USDJPY")
+    await watcher.mark_trade("sig1", taken=False)
+    assert watcher._cooldown_left("USDJPY") is None
+
+
+def test_expired_cooldown_is_cleared(watcher):
+    past = (datetime.now(tz=timezone.utc) - timedelta(minutes=1)).isoformat()
+    watcher.state.pair_cooldown["GBPUSD"] = past
+    assert watcher._cooldown_left("GBPUSD") is None
+    assert "GBPUSD" not in watcher.state.pair_cooldown  # pruned
+
+
+def test_cooldown_persists_across_reload(watcher, tmp_path):
+    watcher.state.pair_cooldown["ETHUSD"] = (
+        datetime.now(tz=timezone.utc) + timedelta(hours=2)
+    ).isoformat()
+    watcher.state.save()
+    from app.services.smc.state import WatcherState
+
+    reloaded = WatcherState(Database(str(tmp_path / "smc.db")))
+    assert "ETHUSD" in reloaded.pair_cooldown


### PR DESCRIPTION
## What does this PR do?
Point 1 of the owner's request: once you press **✅ Took it** on an alert, new setup alerts for that pair are muted for 4 hours (`SMC_TAKEN_COOLDOWN_HOURS`, default 4). You are managing the position, not hunting a second setup on the same pair.

- Cooldown set in `mark_trade` when taken=True; checked in `run_cycle` before sending an alert (suppressed setups are logged and shown in the cycle summary as `🔕 … muted`).
- The **live card of the taken trade keeps updating** (fill→TP/SL) — only *new* setups are muted.
- `/status` lists muted pairs with time remaining; cooldown persists in SQLite across restarts.

## How was this tested?
- [x] Unit tests — **113 pass** (taken sets ~4h cooldown, skipped sets none, expired cooldown is pruned, cooldown survives a state reload)
- [x] flake8 clean

## Breaking Changes
None. New optional env var `SMC_TAKEN_COOLDOWN_HOURS` (default 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)