### PR TITLE
Double the M5 candles on the alert chart (~16h) for HH/HL context

### DIFF
--- a/app/services/smc/chart.py
+++ b/app/services/smc/chart.py
@@ -5,6 +5,7 @@ urgent alert so the setup is visible at a glance without opening TradingView.
 Rendering failures must never block an alert: callers wrap in try/except.
 """
 
+import os
 from io import BytesIO
 from typing import Optional
 
@@ -25,14 +26,22 @@ FG = "#d1d4dc"
 GRID = "#2a2e39"
 
 
-def render_setup_chart(result: AnalysisResult, candles_back: int = 96) -> Optional[bytes]:
-    """Render the approved setup as a PNG (last ~8h of M5). None if no data."""
+# ~16h of M5 by default: enough to show the swing HH/HL structure behind the
+# setup. Tunable via SMC_CHART_CANDLES.
+CHART_CANDLES = int(os.getenv("SMC_CHART_CANDLES", "192"))
+
+
+def render_setup_chart(
+    result: AnalysisResult, candles_back: int = CHART_CANDLES
+) -> Optional[bytes]:
+    """Render the approved setup as a PNG (last ~16h of M5). None if no data."""
     if not result.m5_candles or not result.setup:
         return None
     candles = result.m5_candles[-candles_back:]
     setup = result.setup
 
-    fig, ax = plt.subplots(figsize=(10, 6), dpi=110)
+    # Wider canvas + thinner wicks so twice as many candles stay legible.
+    fig, ax = plt.subplots(figsize=(13, 6), dpi=110)
     fig.patch.set_facecolor(BG)
     ax.set_facecolor(BG)
 

--- a/env.example
+++ b/env.example
@@ -28,6 +28,7 @@ SMC_RISK_PCT=2.0
 SMC_ENFORCE_SESSIONS=true
 SMC_NOTIFY_NO_SETUP=false         # true = also send 15-min "no setup" heartbeats
 SMC_TAKEN_COOLDOWN_HOURS=4        # after "Took it", mute that pair's alerts
+SMC_CHART_CANDLES=192            # M5 candles on the alert chart (~16h)
 # SMC_CHAT_ID=                    # override TELEGRAM_CHAT_ID for alerts
 
 # --- Storage (SQLite: signals journal + runtime state) ---


### PR DESCRIPTION
## What does this PR do?
The alert chart showed 96 M5 candles (~8h) — too little to see the swing HH/HL structure the setup grows from. The default is now **192 candles (~16h)**, tunable via `SMC_CHART_CANDLES`. The canvas is widened to 13in so twice as many candles stay legible (thinner effective candle width, same clarity).

## How was this tested?
- [x] Live render check: produces a valid 192-candle PNG (33 KB, valid header)
- [x] 113 tests pass; flake8 clean

## Breaking Changes
None. New optional env var `SMC_CHART_CANDLES` (default 192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)