### PR TITLE
C:/Program Files/Git/plan⇄watcher info merge + fresh candles on /plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,8 @@ app/services/smc/
 │                         discipline_block (Rule 10 / Rule 0.2), /stats
 ├── plan.py               Pre-Market Plan (Шаблон B): projected entry/SL/TP/RR
 │                         from H4/H1 structure; both-way brackets when H4 flat;
-│                         on-demand only via /plan (not auto-sent)
+│                         on-demand via /plan, folded with live engine status.
+│                         Zone-touch ping fires when result.in_zone flips true
 ├── chart.py              alert chart PNG (M5) + plan chart PNG (H1): candles,
 │                         zones, levels (matplotlib Agg, NO pandas — keep it so)
 ├── telegram_bot.py       long-polling commands, slash-menu registration,

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ setup appears.
 - 💱 **Pairs are switchable at runtime** via Telegram: `/pairs`
 - 📅 **Forex Factory red-news digest** every weekday at 07:45 Prague
   (incl. a session-block breakdown of today's releases)
-- 📋 **`/plan`** — an on-demand Pre-Market Plan for any watched pair
-  (conditional entry/SL/TP/RR + H1 chart; both-direction brackets when flat)
+- 📋 **`/plan`** — an on-demand Pre-Market Plan for any watched pair, folded
+  together with the **live checklist status** (projection + where the pair is
+  right now); conditional entry/SL/TP/RR + H1 chart, both-way brackets when flat
+- 🔔 **Zone-touch ping** — a light "get ready" nudge the moment price reaches a
+  live H1 zone, before the full 🚨 setup forms (`SMC_ZONE_PING`)
 - 📒 **Signal journal**: every alert is auto-tracked to its TP/SL outcome;
   `/stats` shows signal winrate and your personal (taken) winrate separately
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -69,6 +69,11 @@ class SMCSettings(BaseSettings):
         description="After you press 'Took it', mute new alerts for that pair "
         "for this many hours (you are managing the position)",
     )
+    zone_ping: bool = Field(
+        default=True,
+        description="Send a 'get ready' ping when price first reaches a live "
+        "H1 zone, before the full setup forms",
+    )
     notify_no_setup: bool = Field(
         default=False,
         description="Send 15-min heartbeat messages when no setup is found "

--- a/app/services/smc/data.py
+++ b/app/services/smc/data.py
@@ -58,8 +58,11 @@ class BinanceDataFetcher:
             candles = candles[:-1]
         return candles
 
-    async def fetch_all_timeframes(self) -> Dict[str, List[Candle]]:
-        """Fetch H4 / H1 / M5 candles in one call."""
+    async def fetch_all_timeframes(
+        self, force_fresh: bool = False
+    ) -> Dict[str, List[Candle]]:
+        """Fetch H4 / H1 / M5 candles in one call (Binance is never cached,
+        so force_fresh is a no-op — kept for a uniform fetcher interface)."""
         return {
             "h4": await self.fetch_candles("4h", limit=300),
             "h1": await self.fetch_candles("1h", limit=400),

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -185,6 +185,9 @@ class TripleSyncEngine:
                 )
                 return result
 
+        # Price is in a live (non-invalidated) zone — arm the zone-touch ping
+        result.in_zone = True
+
         # Rule 3 phase 2 — M5 CHoCH in trend direction inside the zone
         choch = find_choch(m5, direction, touch)
         if choch is None:

--- a/app/services/smc/models.py
+++ b/app/services/smc/models.py
@@ -123,5 +123,8 @@ class AnalysisResult:
     watch_notes: List[str] = field(default_factory=list)
     session_name: Optional[str] = None
     price_decimals: int = 2
+    # True once price is inside a valid, non-invalidated H1 zone (used for the
+    # "get ready" zone-touch ping before a full setup forms)
+    in_zone: bool = False
     # last fetched M5 candles (in-memory only, used for chart rendering)
     m5_candles: Optional[List[Candle]] = field(default=None, repr=False)

--- a/app/services/smc/notifier.py
+++ b/app/services/smc/notifier.py
@@ -127,11 +127,14 @@ def format_result(result: AnalysisResult) -> str:
     return "\n".join(lines)
 
 
-def format_plan(plan, min_rr: float = 2.0, live_line: str = None) -> str:
+def format_plan(
+    plan, min_rr: float = 2.0, live_line: str = None, as_of: str = None
+) -> str:
     """Render a PairPlan as an HTML pre-market briefing message (Шаблон B).
 
     `live_line` (optional) folds in the watcher's live checklist status so the
-    plan and the live view are one picture.
+    plan and the live view are one picture. `as_of` is the Prague time of the
+    last closed M5 candle, shown so data freshness is visible.
     """
     from app.services.smc.plan import PairPlan  # noqa: F401 (type hint only)
 
@@ -139,7 +142,8 @@ def format_plan(plan, min_rr: float = 2.0, live_line: str = None) -> str:
     trend_label = TREND_LABEL[plan.h4_trend]
     lines = [f"📋 <b>{plan.pair}</b> — Pre-Market Plan (H4 {trend_label})"]
     if plan.price:
-        lines.append(f"💵 {plan.price:.{d}f}")
+        suffix = f"  ·  M5 close {as_of} Prague" if as_of else ""
+        lines.append(f"💵 {plan.price:.{d}f}{suffix}")
     if live_line:
         lines.append(f"📍 <b>Live now:</b> {live_line}")
 

--- a/app/services/smc/notifier.py
+++ b/app/services/smc/notifier.py
@@ -127,8 +127,12 @@ def format_result(result: AnalysisResult) -> str:
     return "\n".join(lines)
 
 
-def format_plan(plan, min_rr: float = 2.0) -> str:
-    """Render a PairPlan as an HTML pre-market briefing message (Шаблон B)."""
+def format_plan(plan, min_rr: float = 2.0, live_line: str = None) -> str:
+    """Render a PairPlan as an HTML pre-market briefing message (Шаблон B).
+
+    `live_line` (optional) folds in the watcher's live checklist status so the
+    plan and the live view are one picture.
+    """
     from app.services.smc.plan import PairPlan  # noqa: F401 (type hint only)
 
     d = plan.price_decimals
@@ -136,6 +140,8 @@ def format_plan(plan, min_rr: float = 2.0) -> str:
     lines = [f"📋 <b>{plan.pair}</b> — Pre-Market Plan (H4 {trend_label})"]
     if plan.price:
         lines.append(f"💵 {plan.price:.{d}f}")
+    if live_line:
+        lines.append(f"📍 <b>Live now:</b> {live_line}")
 
     if plan.note and not plan.scenarios:
         lines.append("")

--- a/app/services/smc/oanda.py
+++ b/app/services/smc/oanda.py
@@ -72,7 +72,10 @@ class OandaDataFetcher:
             raise DataFetchError(f"OANDA returned no data for {self.symbol}")
         return candles
 
-    async def fetch_all_timeframes(self) -> Dict[str, List[Candle]]:
+    async def fetch_all_timeframes(
+        self, force_fresh: bool = False
+    ) -> Dict[str, List[Candle]]:
+        # OANDA is not cached; force_fresh is a no-op (uniform interface).
         return {
             "h4": await self.fetch_candles("4h", limit=300),
             "h1": await self.fetch_candles("1h", limit=400),

--- a/app/services/smc/state.py
+++ b/app/services/smc/state.py
@@ -25,6 +25,9 @@ class WatcherState:
         self.day_stop_notified: str = db.kv_get("day_stop_notified") or ""
         # pair -> ISO expiry: no new alerts for the pair until then (Took it)
         self.pair_cooldown: Dict[str, str] = db.kv_get("pair_cooldown") or {}
+        # pair -> bool: whether the "price reached the zone" ping was sent for
+        # the current in-zone episode (reset when price leaves the zone)
+        self.zone_pinged: Dict[str, bool] = db.kv_get("zone_pinged") or {}
 
     def save(self) -> None:
         self.db.kv_set("pairs", self.pairs)
@@ -33,6 +36,7 @@ class WatcherState:
         self.db.kv_set("news_warned", self.news_warned)
         self.db.kv_set("day_stop_notified", self.day_stop_notified)
         self.db.kv_set("pair_cooldown", self.pair_cooldown)
+        self.db.kv_set("zone_pinged", self.zone_pinged)
 
     def toggle_pair(self, key: str) -> bool:
         """Toggle a pair on/off. Returns True if the pair is now enabled."""

--- a/app/services/smc/twelvedata.py
+++ b/app/services/smc/twelvedata.py
@@ -153,15 +153,18 @@ class TwelveDataFetcher:
         self.api_key = api_key
         self.timeout = timeout
 
-    async def fetch_candles(self, interval: str, limit: int = 400) -> List[Candle]:
+    async def fetch_candles(
+        self, interval: str, limit: int = 400, force_fresh: bool = False
+    ) -> List[Candle]:
         td_interval = _INTERVAL.get(interval)
         if not td_interval:
             raise DataFetchError(f"Unsupported Twelve Data interval: {interval}")
 
         cache_key = (self.symbol, interval)
-        cached = _CACHE.get(cache_key, _TF_CACHE_TTL[interval])
-        if cached is not None:
-            return cached
+        if not force_fresh:
+            cached = _CACHE.get(cache_key, _TF_CACHE_TTL[interval])
+            if cached is not None:
+                return cached
 
         params = {
             "symbol": self.symbol,
@@ -206,11 +209,13 @@ class TwelveDataFetcher:
                 )
         raise DataFetchError(f"Twelve Data rate limited for {self.symbol}")
 
-    async def fetch_all_timeframes(self) -> Dict[str, List[Candle]]:
+    async def fetch_all_timeframes(
+        self, force_fresh: bool = False
+    ) -> Dict[str, List[Candle]]:
         return {
-            "h4": await self.fetch_candles("4h", limit=300),
-            "h1": await self.fetch_candles("1h", limit=400),
-            "m5": await self.fetch_candles("5m", limit=400),
+            "h4": await self.fetch_candles("4h", 300, force_fresh=force_fresh),
+            "h1": await self.fetch_candles("1h", 400, force_fresh=force_fresh),
+            "m5": await self.fetch_candles("5m", 400, force_fresh=force_fresh),
         }
 
     async def fetch_funding_rate(self) -> Optional[float]:

--- a/app/services/smc/yahoo.py
+++ b/app/services/smc/yahoo.py
@@ -78,7 +78,10 @@ class YahooDataFetcher:
             candles = resample_h4(candles, now=now)
         return candles[-limit:]
 
-    async def fetch_all_timeframes(self) -> Dict[str, List[Candle]]:
+    async def fetch_all_timeframes(
+        self, force_fresh: bool = False
+    ) -> Dict[str, List[Candle]]:
+        # Yahoo is not cached; force_fresh is a no-op (uniform interface).
         return {
             "h4": await self.fetch_candles("4h", limit=300),
             "h1": await self.fetch_candles("1h", limit=400),

--- a/env.example
+++ b/env.example
@@ -28,6 +28,7 @@ SMC_RISK_PCT=2.0
 SMC_ENFORCE_SESSIONS=true
 SMC_NOTIFY_NO_SETUP=false         # true = also send 15-min "no setup" heartbeats
 SMC_TAKEN_COOLDOWN_HOURS=4        # after "Took it", mute that pair's alerts
+SMC_ZONE_PING=true               # 'get ready' ping when price reaches an H1 zone
 SMC_CHART_CANDLES=192            # M5 candles on the alert chart (~16h)
 # SMC_CHAT_ID=                    # override TELEGRAM_CHAT_ID for alerts
 

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -277,6 +277,7 @@ class Watcher:
                 await self._send_alert(key, result, fingerprint)
                 heartbeat_lines.append(f"🚨 {key}: SETUP FOUND — details above!")
             else:
+                await self._maybe_zone_ping(key, result)
                 heartbeat_lines.append(line)
 
         for warning in _correlation_warnings(approved):
@@ -475,13 +476,67 @@ class Watcher:
         plan = build_plan(
             instrument, data["h4"], data["h1"], data["m5"], market_closed=stale
         )
-        await self.notifier.send(format_plan(plan, min_rr=settings.smc.min_rr))
+        live_line = None if stale else self._live_status(instrument, data, now)
+        await self.notifier.send(
+            format_plan(plan, min_rr=settings.smc.min_rr, live_line=live_line)
+        )
         try:
             png = render_plan_chart(plan, data["h1"])
             if png:
                 await self.notifier.send_photo(png)
         except Exception as e:
             logger.warning("Plan chart failed", pair=key, error=str(e))
+
+    def _live_status(self, instrument: Instrument, data: dict, now) -> str:
+        """One-line live checklist status of a pair, for the /plan message."""
+        res = AnalysisResult(
+            symbol=instrument.key,
+            verdict=Verdict.SKIP,
+            checked_at=now,
+            price_decimals=instrument.price_decimals,
+        )
+        res.session_name = active_session(
+            now, require_weekday=instrument.source == "forex"
+        )
+        res.price = data["m5"][-1].close
+        res = _build_engine(instrument).evaluate(
+            h4=data["h4"], h1=data["h1"], m5=data["m5"], result=res
+        )
+        d = instrument.price_decimals
+        if res.verdict in APPROVED:
+            s = res.setup
+            return (
+                f"🚨 LIVE SETUP NOW — {s.direction.value} entry {s.entry:.{d}f}, "
+                f"SL {s.stop_loss:.{d}f}, TP {s.take_profit:.{d}f} (RR 1:{s.rr:.1f})"
+            )
+        prefix = "" if res.session_name else "(off session) "
+        icon = "👀" if res.verdict == Verdict.WATCH else "⛔"
+        reason = res.reasons[0] if res.reasons else "no direction"
+        return f"{icon} {prefix}{escape_html(reason)}"
+
+    async def _maybe_zone_ping(self, key: str, result: AnalysisResult) -> None:
+        """Send a one-time 'get ready' ping when price first enters a live zone."""
+        if not settings.smc.zone_ping or result is None:
+            return
+        armed = result.in_zone and result.verdict not in APPROVED and result.h1_zone
+        was_pinged = self.state.zone_pinged.get(key, False)
+        if armed and not was_pinged:
+            if self._cooldown_left(key):  # already managing a position here
+                return
+            zone = result.h1_zone
+            d = result.price_decimals
+            kind = "Demand" if zone.is_demand else "Supply"
+            await self.notifier.send(
+                f"🔔 <b>{key}</b>: price reached the H1 {kind} zone "
+                f"{zone.bottom:.{d}f}–{zone.top:.{d}f} — get ready, watching M5 "
+                f"for a {'bullish' if zone.is_demand else 'bearish'} CHoCH + FVG."
+            )
+            self.state.zone_pinged[key] = True
+            self.state.save()
+            logger.info("Zone-touch ping sent", pair=key)
+        elif not result.in_zone and was_pinged:
+            self.state.zone_pinged[key] = False
+            self.state.save()
 
     async def _rule_04_warnings(self) -> None:
         """Rule 0.4: active signal + red news soon -> SL to BU / pull the order."""

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -464,7 +464,10 @@ class Watcher:
 
         instrument = get_instrument(key)
         try:
-            data = await _build_fetcher(instrument).fetch_all_timeframes()
+            # on-demand -> bypass the Twelve Data cache for the freshest candles
+            data = await _build_fetcher(instrument).fetch_all_timeframes(
+                force_fresh=True
+            )
         except Exception as e:
             logger.warning("Plan fetch failed", pair=key, error=str(e))
             return
@@ -477,8 +480,11 @@ class Watcher:
             instrument, data["h4"], data["h1"], data["m5"], market_closed=stale
         )
         live_line = None if stale else self._live_status(instrument, data, now)
+        as_of = to_prague(data["m5"][-1].timestamp).strftime("%H:%M")
         await self.notifier.send(
-            format_plan(plan, min_rr=settings.smc.min_rr, live_line=live_line)
+            format_plan(
+                plan, min_rr=settings.smc.min_rr, live_line=live_line, as_of=as_of
+            )
         )
         try:
             png = render_plan_chart(plan, data["h1"])

--- a/tests/test_smc/test_twelvedata.py
+++ b/tests/test_smc/test_twelvedata.py
@@ -173,3 +173,24 @@ class TestCache:
         await f.fetch_candles("4h")
         await f.fetch_candles("4h")
         assert calls["n"] == 1  # second call served from cache
+
+    @pytest.mark.asyncio
+    async def test_force_fresh_bypasses_cache(self, monkeypatch):
+        from app.services.smc.twelvedata import TwelveDataFetcher, _CACHE
+
+        calls = {"n": 0}
+
+        async def fake_request(self, params):
+            calls["n"] += 1
+            base = "2000-01-01"
+            return _payload(
+                [_row(f"{base} 10:00:00"), _row(f"{base} 11:00:00")]
+            )
+
+        monkeypatch.setattr(TwelveDataFetcher, "_request", fake_request)
+        f = TwelveDataFetcher("USDJPY", "KEY")
+        await f.fetch_candles("4h")  # miss -> 1 request, caches
+        await f.fetch_candles("4h")  # cache hit -> still 1
+        assert calls["n"] == 1
+        await f.fetch_candles("4h", force_fresh=True)  # bypass -> 2
+        assert calls["n"] == 2

--- a/tests/test_smc/test_zone_ping.py
+++ b/tests/test_smc/test_zone_ping.py
@@ -1,0 +1,172 @@
+"""Tests for /plan⇄watcher info merge: engine in_zone flag, zone-touch ping,
+and the live-status line shown in /plan."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.core.config import settings
+from app.services.smc.engine import TripleSyncEngine
+from app.services.smc.instruments import get_instrument
+from app.services.smc.models import AnalysisResult, Verdict, Zone
+from tests.test_smc.helpers import (
+    H1_PULLBACK_CLOSES,
+    H4_UPTREND_CLOSES,
+    m5_long_trigger,
+    make_candles,
+)
+
+
+def _fresh():
+    return AnalysisResult(
+        symbol="ETHUSD",
+        verdict=Verdict.SKIP,
+        checked_at=datetime(2026, 7, 6, 15, 40, tzinfo=timezone.utc),
+    )
+
+
+def _eval(m5, h4=None):
+    return TripleSyncEngine(min_rr=2.0).evaluate(
+        h4=h4 or make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+        h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+        m5=m5,
+        result=_fresh(),
+    )
+
+
+class TestEngineInZone:
+    def test_in_zone_true_when_waiting_for_choch(self):
+        res = _eval(m5_long_trigger()[:16])  # in the zone, no CHoCH yet
+        assert res.verdict == Verdict.WATCH and res.in_zone
+
+    def test_in_zone_true_when_approved(self):
+        res = _eval(m5_long_trigger())
+        assert res.verdict == Verdict.APPROVED_LIMIT and res.in_zone
+
+    def test_in_zone_false_when_price_not_reached(self):
+        m5 = make_candles([3180, 3178, 3176, 3175, 3174, 3175, 3176, 3175, 3174])
+        res = _eval(m5)
+        assert res.verdict == Verdict.WATCH and not res.in_zone
+
+    def test_in_zone_false_when_flat(self):
+        flat = [3000, 3050, 3000, 3050, 3000, 3050, 3000, 3050, 3000, 3050, 3000]
+        res = _eval(m5_long_trigger(), h4=make_candles(flat, step_minutes=240))
+        assert not res.in_zone
+
+
+class _State:
+    def __init__(self):
+        self.zone_pinged = {}
+        self.pair_cooldown = {}
+
+    def save(self):
+        pass
+
+
+class _Notifier:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, text, **kwargs):
+        self.sent.append(text)
+        return 1
+
+
+def _watcher(monkeypatch):
+    from smc_watcher import Watcher
+
+    monkeypatch.setattr(settings.smc, "zone_ping", True)
+    w = Watcher.__new__(Watcher)
+    w.state = _State()
+    w.notifier = _Notifier()
+    return w
+
+
+def _in_zone_result():
+    r = AnalysisResult(
+        symbol="USDJPY",
+        verdict=Verdict.WATCH,
+        checked_at=datetime.now(tz=timezone.utc),
+        price_decimals=3,
+    )
+    r.in_zone = True
+    r.h1_zone = Zone(
+        bottom=162.0, top=162.12, is_demand=True, pivot_index=0,
+        timestamp=r.checked_at,
+    )
+    return r
+
+
+class TestZonePing:
+    @pytest.mark.asyncio
+    async def test_first_entry_pings_once(self, monkeypatch):
+        w = _watcher(monkeypatch)
+        r = _in_zone_result()
+        await w._maybe_zone_ping("USDJPY", r)
+        await w._maybe_zone_ping("USDJPY", r)  # still in zone -> no second ping
+        assert len(w.notifier.sent) == 1
+        assert "reached the H1 Demand zone" in w.notifier.sent[0]
+
+    @pytest.mark.asyncio
+    async def test_reset_on_leaving_then_repings(self, monkeypatch):
+        w = _watcher(monkeypatch)
+        await w._maybe_zone_ping("USDJPY", _in_zone_result())
+        left = _in_zone_result()
+        left.in_zone = False
+        await w._maybe_zone_ping("USDJPY", left)  # left the zone -> reset
+        await w._maybe_zone_ping("USDJPY", _in_zone_result())  # re-entry pings
+        assert len(w.notifier.sent) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_ping_when_approved(self, monkeypatch):
+        w = _watcher(monkeypatch)
+        r = _in_zone_result()
+        r.verdict = Verdict.APPROVED_LIMIT  # full alert handles this, not a ping
+        await w._maybe_zone_ping("USDJPY", r)
+        assert w.notifier.sent == []
+
+    @pytest.mark.asyncio
+    async def test_cooldown_suppresses_ping(self, monkeypatch):
+        w = _watcher(monkeypatch)
+        w.state.pair_cooldown["USDJPY"] = (
+            datetime.now(tz=timezone.utc) + timedelta(hours=2)
+        ).isoformat()
+        await w._maybe_zone_ping("USDJPY", _in_zone_result())
+        assert w.notifier.sent == []
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_flag(self, monkeypatch):
+        w = _watcher(monkeypatch)
+        monkeypatch.setattr(settings.smc, "zone_ping", False)
+        await w._maybe_zone_ping("USDJPY", _in_zone_result())
+        assert w.notifier.sent == []
+
+
+class TestLiveStatus:
+    def test_reports_live_setup(self, monkeypatch):
+        w = _watcher(monkeypatch)
+        data = {
+            "h4": make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            "h1": make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            "m5": m5_long_trigger(),
+        }
+        line = w._live_status(
+            get_instrument("ETHUSD"),
+            data,
+            datetime(2026, 7, 6, 15, 40, tzinfo=timezone.utc),
+        )
+        assert "LIVE SETUP NOW" in line
+
+    def test_reports_watch_reason(self, monkeypatch):
+        w = _watcher(monkeypatch)
+        data = {
+            "h4": make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            "h1": make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            "m5": m5_long_trigger()[:16],
+        }
+        line = w._live_status(
+            get_instrument("ETHUSD"),
+            data,
+            datetime(2026, 7, 6, 15, 40, tzinfo=timezone.utc),
+        )
+        assert "👀" in line and "zone" in line.lower()


### PR DESCRIPTION
## What does this PR do?
Two related improvements, both about making `/plan` and the watcher one coherent, trustworthy picture.

### 1. Merge /plan and watcher by information (owner's choice)
- **`/plan` folds in the live checklist status** — a `📍 Live now:` line shows the current engine verdict/reason (or the live setup with entry/SL/TP if one is forming), from the same candles.
- **Zone-touch ping** — the engine sets `result.in_zone` once price is inside a valid H1 zone; the watcher sends a one-time 🔔 "get ready, watching M5 for a CHoCH + FVG" on entry, resets on leaving, silent during a taken-cooldown. `SMC_ZONE_PING` (default on).
- Decision-level merge deliberately avoided: the plan never filters live alerts.

### 2. Fresh candles on /plan (bug fix)
On-demand `/plan` reused the Twelve Data timeframe cache (H4 1h / H1 15min TTL), so forex plans could read up to 15min–1h stale vs the live chart (crypto was always fresh — Binance isn't cached).
- `fetch_all_timeframes(force_fresh=True)` bypasses the cache; `/plan` uses it. The param is on every fetcher (no-op where uncached) for a uniform interface. The automatic 5-min cycle keeps the cache to stay under the free daily budget.
- The plan's price line shows the last **closed M5 candle's Prague time** ("M5 close 15:35 Prague") so freshness is visible.

## How was this tested?
- [x] Unit tests — **136 pass** (engine `in_zone` states; zone-ping once/reset/cooldown/flag/approved; live-status line; `force_fresh` bypasses cache while normal calls still hit it)
- [x] Merged `/plan` message previewed; flake8 clean

## Breaking Changes
None. New optional env vars `SMC_ZONE_PING` (default true); `force_fresh` is internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)