### PR TITLE
Add /journal trade journal from MetaTrader screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,27 @@ Once the application is running, visit:
 - `/digest` - Configure daily digest
 - `/charts` - Enable/disable charts
 - `/status` - Check current settings
+- `/journal` - 📓 Personal trade journal (see below)
 - `/support` - Get support information
+
+## 📓 Trade Journal
+
+Track your MetaTrader trades by sending screenshots of the MT4/MT5 history to the bot.
+
+**How it works:**
+
+1. Send a screenshot of your MetaTrader trade history to the bot.
+2. The screenshot is parsed with OpenAI Vision (`API_OPENAI_MODEL`, default `gpt-4o-mini`),
+   extracting every closed trade (symbol, direction, volume, open/close price and time,
+   S/L, T/P, profit, swap, commission, taxes, ticket, and the `[sl]` marker).
+3. The bot replies with a preview of the recognized trades plus **💾 Сохранить / ❌ Отмена**
+   buttons. Nothing is written until you confirm.
+4. On confirm, trades are stored (de-duplicated by ticket) in the `trades` table.
+5. `/journal` shows aggregate stats: total P/L, win rate, profit factor, best/worst trade,
+   a per-symbol breakdown, and the most recent trades.
+
+**Access control:** set `TELEGRAM_OWNER_ID` to your numeric Telegram user id so only you
+can use the journal. Leave it empty to allow all users. Requires `API_OPENAI_API_KEY`.
 
 ## 🏗️ Architecture
 

--- a/app/api/v1/endpoints/telegram.py
+++ b/app/api/v1/endpoints/telegram.py
@@ -1,5 +1,7 @@
 """Telegram webhook API endpoints."""
 
+from typing import Optional
+
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,11 +11,25 @@ from app.core.exceptions import TelegramError, ValidationError
 from app.database.connection import get_database
 from app.models.telegram import TelegramUpdate
 from app.models.user import UserCreate, UserPreferences
+from app.services.journal_service import JournalService
 from app.services.telegram_service import TelegramService
 from app.services.user_service import UserService
 
 router = APIRouter()
 logger = structlog.get_logger(__name__)
+
+journal_service = JournalService()
+
+
+def _is_journal_owner(telegram_id: Optional[int]) -> bool:
+    """Whether the given user may use the private trade journal.
+
+    When TELEGRAM_OWNER_ID is unset, the journal is open to everyone.
+    """
+    owner_id = settings.telegram.owner_id
+    if owner_id is None:
+        return True
+    return telegram_id == owner_id
 
 
 def get_telegram_service() -> TelegramService:
@@ -84,6 +100,11 @@ async def _process_message(
 ):
     """Process incoming message."""
     try:
+        # A screenshot of MetaTrader history -> parse into the trade journal.
+        if message.photo:
+            await _handle_journal_screenshot(message, telegram_service, db)
+            return
+
         # Get or create user
         user = await _get_or_create_user(message.from_user, user_service, db)
 
@@ -151,7 +172,8 @@ async def _process_command(
             "/impact - Set impact level preferences\n"
             "/digest - Configure daily digest\n"
             "/charts - Enable/disable charts\n"
-            "/status - Check your current settings",
+            "/status - Check your current settings\n"
+            "/journal - 📓 Дневник сделок (пришли скриншот истории MT4)",
         )
 
     elif command == "/help":
@@ -167,6 +189,7 @@ async def _process_command(
             "/digest - Daily digest settings\n"
             "/charts - Chart preferences\n"
             "/status - Current settings\n"
+            "/journal - 📓 Дневник сделок (скриншот истории MT4)\n"
             "/support - Get support",
         )
 
@@ -190,6 +213,9 @@ async def _process_command(
 
     elif command == "/status":
         await _show_status(message, telegram_service, user_service, db)
+
+    elif command == "/journal":
+        await _show_journal(message, telegram_service, db)
 
     elif command == "/support":
         await telegram_service.send_message(
@@ -444,6 +470,155 @@ async def _show_status(
         )
 
 
+async def _handle_journal_screenshot(
+    message,
+    telegram_service: TelegramService,
+    db: AsyncSession,
+):
+    """Parse a MetaTrader history screenshot and offer to save the trades."""
+    chat_id = message.chat.id
+    user_id = message.from_user.id if message.from_user else chat_id
+
+    if not _is_journal_owner(user_id):
+        await telegram_service.send_message(
+            chat_id, "🔒 Журнал сделок доступен только владельцу бота."
+        )
+        return
+
+    if not settings.api.openai_api_key:
+        await telegram_service.send_message(
+            chat_id,
+            "⚠️ Распознавание недоступно: не настроен OpenAI API ключ "
+            "(API_OPENAI_API_KEY).",
+        )
+        return
+
+    await telegram_service.send_message(
+        chat_id, "🔍 Распознаю сделки со скриншота, подожди пару секунд..."
+    )
+
+    try:
+        # Largest available photo size is the last one.
+        file_id = message.photo[-1].file_id
+        image_bytes = await telegram_service.download_file(file_id)
+        if not image_bytes:
+            await telegram_service.send_message(
+                chat_id, "❌ Не удалось скачать изображение. Попробуй ещё раз."
+            )
+            return
+
+        trades = await journal_service.parse_screenshot(image_bytes)
+
+        if not trades:
+            await telegram_service.send_message(
+                chat_id, journal_service.format_preview(trades), parse_mode="HTML"
+            )
+            return
+
+        batch_id = await journal_service.save_pending_batch(db, user_id, trades)
+        keyboard = {
+            "inline_keyboard": [
+                [
+                    {"text": "💾 Сохранить", "callback_data": f"jrnl_save_{batch_id}"},
+                    {"text": "❌ Отмена", "callback_data": f"jrnl_cancel_{batch_id}"},
+                ]
+            ]
+        }
+        await telegram_service.send_message(
+            chat_id,
+            journal_service.format_preview(trades),
+            parse_mode="HTML",
+            reply_markup=keyboard,
+        )
+
+    except Exception as e:
+        logger.error("Failed to process journal screenshot", error=str(e), exc_info=True)
+        await telegram_service.send_message(
+            chat_id,
+            "❌ Ошибка при распознавании скриншота. Попробуй прислать более "
+            "чёткое изображение.",
+        )
+
+
+async def _show_journal(
+    message,
+    telegram_service: TelegramService,
+    db: AsyncSession,
+):
+    """Show the /journal statistics."""
+    chat_id = message.chat.id
+    user_id = message.from_user.id if message.from_user else chat_id
+
+    if not _is_journal_owner(user_id):
+        await telegram_service.send_message(
+            chat_id, "🔒 Журнал сделок доступен только владельцу бота."
+        )
+        return
+
+    try:
+        stats = await journal_service.get_stats(db, user_id)
+        await telegram_service.send_message(
+            chat_id, journal_service.format_journal(stats), parse_mode="HTML"
+        )
+    except Exception as e:
+        logger.error("Failed to show journal", error=str(e), exc_info=True)
+        await telegram_service.send_message(
+            chat_id, "❌ Не удалось получить статистику журнала."
+        )
+
+
+async def _handle_journal_callback(
+    callback_query,
+    telegram_service: TelegramService,
+    db: AsyncSession,
+):
+    """Handle Save / Cancel buttons on a parsed trade batch."""
+    data = callback_query.data
+    chat_id = callback_query.message.chat.id if callback_query.message else None
+    user_id = callback_query.from_user.id
+
+    if not _is_journal_owner(user_id):
+        await telegram_service.answer_callback_query(
+            callback_query.id, "🔒 Недоступно", show_alert=True
+        )
+        return
+
+    try:
+        if data.startswith("jrnl_save_"):
+            batch_id = data.replace("jrnl_save_", "")
+            result = await journal_service.confirm_batch(db, user_id, batch_id)
+            saved = result["saved"]
+            dup = result["duplicates"]
+            if saved == 0 and dup == 0:
+                text = "⚠️ Нечего сохранять (батч не найден или уже обработан)."
+            else:
+                text = f"✅ Сохранено сделок: {saved}"
+                if dup:
+                    text += f"\n♻️ Пропущено дубликатов: {dup}"
+            await telegram_service.answer_callback_query(
+                callback_query.id, "Готово"
+            )
+            if chat_id:
+                await telegram_service.send_message(chat_id, text, parse_mode="HTML")
+
+        elif data.startswith("jrnl_cancel_"):
+            batch_id = data.replace("jrnl_cancel_", "")
+            removed = await journal_service.discard_batch(db, user_id, batch_id)
+            await telegram_service.answer_callback_query(
+                callback_query.id, "Отменено"
+            )
+            if chat_id:
+                await telegram_service.send_message(
+                    chat_id,
+                    f"❌ Отменено. Сделки не сохранены (удалено: {removed}).",
+                )
+    except Exception as e:
+        logger.error("Failed to handle journal callback", error=str(e), exc_info=True)
+        await telegram_service.answer_callback_query(
+            callback_query.id, "Ошибка при обработке"
+        )
+
+
 async def _process_callback_data(
     callback_query,
     telegram_service: TelegramService,
@@ -452,6 +627,10 @@ async def _process_callback_data(
 ):
     """Process callback data."""
     data = callback_query.data
+
+    if data.startswith("jrnl_"):
+        await _handle_journal_callback(callback_query, telegram_service, db)
+        return
 
     if data.startswith("currency_"):
         currency = data.replace("currency_", "")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -50,6 +50,10 @@ class TelegramSettings(BaseSettings):
     webhook_url: Optional[str] = Field(default=None, description="Webhook URL")
     webhook_secret: Optional[str] = Field(default=None, description="Webhook secret")
     chat_id: Optional[str] = Field(default=None, description="Default chat ID")
+    owner_id: Optional[int] = Field(
+        default=540529430,
+        description="Telegram user id allowed to use the private trade journal",
+    )
 
     model_config = SettingsConfigDict(env_prefix="TELEGRAM_")
 

--- a/app/database/models.py
+++ b/app/database/models.py
@@ -156,6 +156,47 @@ class ChartModel(Base):
     )
 
 
+class TradeModel(Base):
+    """Trade journal entry parsed from a MetaTrader screenshot."""
+
+    __tablename__ = "trades"
+
+    id = Column(Integer, primary_key=True, index=True)
+    telegram_id = Column(Integer, nullable=False, index=True)  # owner of the trade
+
+    # MetaTrader order identity (used for de-duplication per user)
+    ticket = Column(String(50), nullable=True, index=True)
+
+    symbol = Column(String(20), nullable=False, index=True)
+    direction = Column(String(10), nullable=True)  # buy / sell
+    volume = Column(Float, nullable=True)  # lots
+
+    open_price = Column(Float, nullable=True)
+    close_price = Column(Float, nullable=True)
+    open_time = Column(DateTime(timezone=True), nullable=True)
+    close_time = Column(DateTime(timezone=True), nullable=True, index=True)
+
+    sl = Column(Float, nullable=True)  # Stop Loss level
+    tp = Column(Float, nullable=True)  # Take Profit level
+
+    profit = Column(Float, default=0.0)  # net result in account currency
+    swap = Column(Float, default=0.0)
+    commission = Column(Float, default=0.0)
+    taxes = Column(Float, default=0.0)
+
+    closed_by_sl = Column(Boolean, default=False)  # the "[sl]" marker in MT4
+
+    # Confirmation workflow: pending -> confirmed (or row deleted on cancel)
+    status = Column(String(20), default="pending", index=True)
+    batch_id = Column(String(40), nullable=True, index=True)
+
+    # Timestamps
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+
 class APILogModel(Base):
     """API request logging model."""
 

--- a/app/models/telegram.py
+++ b/app/models/telegram.py
@@ -1,6 +1,6 @@
 """Telegram-related Pydantic models."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -28,24 +28,44 @@ class TelegramChat(BaseModel):
     last_name: Optional[str] = Field(default=None, description="Last name")
 
 
+class TelegramPhotoSize(BaseModel):
+    """Telegram photo size model (one entry per available resolution)."""
+
+    file_id: str = Field(description="File identifier")
+    file_unique_id: Optional[str] = Field(default=None, description="Unique file id")
+    width: Optional[int] = Field(default=None, description="Photo width")
+    height: Optional[int] = Field(default=None, description="Photo height")
+    file_size: Optional[int] = Field(default=None, description="File size in bytes")
+
+
 class TelegramMessage(BaseModel):
     """Telegram message model."""
 
     message_id: int = Field(description="Message ID")
-    from_user: Optional[TelegramUser] = Field(default=None, description="From user")
+    from_user: Optional[TelegramUser] = Field(
+        default=None, alias="from", description="From user"
+    )
     chat: TelegramChat = Field(description="Chat")
     date: int = Field(description="Message date")
     text: Optional[str] = Field(default=None, description="Message text")
+    caption: Optional[str] = Field(default=None, description="Media caption")
+    photo: Optional[List[TelegramPhotoSize]] = Field(
+        default=None, description="Available sizes of the attached photo"
+    )
     entities: Optional[list] = Field(default=None, description="Message entities")
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class TelegramCallbackQuery(BaseModel):
     """Telegram callback query model."""
 
     id: str = Field(description="Callback query ID")
-    from_user: TelegramUser = Field(description="From user")
+    from_user: TelegramUser = Field(alias="from", description="From user")
     message: Optional[TelegramMessage] = Field(default=None, description="Message")
     data: Optional[str] = Field(default=None, description="Callback data")
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class TelegramUpdate(BaseModel):

--- a/app/services/journal_service.py
+++ b/app/services/journal_service.py
@@ -1,0 +1,438 @@
+"""Trade journal service.
+
+Parses MetaTrader history screenshots with OpenAI Vision, stores the trades in
+the database behind a confirmation step, and produces trading statistics for the
+`/journal` command.
+"""
+
+import base64
+import json
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import httpx
+import structlog
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.database.models import TradeModel
+
+logger = structlog.get_logger(__name__)
+
+
+# Keys we expect back from the vision model for every parsed trade.
+_TRADE_KEYS = (
+    "ticket",
+    "symbol",
+    "direction",
+    "volume",
+    "open_price",
+    "close_price",
+    "open_time",
+    "close_time",
+    "sl",
+    "tp",
+    "profit",
+    "swap",
+    "commission",
+    "taxes",
+    "closed_by_sl",
+)
+
+_VISION_PROMPT = (
+    "You are a precise data extraction engine for MetaTrader 4/5 trade history "
+    "screenshots. Extract EVERY closed trade visible in the image.\n\n"
+    "Each trade block typically looks like:\n"
+    "  SYMBOL, buy/sell VOLUME        CLOSE_DATE CLOSE_TIME\n"
+    "  OPEN_PRICE -> CLOSE_PRICE                 PROFIT\n"
+    "  OPEN_DATE OPEN_TIME, [sl]\n"
+    "  S/L: ...   Swap: ...\n"
+    "  T/P: ...   Taxes: ...\n"
+    "  ID: TICKET  Commission: ...\n\n"
+    "Return STRICT JSON only, no markdown, in the shape:\n"
+    '{"trades": [{'
+    '"ticket": string|null, '
+    '"symbol": string, '
+    '"direction": "buy"|"sell"|null, '
+    '"volume": number|null, '
+    '"open_price": number|null, '
+    '"close_price": number|null, '
+    '"open_time": "YYYY-MM-DD HH:MM:SS"|null, '
+    '"close_time": "YYYY-MM-DD HH:MM:SS"|null, '
+    '"sl": number|null, '
+    '"tp": number|null, '
+    '"profit": number|null, '
+    '"swap": number|null, '
+    '"commission": number|null, '
+    '"taxes": number|null, '
+    '"closed_by_sl": boolean'
+    "}]}\n\n"
+    "Rules:\n"
+    "- The 'A -> B' line means open_price=A, close_price=B.\n"
+    "- profit is the colored number on the right of the close date (may be negative).\n"
+    "- closed_by_sl is true when the '[sl]' marker is present near the open time.\n"
+    "- Remove thousands separators/spaces from numbers (e.g. '1 814.32' -> 1814.32).\n"
+    "- Use null for anything not visible. Do not invent values."
+)
+
+
+class JournalService:
+    """Business logic for the personal trade journal."""
+
+    def __init__(self) -> None:
+        self.api_key = settings.api.openai_api_key
+        self.model = settings.api.openai_model or "gpt-4o-mini"
+        self.vision_url = "https://api.openai.com/v1/chat/completions"
+
+    # ------------------------------------------------------------------ #
+    # Screenshot parsing                                                 #
+    # ------------------------------------------------------------------ #
+    async def parse_screenshot(self, image_bytes: bytes) -> List[Dict[str, Any]]:
+        """Extract a list of normalized trade dicts from a screenshot."""
+        if not self.api_key:
+            logger.error("OpenAI API key not configured; cannot parse screenshot")
+            raise RuntimeError("OpenAI API key not configured")
+
+        b64 = base64.b64encode(image_bytes).decode("ascii")
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": _VISION_PROMPT},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/png;base64,{b64}",
+                                "detail": "high",
+                            },
+                        },
+                    ],
+                }
+            ],
+            "max_tokens": 2000,
+            "temperature": 0,
+            "response_format": {"type": "json_object"},
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self.vision_url, headers=headers, json=payload, timeout=90.0
+            )
+            response.raise_for_status()
+            result = response.json()
+
+        content = result["choices"][0]["message"]["content"]
+        data = json.loads(content)
+        raw_trades = data.get("trades", []) if isinstance(data, dict) else []
+        return [self._normalize(t) for t in raw_trades if isinstance(t, dict)]
+
+    def _normalize(self, raw: Dict[str, Any]) -> Dict[str, Any]:
+        """Coerce a raw parsed trade into typed values."""
+        trade: Dict[str, Any] = {k: raw.get(k) for k in _TRADE_KEYS}
+
+        # Strings
+        trade["ticket"] = self._as_str(trade.get("ticket"))
+        trade["symbol"] = (self._as_str(trade.get("symbol")) or "UNKNOWN").upper()
+        direction = self._as_str(trade.get("direction"))
+        trade["direction"] = direction.lower() if direction else None
+
+        # Numbers
+        for key in ("volume", "open_price", "close_price", "sl", "tp"):
+            trade[key] = self._as_float(trade.get(key))
+        for key in ("profit", "swap", "commission", "taxes"):
+            trade[key] = self._as_float(trade.get(key)) or 0.0
+
+        # Dates
+        trade["open_time"] = self._as_dt(trade.get("open_time"))
+        trade["close_time"] = self._as_dt(trade.get("close_time"))
+
+        trade["closed_by_sl"] = bool(trade.get("closed_by_sl"))
+        return trade
+
+    @staticmethod
+    def _as_str(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _as_float(value: Any) -> Optional[float]:
+        if value is None or value == "":
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        cleaned = str(value).replace(" ", "").replace(",", "")
+        try:
+            return float(cleaned)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _as_dt(value: Any) -> Optional[datetime]:
+        if not value:
+            return None
+        text = str(value).strip().replace("/", "-").replace(".", "-")
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M", "%Y-%m-%d"):
+            try:
+                return datetime.strptime(text, fmt)
+            except ValueError:
+                continue
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Persistence (confirmation workflow)                                #
+    # ------------------------------------------------------------------ #
+    async def save_pending_batch(
+        self, db: AsyncSession, telegram_id: int, trades: List[Dict[str, Any]]
+    ) -> str:
+        """Persist parsed trades as a pending batch, return its batch id."""
+        batch_id = uuid.uuid4().hex[:16]
+        for t in trades:
+            db.add(
+                TradeModel(
+                    telegram_id=telegram_id,
+                    ticket=t.get("ticket"),
+                    symbol=t.get("symbol") or "UNKNOWN",
+                    direction=t.get("direction"),
+                    volume=t.get("volume"),
+                    open_price=t.get("open_price"),
+                    close_price=t.get("close_price"),
+                    open_time=t.get("open_time"),
+                    close_time=t.get("close_time"),
+                    sl=t.get("sl"),
+                    tp=t.get("tp"),
+                    profit=t.get("profit") or 0.0,
+                    swap=t.get("swap") or 0.0,
+                    commission=t.get("commission") or 0.0,
+                    taxes=t.get("taxes") or 0.0,
+                    closed_by_sl=bool(t.get("closed_by_sl")),
+                    status="pending",
+                    batch_id=batch_id,
+                )
+            )
+        await db.commit()
+        return batch_id
+
+    async def confirm_batch(
+        self, db: AsyncSession, telegram_id: int, batch_id: str
+    ) -> Dict[str, int]:
+        """Confirm a pending batch, dropping duplicates by ticket.
+
+        Returns {"saved": n, "duplicates": m}.
+        """
+        result = await db.execute(
+            select(TradeModel).where(
+                TradeModel.telegram_id == telegram_id,
+                TradeModel.batch_id == batch_id,
+                TradeModel.status == "pending",
+            )
+        )
+        pending = list(result.scalars().all())
+        if not pending:
+            return {"saved": 0, "duplicates": 0}
+
+        # Existing confirmed tickets for this user (for de-duplication).
+        existing_result = await db.execute(
+            select(TradeModel.ticket).where(
+                TradeModel.telegram_id == telegram_id,
+                TradeModel.status == "confirmed",
+                TradeModel.ticket.isnot(None),
+            )
+        )
+        existing_tickets = {t for (t,) in existing_result.all() if t}
+
+        saved = 0
+        duplicates = 0
+        seen_in_batch: set = set()
+        for trade in pending:
+            ticket = trade.ticket
+            if ticket and (ticket in existing_tickets or ticket in seen_in_batch):
+                await db.delete(trade)
+                duplicates += 1
+                continue
+            trade.status = "confirmed"
+            if ticket:
+                seen_in_batch.add(ticket)
+            saved += 1
+
+        await db.commit()
+        return {"saved": saved, "duplicates": duplicates}
+
+    async def discard_batch(
+        self, db: AsyncSession, telegram_id: int, batch_id: str
+    ) -> int:
+        """Delete a pending batch. Returns number of rows removed."""
+        result = await db.execute(
+            delete(TradeModel).where(
+                TradeModel.telegram_id == telegram_id,
+                TradeModel.batch_id == batch_id,
+                TradeModel.status == "pending",
+            )
+        )
+        await db.commit()
+        return result.rowcount or 0
+
+    # ------------------------------------------------------------------ #
+    # Statistics                                                         #
+    # ------------------------------------------------------------------ #
+    async def get_stats(self, db: AsyncSession, telegram_id: int) -> Dict[str, Any]:
+        """Compute journal statistics for a user's confirmed trades."""
+        result = await db.execute(
+            select(TradeModel)
+            .where(
+                TradeModel.telegram_id == telegram_id,
+                TradeModel.status == "confirmed",
+            )
+            .order_by(TradeModel.close_time.desc().nullslast())
+        )
+        trades = list(result.scalars().all())
+
+        total = len(trades)
+        if total == 0:
+            return {"total": 0}
+
+        def net(t: TradeModel) -> float:
+            return (
+                (t.profit or 0.0)
+                + (t.swap or 0.0)
+                + (t.commission or 0.0)
+                - (t.taxes or 0.0)
+            )
+
+        wins = [t for t in trades if net(t) > 0]
+        losses = [t for t in trades if net(t) < 0]
+        total_net = sum(net(t) for t in trades)
+        gross_profit = sum(net(t) for t in wins)
+        gross_loss = sum(net(t) for t in losses)  # negative
+
+        by_symbol: Dict[str, Dict[str, Any]] = {}
+        for t in trades:
+            s = by_symbol.setdefault(
+                t.symbol or "UNKNOWN",
+                {"count": 0, "wins": 0, "net": 0.0},
+            )
+            s["count"] += 1
+            s["net"] += net(t)
+            if net(t) > 0:
+                s["wins"] += 1
+
+        return {
+            "total": total,
+            "wins": len(wins),
+            "losses": len(losses),
+            "win_rate": (len(wins) / total * 100.0) if total else 0.0,
+            "total_net": total_net,
+            "gross_profit": gross_profit,
+            "gross_loss": gross_loss,
+            "profit_factor": (
+                gross_profit / abs(gross_loss) if gross_loss else None
+            ),
+            "best": max((net(t) for t in trades), default=0.0),
+            "worst": min((net(t) for t in trades), default=0.0),
+            "by_symbol": by_symbol,
+            "recent": trades[:5],
+        }
+
+    # ------------------------------------------------------------------ #
+    # Formatting (HTML)                                                  #
+    # ------------------------------------------------------------------ #
+    def format_preview(self, trades: List[Dict[str, Any]]) -> str:
+        """Human-readable preview of parsed trades before saving."""
+        if not trades:
+            return (
+                "🔍 На скриншоте не удалось распознать ни одной сделки.\n"
+                "Попробуй прислать более чёткий скрин истории MT4."
+            )
+
+        lines = [f"📸 <b>Распознано сделок: {len(trades)}</b>\n"]
+        total = 0.0
+        for i, t in enumerate(trades, 1):
+            profit = t.get("profit") or 0.0
+            total += profit
+            emoji = "🟢" if profit > 0 else ("🔴" if profit < 0 else "⚪️")
+            direction = (t.get("direction") or "?").upper()
+            vol = t.get("volume")
+            vol_str = f"{vol:g}" if vol is not None else "?"
+            op = self._fmt_price(t.get("open_price"))
+            cp = self._fmt_price(t.get("close_price"))
+            sl_mark = " 🛑SL" if t.get("closed_by_sl") else ""
+            ct = t.get("close_time")
+            ct_str = ct.strftime("%Y.%m.%d %H:%M") if ct else "—"
+            lines.append(
+                f"{i}. {emoji} <b>{t.get('symbol')}</b> {direction} {vol_str} "
+                f"| {op} → {cp} | <b>{profit:+.2f}</b>{sl_mark}\n"
+                f"    🎫 {t.get('ticket') or '—'} · {ct_str}"
+            )
+        lines.append(f"\n💰 <b>Итог по батчу: {total:+.2f}</b>")
+        lines.append("\nСохранить эти сделки в журнал?")
+        return "\n".join(lines)
+
+    def format_journal(self, stats: Dict[str, Any]) -> str:
+        """Format the /journal statistics message."""
+        if stats.get("total", 0) == 0:
+            return (
+                "📓 <b>Журнал сделок пуст</b>\n\n"
+                "Пришли скриншот истории сделок из MetaTrader — "
+                "я распознаю и сохраню их сюда."
+            )
+
+        win_rate = stats["win_rate"]
+        pf = stats.get("profit_factor")
+        pf_str = f"{pf:.2f}" if pf is not None else "∞"
+        total_net = stats["total_net"]
+        result_emoji = "🟢" if total_net >= 0 else "🔴"
+
+        lines = [
+            "📓 <b>Журнал сделок</b>",
+            "━━━━━━━━━━━━━━━━━━━━",
+            f"{result_emoji} <b>Итоговый P/L:</b> {total_net:+.2f}",
+            f"📊 <b>Всего сделок:</b> {stats['total']}",
+            f"✅ <b>Прибыльных:</b> {stats['wins']}   "
+            f"❌ <b>Убыточных:</b> {stats['losses']}",
+            f"🎯 <b>Win rate:</b> {win_rate:.1f}%",
+            f"⚖️ <b>Profit factor:</b> {pf_str}",
+            f"🏆 <b>Лучшая:</b> {stats['best']:+.2f}   "
+            f"💥 <b>Худшая:</b> {stats['worst']:+.2f}",
+        ]
+
+        by_symbol = stats.get("by_symbol", {})
+        if by_symbol:
+            lines.append("\n<b>По символам:</b>")
+            for sym, s in sorted(
+                by_symbol.items(), key=lambda kv: kv[1]["net"], reverse=True
+            ):
+                wr = (s["wins"] / s["count"] * 100.0) if s["count"] else 0.0
+                se = "🟢" if s["net"] >= 0 else "🔴"
+                lines.append(
+                    f"  {se} <b>{sym}</b>: {s['net']:+.2f} "
+                    f"({s['count']} сд., WR {wr:.0f}%)"
+                )
+
+        recent = stats.get("recent", [])
+        if recent:
+            lines.append("\n<b>Последние сделки:</b>")
+            for t in recent:
+                profit = t.profit or 0.0
+                emoji = "🟢" if profit > 0 else ("🔴" if profit < 0 else "⚪️")
+                ct = t.close_time.strftime("%m.%d %H:%M") if t.close_time else "—"
+                direction = (t.direction or "?").upper()
+                lines.append(
+                    f"  {emoji} {t.symbol} {direction} {profit:+.2f} · {ct}"
+                )
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _fmt_price(value: Optional[float]) -> str:
+        if value is None:
+            return "—"
+        return f"{value:g}"

--- a/app/services/telegram_service.py
+++ b/app/services/telegram_service.py
@@ -341,12 +341,18 @@ class TelegramBotManager:
         return text
 
     async def send_message(
-        self, chat_id: int, message: str, parse_mode: str = "MarkdownV2"
+        self,
+        chat_id: int,
+        message: str,
+        parse_mode: str = "MarkdownV2",
+        reply_markup: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """Send a message to a Telegram chat."""
         try:
             url = f"{self.base_url}/sendMessage"
             data = {"chat_id": chat_id, "text": message, "parse_mode": parse_mode}
+            if reply_markup:
+                data["reply_markup"] = reply_markup
 
             async with httpx.AsyncClient() as client:
                 response = await client.post(url, json=data)
@@ -358,6 +364,42 @@ class TelegramBotManager:
         except httpx.HTTPError as e:
             logger.error("Failed to send message", chat_id=chat_id, error=str(e))
             raise TelegramError(f"Failed to send message: {e}")
+
+    async def get_file(self, file_id: str) -> Optional[str]:
+        """Resolve a file_id to a downloadable file path via getFile."""
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.base_url}/getFile",
+                    params={"file_id": file_id},
+                    timeout=15.0,
+                )
+                response.raise_for_status()
+                result = response.json()
+                if result.get("ok"):
+                    return result["result"].get("file_path")
+                logger.error("getFile returned not ok", result=result)
+                return None
+        except Exception as e:
+            logger.error("Failed to get file", file_id=file_id, error=str(e))
+            return None
+
+    async def download_file(self, file_id: str) -> Optional[bytes]:
+        """Download a Telegram file's bytes by file_id."""
+        try:
+            file_path = await self.get_file(file_id)
+            if not file_path:
+                return None
+            download_url = (
+                f"https://api.telegram.org/file/bot{self.bot_token}/{file_path}"
+            )
+            async with httpx.AsyncClient() as client:
+                response = await client.get(download_url, timeout=30.0)
+                response.raise_for_status()
+                return response.content
+        except Exception as e:
+            logger.error("Failed to download file", file_id=file_id, error=str(e))
+            return None
 
     async def get_webhook_info(self) -> Dict[str, Any]:
         """Get webhook information."""
@@ -591,14 +633,43 @@ class TelegramService:
             raise
 
     async def send_message(
-        self, chat_id: int, message: str, parse_mode: str = "MarkdownV2"
+        self,
+        chat_id: int,
+        message: str,
+        parse_mode: str = "MarkdownV2",
+        reply_markup: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """Send a message to a Telegram chat."""
         try:
-            return await self.bot_manager.send_message(chat_id, message, parse_mode)
+            return await self.bot_manager.send_message(
+                chat_id, message, parse_mode, reply_markup
+            )
         except Exception as e:
             logger.error("Failed to send message", chat_id=chat_id, error=str(e))
             return False
+
+    async def answer_callback_query(
+        self,
+        callback_query_id: str,
+        text: Optional[str] = None,
+        show_alert: bool = False,
+    ) -> bool:
+        """Answer a callback query."""
+        try:
+            return await self.bot_manager.answer_callback_query(
+                callback_query_id, text, show_alert
+            )
+        except Exception as e:
+            logger.error("Failed to answer callback query", error=str(e))
+            return False
+
+    async def download_file(self, file_id: str) -> Optional[bytes]:
+        """Download a Telegram file's bytes by file_id."""
+        try:
+            return await self.bot_manager.download_file(file_id)
+        except Exception as e:
+            logger.error("Failed to download file", file_id=file_id, error=str(e))
+            return None
 
     async def send_formatted_message(self, chat_id: int, message: str) -> bool:
         """Send a formatted message to a Telegram chat."""

--- a/env.example
+++ b/env.example
@@ -19,6 +19,9 @@ REDIS_URL=redis://localhost:6379/0
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 TELEGRAM_WEBHOOK_URL=https://yourdomain.com/api/v1/telegram/webhook
 TELEGRAM_WEBHOOK_SECRET=your_webhook_secret_here
+# Numeric Telegram user id allowed to use the private trade journal (/journal).
+# Leave empty to allow everyone.
+TELEGRAM_OWNER_ID=540529430
 
 # API Keys
 API_ALPHA_VANTAGE_KEY=your_alpha_vantage_key_here

--- a/tests/test_services/test_journal_service.py
+++ b/tests/test_services/test_journal_service.py
@@ -1,0 +1,196 @@
+"""Tests for JournalService (MT4 screenshot trade journal)."""
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.database.models import Base
+from app.services.journal_service import JournalService
+
+OWNER_ID = 540529430
+
+
+@pytest.fixture
+def journal_service():
+    svc = JournalService()
+    svc.api_key = "test-key"  # ensure parsing path is enabled
+    return svc
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+def _sample():
+    return [
+        {
+            "ticket": "71119736",
+            "symbol": "usdjpy",
+            "direction": "buy",
+            "volume": 0.13,
+            "open_price": "160.012",
+            "close_price": "160.079",
+            "open_time": "2026.06.08 11:57:29",
+            "close_time": "2026.06.09 00:01:29",
+            "sl": "160.079",
+            "tp": "160.400",
+            "profit": "4.71",
+            "swap": "0.71",
+            "closed_by_sl": True,
+        },
+        {
+            "ticket": "71136415",
+            "symbol": "gbpusd",
+            "direction": "sell",
+            "volume": 0.13,
+            "open_price": "1.34018",
+            "close_price": "1.34122",
+            "close_time": "2026.06.10 16:35:20",
+            "profit": "-11.69",
+            "closed_by_sl": True,
+        },
+    ]
+
+
+class TestNormalize:
+    def test_numeric_and_thousands_separators(self, journal_service):
+        t = journal_service._normalize(
+            {"symbol": "ethusd", "open_price": "1 814.32", "profit": "-9.40"}
+        )
+        assert t["symbol"] == "ETHUSD"
+        assert t["open_price"] == 1814.32
+        assert t["profit"] == -9.40
+
+    def test_missing_values_become_none_or_zero(self, journal_service):
+        t = journal_service._normalize({"symbol": "btcusd"})
+        assert t["open_price"] is None
+        assert t["profit"] == 0.0  # money fields default to 0
+        assert t["closed_by_sl"] is False
+
+    def test_datetime_parsing(self, journal_service):
+        t = journal_service._normalize({"symbol": "x", "close_time": "2026.06.09 00:01:29"})
+        assert t["close_time"] == datetime(2026, 6, 9, 0, 1, 29)
+
+    def test_symbol_defaults_when_absent(self, journal_service):
+        t = journal_service._normalize({})
+        assert t["symbol"] == "UNKNOWN"
+
+
+class TestPersistence:
+    @pytest.mark.asyncio
+    async def test_save_confirm_and_stats(self, journal_service, db_session):
+        norm = [journal_service._normalize(t) for t in _sample()]
+        batch = await journal_service.save_pending_batch(db_session, OWNER_ID, norm)
+
+        result = await journal_service.confirm_batch(db_session, OWNER_ID, batch)
+        assert result == {"saved": 2, "duplicates": 0}
+
+        stats = await journal_service.get_stats(db_session, OWNER_ID)
+        assert stats["total"] == 2
+        assert stats["wins"] == 1
+        assert stats["losses"] == 1
+        # 4.71 + 0.71 swap - 11.69 = -6.27
+        assert round(stats["total_net"], 2) == -6.27
+
+    @pytest.mark.asyncio
+    async def test_confirm_deduplicates_by_ticket(self, journal_service, db_session):
+        norm = [journal_service._normalize(t) for t in _sample()]
+        b1 = await journal_service.save_pending_batch(db_session, OWNER_ID, norm)
+        await journal_service.confirm_batch(db_session, OWNER_ID, b1)
+
+        # Same trades again -> all duplicates
+        b2 = await journal_service.save_pending_batch(db_session, OWNER_ID, norm)
+        result = await journal_service.confirm_batch(db_session, OWNER_ID, b2)
+        assert result == {"saved": 0, "duplicates": 2}
+
+        stats = await journal_service.get_stats(db_session, OWNER_ID)
+        assert stats["total"] == 2  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_discard_removes_pending(self, journal_service, db_session):
+        norm = [journal_service._normalize(t) for t in _sample()]
+        batch = await journal_service.save_pending_batch(db_session, OWNER_ID, norm)
+
+        removed = await journal_service.discard_batch(db_session, OWNER_ID, batch)
+        assert removed == 2
+
+        stats = await journal_service.get_stats(db_session, OWNER_ID)
+        assert stats.get("total", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_pending_not_counted_in_stats(self, journal_service, db_session):
+        norm = [journal_service._normalize(t) for t in _sample()]
+        await journal_service.save_pending_batch(db_session, OWNER_ID, norm)
+        # No confirm -> nothing confirmed
+        stats = await journal_service.get_stats(db_session, OWNER_ID)
+        assert stats.get("total", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_stats_isolated_per_user(self, journal_service, db_session):
+        norm = [journal_service._normalize(t) for t in _sample()]
+        b = await journal_service.save_pending_batch(db_session, OWNER_ID, norm)
+        await journal_service.confirm_batch(db_session, OWNER_ID, b)
+
+        other_stats = await journal_service.get_stats(db_session, 111)
+        assert other_stats.get("total", 0) == 0
+
+
+class TestFormatting:
+    def test_empty_preview(self, journal_service):
+        text = journal_service.format_preview([])
+        assert "не удалось распознать" in text
+
+    def test_preview_has_totals(self, journal_service):
+        norm = [journal_service._normalize(t) for t in _sample()]
+        text = journal_service.format_preview(norm)
+        assert "Распознано сделок: 2" in text
+        assert "USDJPY" in text and "GBPUSD" in text
+
+    def test_journal_empty(self, journal_service):
+        assert "пуст" in journal_service.format_journal({"total": 0})
+
+
+class TestParseScreenshot:
+    @pytest.mark.asyncio
+    async def test_parse_screenshot_uses_vision_response(self, journal_service):
+        api_payload = {
+            "choices": [
+                {"message": {"content": json.dumps({"trades": _sample()})}}
+            ]
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = api_payload
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = False
+
+        with patch("app.services.journal_service.httpx.AsyncClient", return_value=mock_client):
+            trades = await journal_service.parse_screenshot(b"fake-image-bytes")
+
+        assert len(trades) == 2
+        assert trades[0]["symbol"] == "USDJPY"
+        assert trades[0]["open_price"] == 160.012
+
+    @pytest.mark.asyncio
+    async def test_parse_screenshot_without_api_key_raises(self, journal_service):
+        journal_service.api_key = None
+        with pytest.raises(RuntimeError):
+            await journal_service.parse_screenshot(b"x")


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Adds a personal **trade journal** to the Telegram bot. The owner sends a screenshot of MetaTrader 4/5 trade history and the bot:
1. Parses **every** closed trade via OpenAI Vision (`gpt-4o-mini`): symbol, direction, volume, open/close price & time, S/L, T/P, profit, swap, commission, taxes, ticket, and the `[sl]` marker.
2. Replies with a **preview** and **💾 Сохранить / ❌ Отмена** buttons — nothing is written until confirmed.
3. On confirm, stores trades in a new `trades` table (de-duplicated by ticket).
4. `/journal` shows aggregate stats: total P/L, win rate, profit factor, best/worst trade, per-symbol breakdown, and recent trades.

Access is gated by `TELEGRAM_OWNER_ID` (empty → open to all).

**Latent bugs fixed along the way:**
- `TelegramMessage.from_user` was always `None` (Telegram sends `from`); added `alias="from"` + `populate_by_name`. This also un-breaks the existing inline menus (`/settings`, etc.).
- `send_message` now accepts `reply_markup`, so inline keyboards actually work.

### Why is this change needed?
The user wants to log trades by simply forwarding MT4 mobile screenshots and review performance statistics inside the bot.

### How was this tested?
- [x] Unit tests added/updated — new `tests/test_services/test_journal_service.py` (14 tests: normalization, save/confirm/dedup/discard, per-user isolation, stats, formatting, Vision parsing with a mocked API).
- [ ] Integration tests added/updated
- [x] Manual testing performed — validated end-to-end flow against an in-memory SQLite DB (save → confirm → dedup → stats) and the sample screenshot data.
- [ ] Performance testing (if applicable)

Full suite: **285 passed**, 1 skipped, 11 failed. The 11 failures are **pre-existing** in `tests/test_services/test_telegram_service.py` and fail identically on `master` before this branch (verified by stashing). flake8 clean on all changed files.

### Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of the code has been performed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Corresponding changes to documentation have been made (README + `env.example`)
- [x] Changes generate no new warnings
- [x] Tests pass locally
- [x] New and existing unit tests pass locally
- [ ] Any dependent changes have been merged and published

### Breaking Changes
- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

New `trades` table is created automatically at startup via `Base.metadata.create_all` — no manual migration required.

### Additional Notes
- Requires `API_OPENAI_API_KEY` for screenshot parsing; without it the bot replies that recognition is unavailable (no crash).
- Net result in stats = `profit + swap + commission − taxes`.
- New files: `app/services/journal_service.py`, `tests/test_services/test_journal_service.py`. Webhook handlers added in `app/api/v1/endpoints/telegram.py`; `TradeModel` in `app/database/models.py`; `photo`/`caption` fields in `app/models/telegram.py`; `get_file`/`download_file` + `reply_markup` in `app/services/telegram_service.py`; `owner_id` in `app/core/config.py`.

### Related Issues
N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)