### PR TITLE
Trade journal: English UI + robust de-duplication (follow-up to #38)

### DIFF
--- a/app/services/smc/db.py
+++ b/app/services/smc/db.py
@@ -237,13 +237,6 @@ class Database:
         ).fetchall()
         return [dict(row) for row in rows]
 
-    def confirmed_tickets(self) -> set:
-        rows = self.conn.execute(
-            "SELECT ticket FROM trades "
-            "WHERE status = 'confirmed' AND ticket IS NOT NULL"
-        ).fetchall()
-        return {row["ticket"] for row in rows if row["ticket"]}
-
     def trade_set_status(self, trade_id: str, status: str) -> None:
         with self.conn:
             self.conn.execute(

--- a/app/services/smc/telegram_bot.py
+++ b/app/services/smc/telegram_bot.py
@@ -232,17 +232,17 @@ class TelegramCommandBot:
             return
         if not self.trade_journal.api_key:
             await self.send(
-                "⚠️ Распознавание недоступно: не настроен OPENAI_API_KEY."
+                "⚠️ Recognition unavailable: OPENAI_API_KEY is not configured."
             )
             return
 
-        await self.send("🔍 Распознаю сделки со скриншота, подожди пару секунд...")
+        await self.send("🔍 Recognizing trades from the screenshot, one moment...")
         try:
             # Largest available photo size is the last entry.
             file_id = message["photo"][-1]["file_id"]
             image_bytes = await self._download_file(file_id)
             if not image_bytes:
-                await self.send("❌ Не удалось скачать изображение. Попробуй ещё раз.")
+                await self.send("❌ Could not download the image. Please try again.")
                 return
 
             trades = await self.trade_journal.parse_screenshot(image_bytes)
@@ -254,8 +254,8 @@ class TelegramCommandBot:
             keyboard = {
                 "inline_keyboard": [
                     [
-                        {"text": "💾 Сохранить", "callback_data": f"jrnl_save_{batch_id}"},
-                        {"text": "❌ Отмена", "callback_data": f"jrnl_cancel_{batch_id}"},
+                        {"text": "💾 Save", "callback_data": f"jrnl_save_{batch_id}"},
+                        {"text": "❌ Cancel", "callback_data": f"jrnl_cancel_{batch_id}"},
                     ]
                 ]
             }
@@ -265,8 +265,8 @@ class TelegramCommandBot:
         except Exception as e:
             logger.error("Failed to process screenshot", error=str(e), exc_info=True)
             await self.send(
-                "❌ Ошибка при распознавании скриншота. Попробуй прислать более "
-                "чёткое изображение."
+                "❌ Error while recognizing the screenshot. "
+                "Please send a clearer image."
             )
 
     async def _handle_callback(self, callback: Dict) -> None:
@@ -331,20 +331,20 @@ class TelegramCommandBot:
                 result = self.trade_journal.confirm_batch(batch_id)
                 saved, dup = result["saved"], result["duplicates"]
                 if saved == 0 and dup == 0:
-                    text = "⚠️ Нечего сохранять (батч не найден или уже обработан)."
-                    chosen = "⚠️ Пусто"
+                    text = "⚠️ Nothing to save (batch not found or already processed)."
+                    chosen = "⚠️ Empty"
                 else:
-                    text = f"✅ Сохранено сделок: {saved}"
+                    text = f"✅ Saved trades: {saved}"
                     if dup:
-                        text += f"\n♻️ Пропущено дубликатов: {dup}"
-                    chosen = f"💾 Сохранено ({saved})"
-                answer["text"] = "Готово"
+                        text += f"\n♻️ Skipped duplicates: {dup}"
+                    chosen = f"💾 Saved ({saved})"
+                answer["text"] = "Done"
             else:  # jrnl_cancel_
                 batch_id = data[len("jrnl_cancel_"):]
                 removed = self.trade_journal.discard_batch(batch_id)
-                text = f"❌ Отменено. Сделки не сохранены (удалено: {removed})."
-                chosen = "❌ Отменено"
-                answer["text"] = "Отменено"
+                text = f"❌ Cancelled. Trades were not saved (removed: {removed})."
+                chosen = "❌ Cancelled"
+                answer["text"] = "Cancelled"
 
             if message:
                 await self._api(
@@ -361,7 +361,7 @@ class TelegramCommandBot:
             await self.send(text)
         except Exception as e:
             logger.error("Journal callback failed", error=str(e), exc_info=True)
-            answer["text"] = "Ошибка при обработке"
+            answer["text"] = "Error while processing"
             await self._api("answerCallbackQuery", **answer)
 
     def _pairs_keyboard(self) -> Dict:

--- a/app/services/smc/trade_journal.py
+++ b/app/services/smc/trade_journal.py
@@ -72,6 +72,9 @@ _VISION_PROMPT = (
     "- profit is the colored number on the right of the close date (may be negative).\n"
     "- closed_by_sl is true when the '[sl]' marker is present near the open time.\n"
     "- Remove thousands separators/spaces from numbers (e.g. '1 814.32' -> 1814.32).\n"
+    "- ticket is the numeric order id (the 'ID:' field). The compact history view "
+    "does NOT show it — if no numeric id is visible for a trade, set ticket to "
+    "null. Never output the literal word 'TICKET' or any placeholder.\n"
     "- Use null for anything not visible. Do not invent values."
 )
 
@@ -139,7 +142,7 @@ class TradeJournal:
         """Coerce a raw parsed trade into typed values."""
         trade: Dict[str, Any] = {k: raw.get(k) for k in _TRADE_KEYS}
 
-        trade["ticket"] = self._as_str(trade.get("ticket"))
+        trade["ticket"] = self._clean_ticket(trade.get("ticket"))
         trade["symbol"] = (self._as_str(trade.get("symbol")) or "UNKNOWN").upper()
         direction = self._as_str(trade.get("direction"))
         trade["direction"] = direction.lower() if direction else None
@@ -160,6 +163,40 @@ class TradeJournal:
             return None
         text = str(value).strip()
         return text or None
+
+    @staticmethod
+    def _clean_ticket(value: Any) -> Optional[str]:
+        """Keep only a genuine numeric MT order id; drop placeholders/None.
+
+        The compact history view has no ID column, and the vision model tends to
+        echo the literal word 'TICKET' from the prompt — treat anything that is
+        not all-digits as "no ticket".
+        """
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text if text.isdigit() else None
+
+    @classmethod
+    def _dedup_key(cls, trade: Dict[str, Any]) -> str:
+        """Stable identity for a trade, used to skip duplicates on re-upload.
+
+        Prefer the numeric ticket; when absent (compact view), fall back to a
+        signature of the trade's defining fields so distinct trades are kept but
+        the same screenshot sent twice is de-duplicated.
+        """
+        ticket = cls._clean_ticket(trade.get("ticket"))
+        if ticket:
+            return f"t:{ticket}"
+        parts = [
+            str(trade.get("symbol")),
+            str(trade.get("direction")),
+            str(trade.get("volume")),
+            str(trade.get("open_price")),
+            str(trade.get("close_price")),
+            str(trade.get("close_time")),
+        ]
+        return "s:" + "|".join(parts)
 
     @staticmethod
     def _as_float(value: Any) -> Optional[float]:
@@ -229,7 +266,10 @@ class TradeJournal:
         return batch_id
 
     def confirm_batch(self, batch_id: str) -> Dict[str, int]:
-        """Confirm a pending batch, dropping duplicates by ticket.
+        """Confirm a pending batch, dropping duplicates.
+
+        De-duplication uses the numeric ticket when present, otherwise a
+        signature of the trade's fields (compact history views have no ticket).
 
         Returns {"saved": n, "duplicates": m}.
         """
@@ -237,19 +277,20 @@ class TradeJournal:
         if not pending:
             return {"saved": 0, "duplicates": 0}
 
-        existing_tickets = self.db.confirmed_tickets()
+        existing_keys = {
+            self._dedup_key(t) for t in self.db.trades_by_status("confirmed")
+        }
         saved = 0
         duplicates = 0
         seen_in_batch: set = set()
         for trade in pending:
-            ticket = trade.get("ticket")
-            if ticket and (ticket in existing_tickets or ticket in seen_in_batch):
+            key = self._dedup_key(trade)
+            if key in existing_keys or key in seen_in_batch:
                 self.db.trade_delete(trade["id"])
                 duplicates += 1
                 continue
             self.db.trade_set_status(trade["id"], "confirmed")
-            if ticket:
-                seen_in_batch.add(ticket)
+            seen_in_batch.add(key)
             saved += 1
         return {"saved": saved, "duplicates": duplicates}
 
@@ -317,11 +358,11 @@ class TradeJournal:
     def format_preview(self, trades: List[Dict[str, Any]]) -> str:
         if not trades:
             return (
-                "🔍 На скриншоте не удалось распознать ни одной сделки.\n"
-                "Попробуй прислать более чёткий скрин истории MT4."
+                "🔍 No trades could be recognized in the screenshot.\n"
+                "Try sending a clearer screenshot of the MT4 history."
             )
 
-        lines = [f"📸 <b>Распознано сделок: {len(trades)}</b>\n"]
+        lines = [f"📸 <b>Recognized trades: {len(trades)}</b>\n"]
         total = 0.0
         for i, t in enumerate(trades, 1):
             profit = t.get("profit") or 0.0
@@ -335,21 +376,23 @@ class TradeJournal:
             sl_mark = " 🛑SL" if t.get("closed_by_sl") else ""
             ct = self._parse_dt(t.get("close_time"))
             ct_str = ct.strftime("%Y.%m.%d %H:%M") if ct else "—"
+            ticket = t.get("ticket")
+            ticket_str = f"🎫 {ticket} · " if ticket else ""
             lines.append(
                 f"{i}. {emoji} <b>{t.get('symbol')}</b> {direction} {vol_str} "
                 f"| {op} → {cp} | <b>{profit:+.2f}</b>{sl_mark}\n"
-                f"    🎫 {t.get('ticket') or '—'} · {ct_str}"
+                f"    {ticket_str}{ct_str}"
             )
-        lines.append(f"\n💰 <b>Итог по батчу: {total:+.2f}</b>")
-        lines.append("\nСохранить эти сделки в журнал?")
+        lines.append(f"\n💰 <b>Batch total: {total:+.2f}</b>")
+        lines.append("\nSave these trades to the journal?")
         return "\n".join(lines)
 
     def format_journal(self, stats: Dict[str, Any]) -> str:
         if stats.get("total", 0) == 0:
             return (
-                "📓 <b>Журнал сделок пуст</b>\n\n"
-                "Пришли скриншот истории сделок из MetaTrader — "
-                "я распознаю и сохраню их сюда."
+                "📓 <b>Trade journal is empty</b>\n\n"
+                "Send a screenshot of your MetaTrader history — "
+                "I'll recognize the trades and save them here."
             )
 
         pf = stats.get("profit_factor")
@@ -358,21 +401,21 @@ class TradeJournal:
         result_emoji = "🟢" if total_net >= 0 else "🔴"
 
         lines = [
-            "📓 <b>Журнал сделок</b>",
+            "📓 <b>Trade journal</b>",
             "━━━━━━━━━━━━━━━━━━━━",
-            f"{result_emoji} <b>Итоговый P/L:</b> {total_net:+.2f}",
-            f"📊 <b>Всего сделок:</b> {stats['total']}",
-            f"✅ <b>Прибыльных:</b> {stats['wins']}   "
-            f"❌ <b>Убыточных:</b> {stats['losses']}",
+            f"{result_emoji} <b>Total P/L:</b> {total_net:+.2f}",
+            f"📊 <b>Total trades:</b> {stats['total']}",
+            f"✅ <b>Winners:</b> {stats['wins']}   "
+            f"❌ <b>Losers:</b> {stats['losses']}",
             f"🎯 <b>Win rate:</b> {stats['win_rate']:.1f}%",
             f"⚖️ <b>Profit factor:</b> {pf_str}",
-            f"🏆 <b>Лучшая:</b> {stats['best']:+.2f}   "
-            f"💥 <b>Худшая:</b> {stats['worst']:+.2f}",
+            f"🏆 <b>Best:</b> {stats['best']:+.2f}   "
+            f"💥 <b>Worst:</b> {stats['worst']:+.2f}",
         ]
 
         by_symbol = stats.get("by_symbol", {})
         if by_symbol:
-            lines.append("\n<b>По символам:</b>")
+            lines.append("\n<b>By symbol:</b>")
             for sym, s in sorted(
                 by_symbol.items(), key=lambda kv: kv[1]["net"], reverse=True
             ):
@@ -380,12 +423,12 @@ class TradeJournal:
                 se = "🟢" if s["net"] >= 0 else "🔴"
                 lines.append(
                     f"  {se} <b>{sym}</b>: {s['net']:+.2f} "
-                    f"({s['count']} сд., WR {wr:.0f}%)"
+                    f"({s['count']} trades, WR {wr:.0f}%)"
                 )
 
         recent = stats.get("recent", [])
         if recent:
-            lines.append("\n<b>Последние сделки:</b>")
+            lines.append("\n<b>Recent trades:</b>")
             for t in recent:
                 profit = t.get("profit") or 0.0
                 emoji = "🟢" if profit > 0 else ("🔴" if profit < 0 else "⚪️")

--- a/tests/test_smc/test_trade_journal.py
+++ b/tests/test_smc/test_trade_journal.py
@@ -70,6 +70,16 @@ class TestNormalize:
         tj = _journal(tmp_path)
         assert tj._normalize({})["symbol"] == "UNKNOWN"
 
+    def test_numeric_ticket_kept(self, tmp_path):
+        tj = _journal(tmp_path)
+        assert tj._normalize({"symbol": "x", "ticket": "71119736"})["ticket"] == "71119736"
+
+    def test_placeholder_ticket_dropped(self, tmp_path):
+        tj = _journal(tmp_path)
+        # The vision model tends to echo the literal word from the prompt.
+        assert tj._normalize({"symbol": "x", "ticket": "TICKET"})["ticket"] is None
+        assert tj._normalize({"symbol": "x", "ticket": "ID"})["ticket"] is None
+
 
 class TestPersistence:
     def test_save_confirm_and_stats(self, tmp_path):
@@ -107,27 +117,65 @@ class TestPersistence:
         tj.save_pending_batch(norm)  # no confirm
         assert tj.get_stats().get("total", 0) == 0
 
+    def test_ticketless_trades_not_falsely_deduped(self, tmp_path):
+        # Regression: a compact MT4 view has no ID column, so every trade came
+        # back with the same placeholder ticket and all-but-one were dropped.
+        tj = _journal(tmp_path)
+        raw = [
+            {"symbol": "usdjpy", "direction": "sell", "volume": 0.04,
+             "open_price": "143.857", "close_price": "142.298",
+             "close_time": "2025.04.14 10:02:43", "profit": "38.38",
+             "ticket": "TICKET"},
+            {"symbol": "usdjpy", "direction": "sell", "volume": 0.04,
+             "open_price": "141.654", "close_price": "142.416",
+             "close_time": "2025.04.23 16:47:45", "profit": "-18.84",
+             "ticket": "TICKET"},
+            {"symbol": "usdjpy", "direction": "buy", "volume": 0.04,
+             "open_price": "143.603", "close_price": "143.190",
+             "close_time": "2025.04.28 15:25:14", "profit": "-10.15",
+             "ticket": "TICKET"},
+        ]
+        norm = [tj._normalize(t) for t in raw]
+        result = tj.confirm_batch(tj.save_pending_batch(norm))
+        assert result == {"saved": 3, "duplicates": 0}
+        assert tj.get_stats()["total"] == 3
+
+    def test_same_screenshot_resent_is_deduped_without_ticket(self, tmp_path):
+        tj = _journal(tmp_path)
+        raw = [
+            {"symbol": "usdjpy", "direction": "sell", "volume": 0.04,
+             "open_price": "143.857", "close_price": "142.298",
+             "close_time": "2025.04.14 10:02:43", "profit": "38.38"},
+        ]
+        norm = [tj._normalize(t) for t in raw]
+        tj.confirm_batch(tj.save_pending_batch(norm))
+        # Same trade again (no ticket) -> caught by signature.
+        result = tj.confirm_batch(tj.save_pending_batch(norm))
+        assert result == {"saved": 0, "duplicates": 1}
+        assert tj.get_stats()["total"] == 1
+
 
 class TestFormatting:
     def test_empty_preview(self, tmp_path):
-        assert "не удалось распознать" in _journal(tmp_path).format_preview([])
+        assert "No trades could be recognized" in _journal(tmp_path).format_preview([])
 
     def test_preview_has_totals(self, tmp_path):
         tj = _journal(tmp_path)
         norm = [tj._normalize(t) for t in _sample()]
         text = tj.format_preview(norm)
-        assert "Распознано сделок: 2" in text
+        assert "Recognized trades: 2" in text
         assert "USDJPY" in text and "GBPUSD" in text
+        assert "Batch total" in text
 
     def test_journal_empty(self, tmp_path):
-        assert "пуст" in _journal(tmp_path).format_journal({"total": 0})
+        assert "empty" in _journal(tmp_path).format_journal({"total": 0})
 
     def test_stats_text_after_confirm(self, tmp_path):
         tj = _journal(tmp_path)
         norm = [tj._normalize(t) for t in _sample()]
         tj.confirm_batch(tj.save_pending_batch(norm))
         text = tj.stats_text()
-        assert "Журнал сделок" in text
+        assert "Trade journal" in text
         assert "Win rate" in text
 
 


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Follow-up to the merged #38. Fixes two issues found on the first real screenshot (a **compact** MT4 history view, which has no ID column):

1. **De-duplication no longer collapses distinct trades.** The vision model echoed the literal placeholder `TICKET` as the ticket for every row, so a batch of 12 trades saved 1 and dropped 11 as "duplicates". Now:
   - non-numeric tickets are discarded (`TICKET`, `ID`, … → no ticket);
   - trades without a numeric ticket are de-duplicated by a **signature** (symbol / direction / volume / open & close price / close_time) instead;
   - distinct trades are kept, and the same screenshot re-sent is still de-duplicated;
   - the vision prompt now explicitly returns `null` when no numeric id is visible.
2. **The journal UI is now fully English** — preview, `/journal` stats, buttons (`💾 Save` / `❌ Cancel`), status and callback messages.

### Why is this change needed?
On the user's first upload, 12 real trades were reduced to 1 saved + 11 false duplicates, and the UI text was Russian. Both are addressed here.

### How was this tested?
- [x] Unit tests added — regression cases for the placeholder ticket and the ticketless signature dedup, plus the formatting assertions updated to English.
- [x] Manual testing — reproduced the exact 12-trade screenshot: first upload → **12 saved, 0 duplicates**; re-uploading the same screenshot → **12 duplicates**.

Full suite: **154 passed**. flake8 clean on all changed files. Merges cleanly onto current `master`.

### Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review performed
- [x] Hard-to-understand areas commented
- [x] No new warnings
- [x] New and existing tests pass locally

### Breaking Changes
- [ ] This PR contains breaking changes

Any trade saved by #38 with the bogus `TICKET` ticket is handled transparently: `_dedup_key` re-sanitizes tickets on read, so such a row falls back to its signature and de-duplicates correctly against re-uploads.

### Additional Notes
Touched: `trade_journal.py` (ticket sanitization, signature dedup, English formatting, prompt), `telegram_bot.py` (English strings), `db.py` (drop now-unused `confirmed_tickets`), `tests/test_smc/test_trade_journal.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)