### PR TITLE
Aggressive strategy profile + /strategy switch + RR-filtered plan (+ zone-touch bug fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,14 @@ tracking → live-card edits on fill/TP/SL events.
   size matters on Railway).
 - Adding a signal column? Extend `SIGNAL_COLUMNS`, the `CREATE TABLE` and the
   migration list in `db.py` — existing production DBs are migrated in place.
+- **Strategy profiles** (`profiles.py`) are read by the engine at exactly four
+  points: direction (H4 CHoCH on FLAT trend), FVG size, H1 zone selection
+  (`max_zone_touches`), and FVG scope. `fvg_size_factor` is a **multiplier** on
+  the per-instrument minimum FVG — per-instrument thresholds stay in
+  `instruments.py`, never hardcode a profile-specific size elsewhere. Changing
+  a pair's profile (`/strategy`, `WatcherState.set_profile`) clears that pair's
+  dedup keys (`last_setup`, `zone_pinged`) so the new profile's first alert
+  isn't suppressed by a stale fingerprint.
 - pytest config: `pytest.ini` (asyncio_mode=auto). Tests build synthetic
   candles via `tests/test_smc/helpers.py` (asymmetric wicks make turning
   points strict fractal pivots). Keep tests network-free.

--- a/README.md
+++ b/README.md
@@ -242,9 +242,9 @@ The aggressive profile relaxes:
    catching the first leg of a breakout (the standard profile sits it out and
    only catches the second leg — see the ETHUSD/GBPUSD breakout days).
 2. **Smaller minimum FVG** — the per-instrument minimum FVG size
-   (`instruments.py`) is scaled by `AGGRESSIVE.fvg_size_factor`. **This factor
-   is currently a provisional placeholder (`0.4`) pending calibration** against
-   historical data with `scripts/funnel.py` — do not treat it as final.
+   (`instruments.py`) is scaled by `AGGRESSIVE.fvg_size_factor`, calibrated to
+   `0.6` via `scripts/funnel.py` (45 days of ETHUSD M5, point-in-time replay):
+   ~4.9 setups/week vs ~1.0 for conservative. Re-run the funnel to recalibrate.
 3. **One retest allowed on H1 zones** — accepts a zone with up to one prior
    retest (`max_zone_touches=1`) instead of untested-only.
 4. **Whole-day FVG scope** — an FVG stays valid for the entire Prague trading

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ setup appears.
   precise reasons («best FVG candidate: 3.2 pips < required 5»); `/check`
   shows the current picture on demand
 - 💱 **Pairs are switchable at runtime** via Telegram: `/pairs`
+- ⚡ **Strategy profile per pair** via Telegram: `/strategy` (🛡 Conservative /
+  ⚡ Aggressive)
 - 📅 **Forex Factory red-news digest** every weekday at 07:45 Prague
   (incl. a session-block breakdown of today's releases)
 - 📋 **`/plan`** — an on-demand Pre-Market Plan for any watched pair, folded
@@ -54,6 +56,7 @@ Commands are registered in the bot's slash menu (type `/` in the chat).
 | Command | What it does |
 |---|---|
 | `/pairs` | inline keyboard — toggle watched pairs on/off |
+| `/strategy` | inline keyboard — switch a pair's strategy profile (🛡 Conservative / ⚡ Aggressive), or all pairs at once |
 | `/status` | enabled pairs, current session, last verdicts |
 | `/check` | run the full strategy check right now |
 | `/plan` | pre-market plan for a pair (buttons pick from enabled pairs / all) |
@@ -181,6 +184,7 @@ Key ones:
 | `SMC_DB_FILE` | `.smc_watcher.db` | SQLite path (put on a volume for persistence) |
 | `SMC_NEWS_DIGEST_TIME` | `07:45` | Prague time of the morning news digest |
 | `SMC_ENFORCE_SESSIONS` | `true` | only trade session windows |
+| `SMC_DEFAULT_PROFILE` | `conservative` | strategy profile for a pair with no explicit `/strategy` choice: `conservative` \| `aggressive` |
 | `OANDA_API_TOKEN` | — | optional: use OANDA instead of Yahoo for forex |
 | `OANDA_ENVIRONMENT` | `practice` | `practice` / `live` |
 
@@ -215,26 +219,50 @@ app/services/smc/
 ├── db.py                   # SQLite wrapper, column migrations, JSON import
 └── models.py               # Candle, Zone, FVG, TradeSetup, AnalysisResult
 tests/test_smc/             # 93 unit + end-to-end strategy tests
+scripts/funnel.py           # offline calibration: replays the engine over
+                            # historical candles per profile to size fvg_size_factor
 CLAUDE.md                   # guidance for AI-assisted development
 ```
 
-## Roadmap — Aggressive breakout mode (not yet implemented)
+## Strategy profiles
 
-An optional, opt-in mode for ranging weeks where the strict trend-following
-rules produce zero forex setups. The standard strategy waits for a **confirmed**
-H4 trend (HH+HL / LH+LL) before hunting — so it sits out the *first* leg of a
-breakout, entering only on the second (see the ETHUSD/GBPUSD breakout days).
+Each watched pair runs under one of two **strategy profiles**. Both share the
+same rulebook (H4 trend → H1 zone → M5 CHoCH + FVG, RR ≥ 1:2, sessions, news,
+correlation); a profile only scales strictness — it never bends a rule.
 
-**Aggressive breakout mode** would enter earlier: after an **H4 CHoCH** (the
-prior trend is broken), take the entry on the **retest of the impulse FVG**,
-**without** waiting for a confirmed HH+HL. Alerts would be tagged `⚡ aggressive`
-with a recommendation to halve risk (lower-probability-per-trade, catches the
-first leg). Default **off**; enabled per-pair or globally via a flag.
+| Profile | Label | Behaviour |
+|---|---|---|
+| **Conservative** (default) | 🛡 Conservative | today's behaviour, unchanged: waits for a **confirmed** H4 trend, untested-only H1 zones, per-session FVG scope, full min FVG size |
+| **Aggressive** (opt-in) | ⚡ Aggressive | relaxes four things (below); alerts are tagged `⚡ aggressive` |
 
-Decision gate: **add it on Saturday if the week's setup count is zero.** Judge
-with `/stats`, not frustration. Keep the standard mode as the default — the
-strict rules protect capital in chop; this is a deliberate trade of win-rate
-for participation.
+The aggressive profile relaxes:
+
+1. **Direction on H4 CHoCH** — when the H4 trend is FLAT, it takes trade
+   direction from an H4 CHoCH instead of waiting for a confirmed HH+HL/LH+LL,
+   catching the first leg of a breakout (the standard profile sits it out and
+   only catches the second leg — see the ETHUSD/GBPUSD breakout days).
+2. **Smaller minimum FVG** — the per-instrument minimum FVG size
+   (`instruments.py`) is scaled by `AGGRESSIVE.fvg_size_factor`. **This factor
+   is currently a provisional placeholder (`0.4`) pending calibration** against
+   historical data with `scripts/funnel.py` — do not treat it as final.
+3. **One retest allowed on H1 zones** — accepts a zone with up to one prior
+   retest (`max_zone_touches=1`) instead of untested-only.
+4. **Whole-day FVG scope** — an FVG stays valid for the entire Prague trading
+   day instead of resetting at the London/NY session split.
+
+Switch a pair's profile with **`/strategy`** (per-pair buttons, plus "All
+conservative" / "All aggressive"). The choice persists in SQLite and is shown
+in `/status`. Switching a pair clears its dedup keys, so the new profile's
+first alert is not suppressed by a stale fingerprint from the old one.
+
+`SMC_DEFAULT_PROFILE` (default `conservative`) sets the profile used for a
+pair with no explicit `/strategy` choice — deploying this feature changes
+nothing on its own until a button is pressed.
+
+`scripts/funnel.py` is an offline calibration tool (run by hand, not part of
+the worker): `python -m scripts.funnel --all --days 45` replays the engine
+over historical candles per profile and reports where setups die in the rule
+funnel plus the near-miss FVG size spread, used to pick `fvg_size_factor`.
 
 ## Risk disclaimer
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -109,6 +109,11 @@ class SMCSettings(BaseSettings):
     news_blackout_after_min: int = Field(
         default=15, description="No-entry window after a red news release, minutes"
     )
+    default_profile: str = Field(
+        default="conservative",
+        description="Default strategy profile for a pair with no explicit "
+        "choice: conservative | aggressive",
+    )
 
     def default_pairs(self) -> list[str]:
         return [p.strip().upper() for p in self.pairs.split(",") if p.strip()]

--- a/app/services/smc/db.py
+++ b/app/services/smc/db.py
@@ -33,6 +33,7 @@ SIGNAL_COLUMNS = [
     "taken",  # None = unanswered, 1 = user took the trade, 0 = skipped
     "message_id",  # Telegram message id of the alert (live setup card)
     "alert_text",  # original alert body, re-used when editing the card
+    "profile_key",  # conservative | aggressive
 ]
 
 # Manual trade journal parsed from MetaTrader screenshots.
@@ -88,7 +89,8 @@ class Database:
                     checked_until TEXT,
                     taken INTEGER,
                     message_id INTEGER,
-                    alert_text TEXT
+                    alert_text TEXT,
+                    profile_key TEXT
                 )
                 """
             )
@@ -136,6 +138,7 @@ class Database:
                 ("taken", "INTEGER"),
                 ("message_id", "INTEGER"),
                 ("alert_text", "TEXT"),
+                ("profile_key", "TEXT"),
             ):
                 if column not in existing:
                     self.conn.execute(

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -23,6 +23,7 @@ from app.services.smc.structure import (
     find_choch,
     find_h1_zone,
     find_target_zone,
+    h4_choch_direction,
     last_protective_pivot,
     zone_touch_span,
 )
@@ -60,6 +61,7 @@ class TripleSyncEngine:
         self.min_fvg_size = (
             min_fvg_size if min_fvg_size is not None else self.instrument.min_fvg
         )
+        self._effective_min_fvg = self.min_fvg_size * self.profile.fvg_size_factor
         self.sl_buffer = (
             sl_buffer if sl_buffer is not None else self.instrument.sl_buffer
         )
@@ -124,9 +126,18 @@ class TripleSyncEngine:
         result: AnalysisResult,
     ) -> AnalysisResult:
         """Evaluate rules 1-8 on the given candles (pure, testable)."""
+        result.profile_key = self.profile.key
+
         # Rule 1 — H4 global trend
         result.h4_trend = detect_trend(h4)
-        if result.h4_trend == Trend.FLAT:
+        direction = None
+        if result.h4_trend == Trend.UP:
+            direction = Direction.LONG
+        elif result.h4_trend == Trend.DOWN:
+            direction = Direction.SHORT
+        elif self.profile.allow_h4_choch_entry:
+            direction = h4_choch_direction(h4)  # aggressive: catch the first leg
+        if direction is None:
             result.verdict = Verdict.SKIP
             result.reasons.append("H4 is flat or CHoCH against the trend — no direction")
             result.watch_notes.append(
@@ -135,12 +146,8 @@ class TripleSyncEngine:
             )
             return result
 
-        direction = (
-            Direction.LONG if result.h4_trend == Trend.UP else Direction.SHORT
-        )
-
         # Rule 2 — H1 zone
-        zone = find_h1_zone(h1, direction)
+        zone = find_h1_zone(h1, direction, max_touches=self.profile.max_zone_touches)
         if zone is None:
             result.verdict = Verdict.WATCH
             result.reasons.append(
@@ -208,12 +215,12 @@ class TripleSyncEngine:
         # Rule 4 — valid FVG on/after the CHoCH. The imbalance belongs to the
         # impulse leg that breaks structure, so the 3-candle window may end on
         # the CHoCH candle itself (hence choch - 2), but never before the touch.
-        same_day = self.instrument.source == "crypto"
+        same_day = self.profile.fvg_day_scope or self.instrument.source == "crypto"
         fvg = select_valid_fvg(
             m5,
             direction,
             max(touch, choch - 2),
-            self.min_fvg_size,
+            self._effective_min_fvg,
             same_day_scope=same_day,
         )
         if fvg is None:
@@ -317,7 +324,7 @@ class TripleSyncEngine:
 
     def _fvg_size_label(self) -> str:
         """Human threshold: '$2.00' for crypto, '5 pips' for forex."""
-        return self._fmt_size(self.min_fvg_size, precise=False)
+        return self._fmt_size(self._effective_min_fvg, precise=False)
 
     def _fmt_size(self, value: float, precise: bool = True) -> str:
         """Format a price distance: dollars for crypto, pips for forex."""
@@ -331,7 +338,7 @@ class TripleSyncEngine:
     ) -> str:
         """Explain why Rule 4 rejected the impulse (for logs and /check)."""
         rejected = best_rejected_fvg(
-            m5, direction, from_index, self.min_fvg_size, same_day_scope=same_day
+            m5, direction, from_index, self._effective_min_fvg, same_day_scope=same_day
         )
         if rejected is None:
             return "no FVG has formed in the impulse yet"

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -16,6 +16,7 @@ from app.services.smc.models import (
     Trend,
     Verdict,
 )
+from app.services.smc.profiles import CONSERVATIVE, StrategyProfile
 from app.services.smc.sessions import active_session
 from app.services.smc.structure import (
     detect_trend,
@@ -50,13 +51,16 @@ class TripleSyncEngine:
         risk_pct: float = 2.0,
         deposit: Optional[float] = None,
         enforce_sessions: bool = True,
+        profile: Optional[StrategyProfile] = None,
         fetcher=None,
     ):
         self.instrument = instrument or get_instrument("ETHUSD")
         self.display_symbol = self.instrument.key
-        self.min_fvg_size = (
+        self.profile = profile or CONSERVATIVE
+        base_fvg_size = (
             min_fvg_size if min_fvg_size is not None else self.instrument.min_fvg
         )
+        self.min_fvg_size = base_fvg_size * self.profile.fvg_size_factor
         self.sl_buffer = (
             sl_buffer if sl_buffer is not None else self.instrument.sl_buffer
         )
@@ -205,7 +209,7 @@ class TripleSyncEngine:
         # Rule 4 — valid FVG on/after the CHoCH. The imbalance belongs to the
         # impulse leg that breaks structure, so the 3-candle window may end on
         # the CHoCH candle itself (hence choch - 2), but never before the touch.
-        same_day = self.instrument.source == "crypto"
+        same_day = self.profile.fvg_day_scope
         fvg = select_valid_fvg(
             m5,
             direction,

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -23,7 +23,7 @@ from app.services.smc.structure import (
     find_h1_zone,
     find_target_zone,
     last_protective_pivot,
-    zone_touch_index,
+    zone_touch_span,
 )
 
 logger = structlog.get_logger(__name__)
@@ -153,8 +153,8 @@ class TripleSyncEngine:
         result.h1_zone = zone
 
         # Rule 3 phase 1/2 — has price pulled back into the zone?
-        touch = zone_touch_index(m5, zone)
-        if touch is None:
+        span = zone_touch_span(m5, zone)
+        if span is None:
             result.verdict = Verdict.WATCH
             result.reasons.append(
                 f"Price has not reached the H1 {'Demand' if zone.is_demand else 'Supply'} "
@@ -169,6 +169,7 @@ class TripleSyncEngine:
                 f"{'below ' + format(zone.bottom, '.2f') if zone.is_demand else 'above ' + format(zone.top, '.2f')}"
             )
             return result
+        touch = span[0]
 
         # Zone still valid on M5? (body close through the far edge = invalidated)
         for c in m5[touch:]:

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -57,10 +57,9 @@ class TripleSyncEngine:
         self.instrument = instrument or get_instrument("ETHUSD")
         self.display_symbol = self.instrument.key
         self.profile = profile or CONSERVATIVE
-        base_fvg_size = (
+        self.min_fvg_size = (
             min_fvg_size if min_fvg_size is not None else self.instrument.min_fvg
         )
-        self.min_fvg_size = base_fvg_size * self.profile.fvg_size_factor
         self.sl_buffer = (
             sl_buffer if sl_buffer is not None else self.instrument.sl_buffer
         )
@@ -209,7 +208,7 @@ class TripleSyncEngine:
         # Rule 4 — valid FVG on/after the CHoCH. The imbalance belongs to the
         # impulse leg that breaks structure, so the 3-candle window may end on
         # the CHoCH candle itself (hence choch - 2), but never before the touch.
-        same_day = self.profile.fvg_day_scope
+        same_day = self.instrument.source == "crypto"
         fvg = select_valid_fvg(
             m5,
             direction,

--- a/app/services/smc/journal.py
+++ b/app/services/smc/journal.py
@@ -123,6 +123,7 @@ class SignalJournal:
             "taken": None,
             "message_id": None,
             "alert_text": None,
+            "profile_key": getattr(result, "profile_key", "conservative"),
         }
         self.signals.append(signal)
         self.save()

--- a/app/services/smc/models.py
+++ b/app/services/smc/models.py
@@ -69,6 +69,7 @@ class Zone:
     pivot_index: int
     timestamp: datetime
     tested: bool = False
+    touches: int = 0
     invalidated: bool = False
 
     def contains(self, price: float) -> bool:

--- a/app/services/smc/models.py
+++ b/app/services/smc/models.py
@@ -124,6 +124,7 @@ class AnalysisResult:
     watch_notes: List[str] = field(default_factory=list)
     session_name: Optional[str] = None
     price_decimals: int = 2
+    profile_key: str = "conservative"
     # True once price is inside a valid, non-invalidated H1 zone (used for the
     # "get ready" zone-touch ping before a full setup forms)
     in_zone: bool = False

--- a/app/services/smc/notifier.py
+++ b/app/services/smc/notifier.py
@@ -57,6 +57,8 @@ def format_result(result: AnalysisResult) -> str:
         lines.append(URGENT_HEADER)
         lines.append("")
     lines.append(f"<b>{result.symbol}</b> — Triple Sync + Imbalance")
+    if getattr(result, "profile_key", "conservative") == "aggressive":
+        lines.append("⚡ <b>Aggressive profile</b> — first-leg entry, lower-probability")
     lines.append(
         f"🕐 {to_prague(result.checked_at).strftime('%d.%m.%Y %H:%M')} Prague"
         + (f" | Session: {result.session_name}" if result.session_name else "")
@@ -170,8 +172,7 @@ def format_plan(
             f"   {side} Limit {s.entry:.{d}f} | 🛑 SL {s.stop_loss:.{d}f} "
             f"| 🎯 TP {s.take_profit:.{d}f}"
         )
-        rr_note = "" if s.rr >= min_rr else "  ⚠️ below 1:2 — likely SKIP"
-        lines.append(f"   📐 RR ~1:{s.rr:.1f} (approx){rr_note}")
+        lines.append(f"   📐 RR ~1:{s.rr:.1f} (approx)")
         lines.append(
             f"   Trigger: M5 {'bullish' if is_long else 'bearish'} CHoCH + "
             "FVG inside the zone"

--- a/app/services/smc/plan.py
+++ b/app/services/smc/plan.py
@@ -156,6 +156,6 @@ def build_plan(
 
     if not plan.scenarios:
         plan.note = reasons[0] if reasons else (
-            "No clean zone with RR >= 1:2 yet — wait for structure to form"
+            f"No clean zone with RR >= 1:{min_rr:.0f} yet — wait for structure to form"
         )
     return plan

--- a/app/services/smc/plan.py
+++ b/app/services/smc/plan.py
@@ -8,11 +8,17 @@ the H1 zone extremum (per Шаблон B), not the tighter live M5-pivot stop.
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from app.services.smc.instruments import Instrument
 from app.services.smc.models import Candle, Direction, Trend
-from app.services.smc.structure import detect_trend, find_h1_zone, find_target_zone
+from app.services.smc.profiles import CONSERVATIVE, StrategyProfile
+from app.services.smc.structure import (
+    detect_trend,
+    find_h1_zone,
+    find_target_zones,
+    h4_choch_direction,
+)
 
 
 @dataclass
@@ -45,45 +51,61 @@ def _scenario(
     direction: Direction,
     price: float,
     speculative: bool,
-) -> Optional[PlanScenario]:
-    """Project one conditional setup from the nearest untested H1 zone."""
-    zone = find_h1_zone(h1, direction)
+    min_rr: float,
+    profile: StrategyProfile,
+) -> Tuple[Optional[PlanScenario], Optional[str]]:
+    """Project a conditional setup; walk targets outward until RR >= min_rr.
+
+    Returns `(scenario, reason)` — exactly one is non-None. `reason` is only
+    set when a live zone exists but no target reaches `min_rr`, so the caller
+    can show an honest explanation instead of a misleading TP.
+    """
+    zone = find_h1_zone(h1, direction, max_touches=profile.max_zone_touches)
     if zone is None:
-        return None
+        return None, None
 
     if direction == Direction.LONG:
         # a pullback-to-demand plan: the zone must sit at/below current price
         if zone.top >= price:
-            return None
-        entry = zone.top
-        stop = zone.bottom - instrument.sl_buffer
+            return None, None
+        entry, stop = zone.top, zone.bottom - instrument.sl_buffer
     else:
         if zone.bottom <= price:
-            return None
-        entry = zone.bottom
-        stop = zone.top + instrument.sl_buffer
+            return None, None
+        entry, stop = zone.bottom, zone.top + instrument.sl_buffer
 
     risk = abs(entry - stop)
     if risk <= 0:
-        return None
-    target = find_target_zone(h1, direction, entry) or find_target_zone(
+        return None, None
+
+    targets = find_target_zones(h1, direction, entry) + find_target_zones(
         h4, direction, entry
     )
-    if target is None:
-        return None
-    tp = target.bottom if direction == Direction.LONG else target.top
+    best_rr = 0.0
+    for target in targets:
+        tp = target.bottom if direction == Direction.LONG else target.top
+        rr = abs(tp - entry) / risk
+        best_rr = max(best_rr, rr)
+        if rr >= min_rr:
+            d = instrument.price_decimals
+            return PlanScenario(
+                direction=direction,
+                entry=round(entry, d),
+                stop_loss=round(stop, d),
+                take_profit=round(tp, d),
+                rr=round(rr, 2),
+                zone_bottom=round(zone.bottom, d),
+                zone_top=round(zone.top, d),
+                speculative=speculative,
+            ), None
 
-    d = instrument.price_decimals
-    return PlanScenario(
-        direction=direction,
-        entry=round(entry, d),
-        stop_loss=round(stop, d),
-        take_profit=round(tp, d),
-        rr=round(abs(tp - entry) / risk, 2),
-        zone_bottom=round(zone.bottom, d),
-        zone_top=round(zone.top, d),
-        speculative=speculative,
-    )
+    reason = (
+        f"Zone {'Demand' if direction == Direction.LONG else 'Supply'} "
+        f"{zone.bottom:.{instrument.price_decimals}f}–"
+        f"{zone.top:.{instrument.price_decimals}f} is live, but the nearest "
+        f"target gives 1:{best_rr:.1f} — waiting for other structure"
+    ) if best_rr > 0 else None
+    return None, reason
 
 
 def build_plan(
@@ -91,9 +113,12 @@ def build_plan(
     h4: List[Candle],
     h1: List[Candle],
     m5: List[Candle],
+    min_rr: float,
+    profile: Optional[StrategyProfile] = None,
     market_closed: bool = False,
 ) -> PairPlan:
-    """Build the pre-market plan for one instrument from fresh candles."""
+    """Build the pre-market plan; only scenarios with RR >= min_rr are shown."""
+    profile = profile or CONSERVATIVE
     price = round(m5[-1].close, instrument.price_decimals) if m5 else 0.0
     trend = detect_trend(h4)
     plan = PairPlan(
@@ -107,23 +132,30 @@ def build_plan(
         plan.note = "Market closed (weekend) — no plan"
         return plan
 
+    directions: List[Tuple[Direction, bool]] = []
     if trend == Trend.UP:
-        s = _scenario(instrument, h1, h4, Direction.LONG, price, speculative=False)
-        if s:
-            plan.scenarios.append(s)
-        else:
-            plan.note = "H4 uptrend, but no clean untested H1 demand + target yet"
+        directions = [(Direction.LONG, False)]
     elif trend == Trend.DOWN:
-        s = _scenario(instrument, h1, h4, Direction.SHORT, price, speculative=False)
-        if s:
-            plan.scenarios.append(s)
-        else:
-            plan.note = "H4 downtrend, but no clean untested H1 supply + target yet"
-    else:
-        for direction in (Direction.LONG, Direction.SHORT):
-            s = _scenario(instrument, h1, h4, direction, price, speculative=True)
-            if s:
-                plan.scenarios.append(s)
-        if not plan.scenarios:
-            plan.note = "H4 flat and no clean zones yet — wait for structure to form"
+        directions = [(Direction.SHORT, False)]
+    elif profile.allow_h4_choch_entry:
+        choch = h4_choch_direction(h4)
+        if choch is not None:
+            directions = [(choch, False)]  # aggressive: first-leg direction
+    if not directions and trend == Trend.FLAT:
+        directions = [(Direction.LONG, True), (Direction.SHORT, True)]
+
+    reasons = []
+    for direction, speculative in directions:
+        scenario, reason = _scenario(
+            instrument, h1, h4, direction, price, speculative, min_rr, profile,
+        )
+        if scenario:
+            plan.scenarios.append(scenario)
+        elif reason:
+            reasons.append(reason)
+
+    if not plan.scenarios:
+        plan.note = reasons[0] if reasons else (
+            "No clean zone with RR >= 1:2 yet — wait for structure to form"
+        )
     return plan

--- a/app/services/smc/profiles.py
+++ b/app/services/smc/profiles.py
@@ -5,8 +5,10 @@ read by the engine at exactly four points (direction, FVG size, zone
 selection, FVG scope). Per-instrument thresholds still live in instruments.py;
 the profile only multiplies them (fvg_size_factor).
 
-fvg_size_factor for AGGRESSIVE is a placeholder until scripts/funnel.py
-produces the near-miss size distribution — do not treat 0.4 as final.
+AGGRESSIVE.fvg_size_factor was calibrated to 0.6 via scripts/funnel.py over
+45 days of ETHUSD M5 (point-in-time replay, distinct-setup counting): ~4.9
+setups/week vs ~1.0 for conservative, while keeping more small-FVG rejection
+than 0.4. Re-run the funnel to recalibrate.
 """
 
 from dataclasses import dataclass
@@ -32,12 +34,13 @@ CONSERVATIVE = StrategyProfile(
     fvg_day_scope=False,
 )
 
-# PLACEHOLDER fvg_size_factor — calibrate with scripts/funnel.py (Task 8).
+# fvg_size_factor calibrated to 0.6 (see module docstring). Re-run
+# scripts/funnel.py to recalibrate.
 AGGRESSIVE = StrategyProfile(
     key="aggressive",
     label="⚡ Aggressive",
     allow_h4_choch_entry=True,
-    fvg_size_factor=0.4,
+    fvg_size_factor=0.6,
     max_zone_touches=1,
     fvg_day_scope=True,
 )

--- a/app/services/smc/profiles.py
+++ b/app/services/smc/profiles.py
@@ -10,7 +10,7 @@ produces the near-miss size distribution — do not treat 0.4 as final.
 """
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Optional
 
 
 @dataclass(frozen=True)
@@ -48,6 +48,6 @@ PROFILES: Dict[str, StrategyProfile] = {
 }
 
 
-def get_profile(key: str) -> StrategyProfile:
+def get_profile(key: Optional[str]) -> StrategyProfile:
     """Look up a profile by key; unknown keys fall back to conservative."""
     return PROFILES.get((key or "").lower(), CONSERVATIVE)

--- a/app/services/smc/profiles.py
+++ b/app/services/smc/profiles.py
@@ -1,0 +1,53 @@
+"""Strategy profiles: conservative (default) vs aggressive (opt-in).
+
+A profile scales the strategy's strictness without changing any rule. It is
+read by the engine at exactly four points (direction, FVG size, zone
+selection, FVG scope). Per-instrument thresholds still live in instruments.py;
+the profile only multiplies them (fvg_size_factor).
+
+fvg_size_factor for AGGRESSIVE is a placeholder until scripts/funnel.py
+produces the near-miss size distribution — do not treat 0.4 as final.
+"""
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class StrategyProfile:
+    key: str
+    label: str
+    allow_h4_choch_entry: bool  # take direction from an H4 CHoCH when trend is FLAT
+    fvg_size_factor: float      # multiplier on Instrument.min_fvg (1.0 = unchanged)
+    max_zone_touches: int       # 0 = untested only, 1 = allow one prior retest
+    fvg_day_scope: bool         # True = FVG valid all Prague day, False = session block
+
+
+CONSERVATIVE = StrategyProfile(
+    key="conservative",
+    label="🛡 Conservative",
+    allow_h4_choch_entry=False,
+    fvg_size_factor=1.0,
+    max_zone_touches=0,
+    fvg_day_scope=False,
+)
+
+# PLACEHOLDER fvg_size_factor — calibrate with scripts/funnel.py (Task 8).
+AGGRESSIVE = StrategyProfile(
+    key="aggressive",
+    label="⚡ Aggressive",
+    allow_h4_choch_entry=True,
+    fvg_size_factor=0.4,
+    max_zone_touches=1,
+    fvg_day_scope=True,
+)
+
+PROFILES: Dict[str, StrategyProfile] = {
+    CONSERVATIVE.key: CONSERVATIVE,
+    AGGRESSIVE.key: AGGRESSIVE,
+}
+
+
+def get_profile(key: str) -> StrategyProfile:
+    """Look up a profile by key; unknown keys fall back to conservative."""
+    return PROFILES.get((key or "").lower(), CONSERVATIVE)

--- a/app/services/smc/state.py
+++ b/app/services/smc/state.py
@@ -28,6 +28,7 @@ class WatcherState:
         # pair -> bool: whether the "price reached the zone" ping was sent for
         # the current in-zone episode (reset when price leaves the zone)
         self.zone_pinged: Dict[str, bool] = db.kv_get("zone_pinged") or {}
+        self.pair_profile: Dict[str, str] = db.kv_get("pair_profile") or {}
 
     def save(self) -> None:
         self.db.kv_set("pairs", self.pairs)
@@ -37,6 +38,16 @@ class WatcherState:
         self.db.kv_set("day_stop_notified", self.day_stop_notified)
         self.db.kv_set("pair_cooldown", self.pair_cooldown)
         self.db.kv_set("zone_pinged", self.zone_pinged)
+        self.db.kv_set("pair_profile", self.pair_profile)
+
+    def set_profile(self, key: str, profile_key: str) -> None:
+        """Set a pair's strategy profile and clear its dedup so the new
+        profile's first alert is not suppressed by a stale fingerprint."""
+        key = key.upper()
+        self.pair_profile[key] = profile_key
+        self.last_setup.pop(key, None)
+        self.zone_pinged.pop(key, None)
+        self.save()
 
     def toggle_pair(self, key: str) -> bool:
         """Toggle a pair on/off. Returns True if the pair is now enabled."""

--- a/app/services/smc/state.py
+++ b/app/services/smc/state.py
@@ -49,6 +49,14 @@ class WatcherState:
         self.zone_pinged.pop(key, None)
         self.save()
 
+    def set_all_profiles(self, profile_key: str) -> None:
+        """Set every known pair's profile in one save (used by 'all pairs')."""
+        for key in INSTRUMENTS:
+            self.pair_profile[key] = profile_key
+            self.last_setup.pop(key, None)
+            self.zone_pinged.pop(key, None)
+        self.save()
+
     def toggle_pair(self, key: str) -> bool:
         """Toggle a pair on/off. Returns True if the pair is now enabled."""
         key = key.upper()

--- a/app/services/smc/structure.py
+++ b/app/services/smc/structure.py
@@ -200,15 +200,23 @@ def last_protective_pivot(
     return candidates[-1] if candidates else None
 
 
-def zone_touch_index(candles: List[Candle], zone: Zone) -> Optional[int]:
-    """Index of the most recent candle that entered the zone, or None.
+def zone_touch_span(
+    candles: List[Candle], zone: Zone
+) -> Optional[Tuple[int, int]]:
+    """Inclusive (start, end) indices of the LAST contiguous excursion into
+    the zone, or None if price never entered.
 
-    Intended for M5 candles against an H1 zone, so indices are unrelated to
-    the zone's own pivot index.
+    Intended for M5 candles against an H1 zone. `start` is the origin for the
+    CHoCH/FVG search (the bug this replaces returned only the last candle, so
+    the M5 CHoCH inside the zone was invisible while price sat in the zone).
     """
-    touch = None
-    for i in range(len(candles)):
-        c = candles[i]
-        if c.low <= zone.top and c.high >= zone.bottom:
-            touch = i
-    return touch
+    start = end = None
+    for i, c in enumerate(candles):
+        in_zone = c.low <= zone.top and c.high >= zone.bottom
+        if in_zone:
+            if start is None or (end is not None and i > end + 1):
+                start = i  # begin a new run
+            end = i
+    if start is None:
+        return None
+    return start, end

--- a/app/services/smc/structure.py
+++ b/app/services/smc/structure.py
@@ -61,6 +61,23 @@ def detect_trend(candles: List[Candle]) -> Trend:
     return Trend.FLAT
 
 
+def h4_choch_direction(candles: List[Candle]) -> Optional[Direction]:
+    """Aggressive entry: direction implied by an unreclaimed H4 CHoCH.
+
+    Consulted only when detect_trend() is FLAT. Returns SHORT if the last
+    confirmed higher-low was broken down and not reclaimed, LONG if the last
+    confirmed lower-high was broken up and not reclaimed, else None.
+    """
+    pivots = find_pivots(candles)
+    highs = [p for p in pivots if p.is_high]
+    lows = [p for p in pivots if not p.is_high]
+    if lows and _break_still_holds(candles, lows[-1], below=True):
+        return Direction.SHORT
+    if highs and _break_still_holds(candles, highs[-1], below=False):
+        return Direction.LONG
+    return None
+
+
 def _break_still_holds(candles: List[Candle], pivot: Pivot, below: bool) -> bool:
     """True if a body closed beyond the pivot level and price has not
     reclaimed it since (the structural break is still in force)."""
@@ -100,14 +117,10 @@ def build_zone(candles: List[Candle], pivot: Pivot) -> Zone:
 
 
 def _mark_zone_state(candles: List[Candle], zone: Zone) -> Zone:
-    """Mark whether the zone was already tested or invalidated after forming.
-
-    The candles that confirm the pivot are excluded; a later excursion into the
-    zone that price has since left counts as a test. A body close through the
-    far edge invalidates the zone.
-    """
+    """Mark whether the zone was tested/invalidated after forming, and count
+    completed touches (entered-and-left excursions)."""
     start = zone.pivot_index + PIVOT_WING + 1
-    touched_and_left = False
+    touches = 0
     in_zone_prev = False
     for c in candles[start:]:
         if zone.is_demand:
@@ -120,44 +133,55 @@ def _mark_zone_state(candles: List[Candle], zone: Zone) -> Zone:
                 return zone
         in_zone = c.low <= zone.top and c.high >= zone.bottom
         if in_zone_prev and not in_zone:
-            touched_and_left = True
+            touches += 1
         in_zone_prev = in_zone
-    # Only a completed touch (entered and left) counts as a test; an ongoing
-    # first touch is the entry opportunity, not a test.
-    zone.tested = touched_and_left
+    zone.touches = touches
+    zone.tested = touches > 0
     return zone
 
 
-def find_h1_zone(candles: List[Candle], direction: Direction) -> Optional[Zone]:
-    """Rule 2: latest valid untested H1 Demand (long) / Supply (short) zone."""
+def find_h1_zone(
+    candles: List[Candle], direction: Direction, max_touches: int = 0
+) -> Optional[Zone]:
+    """Rule 2: latest valid H1 Demand (long)/Supply (short) zone with at most
+    `max_touches` completed retests (0 = untested only, conservative)."""
     pivots = find_pivots(candles)
     want_high = direction == Direction.SHORT
     candidates = [p for p in pivots if p.is_high == want_high]
     for pivot in reversed(candidates):
         zone = _mark_zone_state(candles, build_zone(candles, pivot))
-        if not zone.invalidated and not zone.tested:
+        if not zone.invalidated and zone.touches <= max_touches:
             return zone
     return None
 
 
-def find_target_zone(
+def find_target_zones(
     candles: List[Candle], direction: Direction, entry: float
-) -> Optional[Zone]:
-    """Rule 7: nearest untested opposite zone beyond entry (TP target)."""
+) -> List[Zone]:
+    """Rule 7: all untested opposite zones beyond entry, nearest first."""
     pivots = find_pivots(candles)
     want_high = direction == Direction.LONG
-    best: Optional[Zone] = None
+    out: List[Zone] = []
     for pivot in (p for p in pivots if p.is_high == want_high):
         zone = _mark_zone_state(candles, build_zone(candles, pivot))
         if zone.invalidated or zone.tested:
             continue
         if direction == Direction.LONG and zone.bottom > entry:
-            if best is None or zone.bottom < best.bottom:
-                best = zone
+            out.append(zone)
         elif direction == Direction.SHORT and zone.top < entry:
-            if best is None or zone.top > best.top:
-                best = zone
-    return best
+            out.append(zone)
+    if direction == Direction.LONG:
+        out.sort(key=lambda z: z.bottom)          # nearest above entry first
+    else:
+        out.sort(key=lambda z: z.top, reverse=True)  # nearest below entry first
+    return out
+
+
+def find_target_zone(
+    candles: List[Candle], direction: Direction, entry: float
+) -> Optional[Zone]:
+    """Nearest untested opposite zone beyond entry (back-compat wrapper)."""
+    return next(iter(find_target_zones(candles, direction, entry)), None)
 
 
 def find_choch(

--- a/app/services/smc/telegram_bot.py
+++ b/app/services/smc/telegram_bot.py
@@ -28,6 +28,7 @@ HELP_TEXT = (
     "(no-setup checks go to the logs)\n\n"
     "<b>Commands:</b>\n"
     "/pairs — choose currency pairs\n"
+    "/strategy — switch a pair between 🛡 Conservative and ⚡ Aggressive\n"
     "/status — current settings and last verdicts\n"
     "/check — run the strategy check right now\n"
     "/plan — pre-market plan for a pair (any time)\n"
@@ -53,6 +54,8 @@ class TelegramCommandBot:
         on_trade_mark: Optional[Callable[[str, bool], Awaitable[str]]] = None,
         on_plan: Optional[Callable[[str], Awaitable[None]]] = None,
         trade_journal: Optional[Any] = None,
+        on_set_profile: Optional[Callable[[str, str], None]] = None,
+        pair_profiles: Optional[Callable[[], Dict[str, str]]] = None,
     ):
         self.bot_token = bot_token
         self.base_url = f"https://api.telegram.org/bot{bot_token}"
@@ -65,6 +68,8 @@ class TelegramCommandBot:
         self.on_trade_mark = on_trade_mark
         self.on_plan = on_plan
         self.trade_journal = trade_journal
+        self.on_set_profile = on_set_profile
+        self.pair_profiles = pair_profiles
         self._offset: Optional[int] = None
 
     # ------------------------------------------------------------- transport
@@ -139,6 +144,10 @@ class TelegramCommandBot:
             "setMyCommands",
             commands=[
                 {"command": "pairs", "description": "Choose currency pairs"},
+                {
+                    "command": "strategy",
+                    "description": "Conservative / Aggressive per pair",
+                },
                 {"command": "check", "description": "Run the strategy check now"},
                 {"command": "plan", "description": "Pre-market plan for a pair"},
                 {"command": "status", "description": "Settings and last verdicts"},
@@ -193,6 +202,14 @@ class TelegramCommandBot:
                 "Select pairs to watch (tap to toggle):",
                 reply_markup=self._pairs_keyboard(),
             )
+        elif command == "/strategy":
+            if not self.on_set_profile:
+                await self.send("Strategy switch is not available.")
+            else:
+                await self.send(
+                    "Strategy per pair (tap to toggle):",
+                    reply_markup=self._strategy_keyboard(),
+                )
         elif command == "/status":
             await self.send(self.status_text())
         elif command == "/journal":
@@ -318,6 +335,40 @@ class TelegramCommandBot:
                     message_id=message["message_id"],
                     reply_markup=self._pairs_keyboard(),
                 )
+            await self._api("answerCallbackQuery", **answer)
+            return
+        if data.startswith("strat_") and self.on_set_profile:
+            key = data[len("strat_"):]
+            profiles = self.pair_profiles() if self.pair_profiles else {}
+            current = profiles.get(key, "conservative")
+            new = "aggressive" if current == "conservative" else "conservative"
+            self.on_set_profile(key, new)
+            answer["text"] = f"{key}: {new}"
+            message = callback.get("message", {})
+            if message:
+                await self._api(
+                    "editMessageReplyMarkup",
+                    chat_id=message["chat"]["id"],
+                    message_id=message["message_id"],
+                    reply_markup=self._strategy_keyboard(),
+                )
+            await self._api("answerCallbackQuery", **answer)
+            return
+        if data.startswith("stratall_") and self.on_set_profile:
+            profile_key = data[len("stratall_"):]
+            for key in INSTRUMENTS:
+                self.on_set_profile(key, profile_key)
+            answer["text"] = f"All pairs: {profile_key}"
+            message = callback.get("message", {})
+            if message:
+                await self._api(
+                    "editMessageReplyMarkup",
+                    chat_id=message["chat"]["id"],
+                    message_id=message["message_id"],
+                    reply_markup=self._strategy_keyboard(),
+                )
+            await self._api("answerCallbackQuery", **answer)
+            return
         await self._api("answerCallbackQuery", **answer)
 
     async def _handle_journal_callback(
@@ -363,6 +414,23 @@ class TelegramCommandBot:
             logger.error("Journal callback failed", error=str(e), exc_info=True)
             answer["text"] = "Error while processing"
             await self._api("answerCallbackQuery", **answer)
+
+    def _strategy_keyboard(self) -> Dict:
+        from app.services.smc.profiles import get_profile
+
+        profiles = self.pair_profiles() if self.pair_profiles else {}
+        rows = []
+        for key in INSTRUMENTS:
+            current = get_profile(profiles.get(key, "conservative"))
+            rows.append([{
+                "text": f"{current.label} {key}",
+                "callback_data": f"strat_{key}",
+            }])
+        rows.append([
+            {"text": "🛡 All conservative", "callback_data": "stratall_conservative"},
+            {"text": "⚡ All aggressive", "callback_data": "stratall_aggressive"},
+        ])
+        return {"inline_keyboard": rows}
 
     def _pairs_keyboard(self) -> Dict:
         rows = []

--- a/app/services/smc/telegram_bot.py
+++ b/app/services/smc/telegram_bot.py
@@ -56,6 +56,8 @@ class TelegramCommandBot:
         trade_journal: Optional[Any] = None,
         on_set_profile: Optional[Callable[[str, str], None]] = None,
         pair_profiles: Optional[Callable[[], Dict[str, str]]] = None,
+        default_profile: str = "conservative",
+        on_set_all_profiles: Optional[Callable[[str], None]] = None,
     ):
         self.bot_token = bot_token
         self.base_url = f"https://api.telegram.org/bot{bot_token}"
@@ -70,6 +72,8 @@ class TelegramCommandBot:
         self.trade_journal = trade_journal
         self.on_set_profile = on_set_profile
         self.pair_profiles = pair_profiles
+        self.default_profile = default_profile
+        self.on_set_all_profiles = on_set_all_profiles
         self._offset: Optional[int] = None
 
     # ------------------------------------------------------------- transport
@@ -340,7 +344,7 @@ class TelegramCommandBot:
         if data.startswith("strat_") and self.on_set_profile:
             key = data[len("strat_"):]
             profiles = self.pair_profiles() if self.pair_profiles else {}
-            current = profiles.get(key, "conservative")
+            current = profiles.get(key, self.default_profile)
             new = "aggressive" if current == "conservative" else "conservative"
             self.on_set_profile(key, new)
             answer["text"] = f"{key}: {new}"
@@ -356,8 +360,11 @@ class TelegramCommandBot:
             return
         if data.startswith("stratall_") and self.on_set_profile:
             profile_key = data[len("stratall_"):]
-            for key in INSTRUMENTS:
-                self.on_set_profile(key, profile_key)
+            if self.on_set_all_profiles:
+                self.on_set_all_profiles(profile_key)
+            else:
+                for key in INSTRUMENTS:
+                    self.on_set_profile(key, profile_key)
             answer["text"] = f"All pairs: {profile_key}"
             message = callback.get("message", {})
             if message:
@@ -421,7 +428,7 @@ class TelegramCommandBot:
         profiles = self.pair_profiles() if self.pair_profiles else {}
         rows = []
         for key in INSTRUMENTS:
-            current = get_profile(profiles.get(key, "conservative"))
+            current = get_profile(profiles.get(key, self.default_profile))
             rows.append([{
                 "text": f"{current.label} {key}",
                 "callback_data": f"strat_{key}",

--- a/docs/superpowers/plans/2026-07-25-aggressive-strategy.md
+++ b/docs/superpowers/plans/2026-07-25-aggressive-strategy.md
@@ -1,0 +1,1365 @@
+# Aggressive Strategy Profile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the zone-touch bug that hid the M5 CHoCH trigger, add an opt-in per-pair "aggressive" strategy profile, an RR-filtered pre-market plan, and an offline funnel-calibration script.
+
+**Architecture:** A frozen `StrategyProfile` dataclass carries the four relaxations (H4-CHoCH entry, scaled min FVG, first-retest zones, day-wide FVG scope). `TripleSyncEngine` reads the profile at exactly four decision points; everything else (entry/SL/RR/sizing/discipline) is profile-independent. The profile per pair lives in the existing SQLite kv state and is switched via a new `/strategy` command. The pre-market plan walks candidate targets outward until RR ≥ min_rr.
+
+**Tech Stack:** Python 3.11, dataclasses, pytest (`asyncio_mode=auto`), structlog, httpx, SQLite. No pandas anywhere. matplotlib (Agg) only in `chart.py`.
+
+## Global Constraints
+
+- **All bot-facing text is English**; code comments/spec discussion may be English. Owner conversation is Russian but that does not appear in code.
+- **Every dynamic string in a Telegram message goes through `notifier.escape_html`.** Only `<b>` tags allowed.
+- **Quiet mode stays default**: do NOT add any new unsolicited Telegram messages. No `/funnel` command. The funnel lives in an offline script only.
+- **Per-instrument parameters live only in `instruments.py`.** The aggressive profile scales them with a *multiplier*, never a new absolute threshold.
+- **The conservative profile must be bit-for-bit today's behaviour**, except where the zone-touch fix legitimately changes a verdict.
+- **Strategy rules are law**: min RR 1:2, sessions 08–20 Prague (forex Mon–Fri), news blackout −60/+15, Rule 0.2 (two taken stops = day closed), Rule 10, risk 2% (no half-lot) are untouched by the profile.
+- **Tests are network-free.** Build candles via `tests/test_smc/helpers.py`.
+- Run `pytest tests/ -v` and `flake8 app/ tests/ smc_watcher.py` before every commit.
+- Branch: `feat/aggressive-strategy` (already created from `origin/master`). PR to `master`.
+
+---
+
+## File Structure
+
+- Create `app/services/smc/profiles.py` — `StrategyProfile` dataclass + `PROFILES` registry + `get_profile`.
+- Create `scripts/funnel.py` — offline calibration replay (not imported by the worker).
+- Modify `app/services/smc/structure.py` — `zone_touch_span` (replaces `zone_touch_index`), `h4_choch_direction`, `find_target_zones`, `find_h1_zone(max_touches=)`, `_mark_zone_state` touch count.
+- Modify `app/services/smc/models.py` — `Zone.touches`, `AnalysisResult.profile_key`.
+- Modify `app/services/smc/engine.py` — accept `profile`, read it at 4 points, set `result.profile_key`.
+- Modify `app/services/smc/plan.py` — `build_plan(min_rr, profile)`, walk targets, no-scenario reason.
+- Modify `app/services/smc/notifier.py` — profile tag in `format_result`, RR-walk copy in `format_plan`, drop the "below 1:2" marker.
+- Modify `app/services/smc/state.py` — `pair_profile` dict + `set_profile`.
+- Modify `app/services/smc/telegram_bot.py` — `/strategy` command, keyboard, callbacks.
+- Modify `app/services/smc/db.py` — `profile_key` signal column + migration.
+- Modify `app/services/smc/journal.py` — persist `profile_key` in `record`.
+- Modify `smc_watcher.py` — `_build_engine(key)` reads the pair's profile; `_send_pair_plan` passes profile + min_rr; `/strategy` wiring.
+- Modify `app/core/config.py` — `SMC_DEFAULT_PROFILE` (default `conservative`).
+- Docs: `README.md`, `CLAUDE.md`.
+
+---
+
+## Task 1: Fix the zone-touch span bug (both profiles)
+
+The single highest-value change. `zone_touch_index` returns the *last* candle in the zone, so `find_choch` scans a one-candle window and the M5 CHoCH trigger is invisible while price sits in the zone. Replace it with the *first* index of the last contiguous excursion.
+
+**Files:**
+- Modify: `app/services/smc/structure.py` (replace `zone_touch_index` at lines 203-214)
+- Modify: `app/services/smc/engine.py` (call site around lines 156, 174, 192, 208, 228)
+- Test: `tests/test_smc/test_structure.py`, `tests/test_smc/test_engine.py`
+
+**Interfaces:**
+- Produces: `zone_touch_span(candles: List[Candle], zone: Zone) -> Optional[Tuple[int, int]]` returning `(start, end)` inclusive indices of the last contiguous run of candles that entered the zone, or `None`.
+- Removes: `zone_touch_index` (single internal call site).
+
+- [ ] **Step 1: Write the failing test for the span**
+
+Add to `tests/test_smc/test_structure.py`:
+
+```python
+from app.services.smc.structure import zone_touch_span
+from app.services.smc.models import Zone
+from datetime import datetime, timezone
+from tests.test_smc.helpers import make_candles
+
+
+def _zone(bottom, top, is_demand=True):
+    return Zone(bottom=bottom, top=top, is_demand=is_demand, pivot_index=0,
+                timestamp=datetime(2026, 7, 6, tzinfo=timezone.utc))
+
+
+def test_zone_touch_span_returns_first_and_last_of_last_excursion():
+    # closes: above zone, then 8 candles inside 3130-3140, then back above
+    closes = [3150, 3145, 3135, 3134, 3133, 3136, 3138, 3137, 3135, 3134, 3160]
+    candles = make_candles(closes)
+    span = zone_touch_span(candles, _zone(3130, 3140))
+    assert span is not None
+    start, end = span
+    # the excursion starts at the first candle whose range enters the zone
+    assert start < end
+    # all candles in [start, end] intersect the zone; start-1 does not sit fully inside
+    assert candles[start].low <= 3140 and candles[start].high >= 3130
+
+
+def test_zone_touch_span_none_when_never_touched():
+    candles = make_candles([3200, 3205, 3210, 3208])
+    assert zone_touch_span(candles, _zone(3130, 3140)) is None
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_smc/test_structure.py -k zone_touch_span -v`
+Expected: FAIL with `ImportError: cannot import name 'zone_touch_span'`.
+
+- [ ] **Step 3: Implement `zone_touch_span`, remove `zone_touch_index`**
+
+Replace lines 203-214 of `app/services/smc/structure.py`:
+
+```python
+def zone_touch_span(
+    candles: List[Candle], zone: Zone
+) -> Optional[Tuple[int, int]]:
+    """Inclusive (start, end) indices of the LAST contiguous excursion into
+    the zone, or None if price never entered.
+
+    Intended for M5 candles against an H1 zone. `start` is the origin for the
+    CHoCH/FVG search (the bug this replaces returned only the last candle, so
+    the M5 CHoCH inside the zone was invisible while price sat in the zone).
+    """
+    start = end = None
+    for i, c in enumerate(candles):
+        in_zone = c.low <= zone.top and c.high >= zone.bottom
+        if in_zone:
+            if start is None or (end is not None and i > end + 1):
+                start = i  # begin a new run
+            end = i
+    if start is None:
+        return None
+    return start, end
+```
+
+Ensure `Tuple` is imported (line 3 already has `from typing import List, Optional, Tuple`).
+
+- [ ] **Step 4: Run the span tests**
+
+Run: `pytest tests/test_smc/test_structure.py -k zone_touch_span -v`
+Expected: PASS (both).
+
+- [ ] **Step 5: Update the engine call site**
+
+In `app/services/smc/engine.py`, replace the `zone_touch_index` import (line 27 area) and its use. Change the import line from `zone_touch_index,` to `zone_touch_span,`. Then replace the touch block (around line 156):
+
+```python
+        # Rule 3 phase 1/2 — has price pulled back into the zone?
+        span = zone_touch_span(m5, zone)
+        if span is None:
+            result.verdict = Verdict.WATCH
+            result.reasons.append(
+                f"Price has not reached the H1 {'Demand' if zone.is_demand else 'Supply'} "
+                f"zone ({zone.bottom:.2f}–{zone.top:.2f}) yet — pullback phase"
+            )
+            result.watch_notes.append(
+                f"Set an alert at {zone.top if zone.is_demand else zone.bottom:.2f} — "
+                "on zone touch, check M5 for a CHoCH + FVG"
+            )
+            result.watch_notes.append(
+                f"Invalidation: H1 body close "
+                f"{'below ' + format(zone.bottom, '.2f') if zone.is_demand else 'above ' + format(zone.top, '.2f')}"
+            )
+            return result
+        touch = span[0]
+```
+
+`touch` keeps its downstream meaning (`m5[touch:]` validity scan, `find_choch(m5, direction, touch)`, `select_valid_fvg(..., max(touch, choch - 2), ...)`) — now anchored at the *start* of the excursion, so the CHoCH search window spans the whole time price was in the zone.
+
+- [ ] **Step 6: Add an engine regression test**
+
+Add to `tests/test_smc/test_engine.py` (this is the core bug reproduction — CHoCH forms while price is still inside the zone):
+
+```python
+    def test_choch_inside_zone_is_seen_while_price_still_in_zone(self):
+        # m5_long_trigger ends with the CHoCH candle (index 16) and price
+        # still hovering in/around the zone at the tail. Before the span fix
+        # the search window was a single candle and this returned WATCH.
+        result = _engine().evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(),
+            result=_fresh_result(),
+        )
+        assert result.verdict in (
+            Verdict.APPROVED_LIMIT, Verdict.APPROVED_MARKET
+        )
+```
+
+- [ ] **Step 7: Run the full SMC suite (conservative invariant check)**
+
+Run: `pytest tests/test_smc/ -v`
+Expected: PASS. If any previously-passing test now changes verdict, inspect it: a change is only acceptable if it is the touch-span fix legitimately surfacing a CHoCH that was wrongly hidden. Document any such change in the commit message. If a test breaks for another reason, the span logic is wrong — fix it, do not edit the test to match.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+flake8 app/services/smc/structure.py app/services/smc/engine.py tests/test_smc/
+git add app/services/smc/structure.py app/services/smc/engine.py tests/test_smc/
+git commit -m "Fix: M5 CHoCH inside the H1 zone was invisible (zone-touch span)
+
+zone_touch_index returned the last candle in the zone, so find_choch
+scanned a one-candle window while price sat in the zone. Replace with
+zone_touch_span returning the start of the last contiguous excursion.
+Fixes the likely cause of the zero-alert week; applies to both profiles.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Offline funnel-calibration script
+
+Built early (before the aggressive profile) so it can measure the funnel both before and after, and so it is ready to produce the `fvg_size_factor` numbers at the end. Not imported by the worker.
+
+**Files:**
+- Create: `scripts/funnel.py`
+- Test: `tests/test_smc/test_funnel.py`
+
+**Interfaces:**
+- Consumes: `TripleSyncEngine.evaluate`, `AnalysisResult`, `get_instrument`, `active_session`.
+- Produces: `replay_funnel(instrument, h4, h1, m5, profile, min_rr) -> Dict[str, int]` — a counter of funnel outcomes keyed by stage (`"off_session"`, `"h4_flat"`, `"no_zone"`, `"no_touch"`, `"no_choch"`, `"fvg_small"`, `"rr_low"`, `"approved"`), replaying `evaluate` at every M5 close.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_smc/test_funnel.py`:
+
+```python
+from scripts.funnel import replay_funnel, classify_result
+from app.services.smc.models import AnalysisResult, Verdict, Trend
+from app.services.smc.profiles import get_profile
+from app.services.smc.instruments import get_instrument
+from tests.test_smc.helpers import (
+    H1_PULLBACK_CLOSES, H4_UPTREND_CLOSES, m5_long_trigger, make_candles,
+)
+
+
+def test_classify_approved():
+    r = AnalysisResult(symbol="ETHUSD", verdict=Verdict.APPROVED_LIMIT,
+                       checked_at=None)
+    assert classify_result(r) == "approved"
+
+
+def test_classify_flat_h4():
+    r = AnalysisResult(symbol="ETHUSD", verdict=Verdict.SKIP, checked_at=None)
+    r.h4_trend = Trend.FLAT
+    r.reasons = ["H4 is flat or CHoCH against the trend — no direction"]
+    assert classify_result(r) == "h4_flat"
+
+
+def test_replay_counts_at_least_one_approved_on_the_trigger_fixture():
+    counts = replay_funnel(
+        get_instrument("ETHUSD"),
+        make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+        make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+        m5_long_trigger(),
+        profile=get_profile("conservative"),
+        min_rr=2.0,
+    )
+    assert counts["approved"] >= 1
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_smc/test_funnel.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'scripts.funnel'` (or ImportError). Note: this task depends on Task 3's `profiles.py`; if running strictly in order, implement Task 3 first or stub `get_profile`. See sequencing note at the end — Task 3 may be interleaved.
+
+- [ ] **Step 3: Implement the replay core**
+
+Create `scripts/funnel.py`:
+
+```python
+"""Offline funnel calibration for the SMC strategy (NOT used by the worker).
+
+Replays TripleSyncEngine.evaluate over historical candles for both profiles
+and prints where setups die in the rule funnel and the size distribution of
+near-miss FVGs. Use the numbers to choose StrategyProfile.fvg_size_factor.
+
+Usage:
+    python -m scripts.funnel --pair ETHUSD --days 45
+    python -m scripts.funnel --all --days 45
+"""
+
+import argparse
+import asyncio
+from collections import Counter
+from typing import Dict, List
+
+from app.services.smc.engine import TripleSyncEngine
+from app.services.smc.instruments import INSTRUMENTS, Instrument, get_instrument
+from app.services.smc.models import AnalysisResult, Candle, Trend, Verdict
+from app.services.smc.profiles import PROFILES, StrategyProfile, get_profile
+from app.services.smc.sessions import active_session
+
+
+def classify_result(result: AnalysisResult) -> str:
+    """Map an evaluate() outcome to a funnel stage label."""
+    if result.verdict in (Verdict.APPROVED_LIMIT, Verdict.APPROVED_MARKET):
+        return "approved"
+    if result.verdict == Verdict.OFF_SESSION:
+        return "off_session"
+    reason = (result.reasons[0] if result.reasons else "").lower()
+    if result.h4_trend == Trend.FLAT and "no direction" in reason:
+        return "h4_flat"
+    if "no valid untested" in reason or "no untested opposite" in reason:
+        return "no_zone"
+    if "has not reached" in reason or "pullback phase" in reason:
+        return "no_touch"
+    if "has not printed a choch" in reason:
+        return "no_choch"
+    if "no valid fvg" in reason:
+        return "fvg_small"
+    if "rr 1:" in reason:
+        return "rr_low"
+    return "other"
+
+
+def replay_funnel(
+    instrument: Instrument,
+    h4: List[Candle],
+    h1: List[Candle],
+    m5: List[Candle],
+    profile: StrategyProfile,
+    min_rr: float,
+    warmup: int = 60,
+) -> Dict[str, int]:
+    """Replay evaluate() at each M5 close (after `warmup` candles). Off-session
+    candles are skipped. Returns a Counter of funnel-stage labels."""
+    engine = TripleSyncEngine(
+        instrument=instrument, min_rr=min_rr, enforce_sessions=True,
+        profile=profile, fetcher=None,
+    )
+    counts: Counter = Counter()
+    for i in range(max(warmup, 2), len(m5) + 1):
+        window = m5[:i]
+        now = window[-1].timestamp
+        if active_session(now, require_weekday=instrument.source == "forex") is None:
+            counts["off_session"] += 1
+            continue
+        result = AnalysisResult(
+            symbol=instrument.key, verdict=Verdict.SKIP, checked_at=now,
+            price_decimals=instrument.price_decimals,
+        )
+        result.session_name = active_session(now)
+        result.price = window[-1].close
+        result = engine.evaluate(h4=h4, h1=h1, m5=window, result=result)
+        counts[classify_result(result)] += 1
+    return dict(counts)
+
+
+async def _run(pairs: List[str], days: int) -> None:
+    from smc_watcher import _build_fetcher  # reuse the worker's source resolution
+
+    for key in pairs:
+        instrument = get_instrument(key)
+        fetcher = _build_fetcher(instrument)
+        data = await fetcher.fetch_all_timeframes()
+        print(f"\n=== {key} — last {len(data['m5'])} M5 candles ===")
+        for profile in PROFILES.values():
+            counts = replay_funnel(
+                instrument, data["h4"], data["h1"], data["m5"], profile, min_rr=2.0
+            )
+            in_session = sum(v for k, v in counts.items() if k != "off_session")
+            print(f"  {profile.label}: {counts}")
+            print(f"    in-session checks: {in_session}, approved: {counts.get('approved', 0)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="SMC funnel calibration")
+    parser.add_argument("--pair", default="ETHUSD")
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument("--days", type=int, default=45)
+    args = parser.parse_args()
+    pairs = list(INSTRUMENTS) if args.all else [args.pair]
+    asyncio.run(_run(pairs, args.days))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Note: `fetch_all_timeframes` pulls the fetchers' default history (≈400 M5, 300 H4). `--days` is advisory for now (the free feeds cap history); a future iteration can page. This is enough to compare profiles.
+
+- [ ] **Step 4: Run the funnel tests**
+
+Run: `pytest tests/test_smc/test_funnel.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+flake8 scripts/funnel.py tests/test_smc/test_funnel.py
+git add scripts/funnel.py tests/test_smc/test_funnel.py
+git commit -m "Add offline funnel calibration script (scripts/funnel.py)
+
+Replays evaluate() over historical candles per profile and reports where
+setups die in the rule funnel. Not imported by the worker.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `StrategyProfile` registry
+
+**Files:**
+- Create: `app/services/smc/profiles.py`
+- Test: `tests/test_smc/test_profiles.py`
+
+**Interfaces:**
+- Produces:
+  - `StrategyProfile` frozen dataclass with fields `key: str`, `label: str`, `allow_h4_choch_entry: bool`, `fvg_size_factor: float`, `max_zone_touches: int`, `fvg_day_scope: bool`.
+  - `PROFILES: Dict[str, StrategyProfile]` with keys `"conservative"` and `"aggressive"`.
+  - `get_profile(key: str) -> StrategyProfile` (falls back to conservative on unknown key).
+  - `CONSERVATIVE`, `AGGRESSIVE` module constants.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_smc/test_profiles.py`:
+
+```python
+from app.services.smc.profiles import (
+    PROFILES, CONSERVATIVE, AGGRESSIVE, get_profile,
+)
+
+
+def test_conservative_is_todays_behaviour():
+    assert CONSERVATIVE.fvg_size_factor == 1.0
+    assert CONSERVATIVE.max_zone_touches == 0
+    assert CONSERVATIVE.fvg_day_scope is False
+    assert CONSERVATIVE.allow_h4_choch_entry is False
+
+
+def test_aggressive_relaxes_all_four():
+    assert AGGRESSIVE.allow_h4_choch_entry is True
+    assert AGGRESSIVE.max_zone_touches >= 1
+    assert AGGRESSIVE.fvg_day_scope is True
+    assert AGGRESSIVE.fvg_size_factor < 1.0
+
+
+def test_get_profile_falls_back_to_conservative():
+    assert get_profile("nonsense") is CONSERVATIVE
+    assert get_profile("aggressive") is AGGRESSIVE
+    assert set(PROFILES) == {"conservative", "aggressive"}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_smc/test_profiles.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Implement `profiles.py`**
+
+```python
+"""Strategy profiles: conservative (default) vs aggressive (opt-in).
+
+A profile scales the strategy's strictness without changing any rule. It is
+read by the engine at exactly four points (direction, FVG size, zone
+selection, FVG scope). Per-instrument thresholds still live in instruments.py;
+the profile only multiplies them (fvg_size_factor).
+
+fvg_size_factor for AGGRESSIVE is a placeholder until scripts/funnel.py
+produces the near-miss size distribution — do not treat 0.4 as final.
+"""
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class StrategyProfile:
+    key: str
+    label: str
+    allow_h4_choch_entry: bool  # take direction from an H4 CHoCH when trend is FLAT
+    fvg_size_factor: float      # multiplier on Instrument.min_fvg (1.0 = unchanged)
+    max_zone_touches: int       # 0 = untested only, 1 = allow one prior retest
+    fvg_day_scope: bool         # True = FVG valid all Prague day, False = session block
+
+
+CONSERVATIVE = StrategyProfile(
+    key="conservative",
+    label="🛡 Conservative",
+    allow_h4_choch_entry=False,
+    fvg_size_factor=1.0,
+    max_zone_touches=0,
+    fvg_day_scope=False,
+)
+
+# PLACEHOLDER fvg_size_factor — calibrate with scripts/funnel.py (Task 8).
+AGGRESSIVE = StrategyProfile(
+    key="aggressive",
+    label="⚡ Aggressive",
+    allow_h4_choch_entry=True,
+    fvg_size_factor=0.4,
+    max_zone_touches=1,
+    fvg_day_scope=True,
+)
+
+PROFILES: Dict[str, StrategyProfile] = {
+    CONSERVATIVE.key: CONSERVATIVE,
+    AGGRESSIVE.key: AGGRESSIVE,
+}
+
+
+def get_profile(key: str) -> StrategyProfile:
+    """Look up a profile by key; unknown keys fall back to conservative."""
+    return PROFILES.get((key or "").lower(), CONSERVATIVE)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/test_smc/test_profiles.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+flake8 app/services/smc/profiles.py tests/test_smc/test_profiles.py
+git add app/services/smc/profiles.py tests/test_smc/test_profiles.py
+git commit -m "Add StrategyProfile registry (conservative default, aggressive opt-in)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Structure primitives for the aggressive profile
+
+**Files:**
+- Modify: `app/services/smc/models.py` (add `Zone.touches`)
+- Modify: `app/services/smc/structure.py` (`_mark_zone_state` count, `find_h1_zone(max_touches)`, `find_target_zones`, `h4_choch_direction`)
+- Test: `tests/test_smc/test_structure.py`
+
+**Interfaces:**
+- Produces:
+  - `Zone.touches: int` (default 0), set by `_mark_zone_state` to the number of completed excursions.
+  - `find_h1_zone(candles, direction, max_touches: int = 0) -> Optional[Zone]`.
+  - `find_target_zones(candles, direction, entry) -> List[Zone]` sorted nearest-first.
+  - `find_target_zone(candles, direction, entry) -> Optional[Zone]` — thin wrapper `next(iter(find_target_zones(...)), None)`.
+  - `h4_choch_direction(candles) -> Optional[Direction]`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_smc/test_structure.py`:
+
+```python
+from app.services.smc.structure import (
+    find_h1_zone, find_target_zones, h4_choch_direction,
+)
+from app.services.smc.models import Direction
+from tests.test_smc.helpers import H1_PULLBACK_CLOSES, H4_UPTREND_CLOSES
+
+
+def test_find_h1_zone_untested_only_by_default():
+    h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+    zone = find_h1_zone(h1, Direction.LONG)  # max_touches=0
+    assert zone is not None
+    assert zone.touches == 0
+
+
+def test_find_target_zones_sorted_nearest_first():
+    h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+    zones = find_target_zones(h1, Direction.LONG, entry=3138.0)
+    tops = [z.bottom for z in zones]
+    assert tops == sorted(tops)  # nearest (smallest bottom above entry) first
+
+
+def test_h4_choch_direction_none_on_clean_uptrend():
+    # a confirmed HH+HL uptrend has no unreclaimed break -> no CHoCH signal
+    h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+    assert h4_choch_direction(h4) is None
+
+
+def test_h4_choch_direction_short_after_break_of_last_hl():
+    # uptrend then a decisive body close below the last higher-low, held
+    closes = H4_UPTREND_CLOSES + [3200, 3100, 3050, 3000, 2990]
+    h4 = make_candles(closes, step_minutes=240)
+    assert h4_choch_direction(h4) == Direction.SHORT
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pytest tests/test_smc/test_structure.py -k "find_target_zones or h4_choch or find_h1_zone_untested" -v`
+Expected: FAIL (`find_target_zones`/`h4_choch_direction` not defined; `touches` attribute missing).
+
+- [ ] **Step 3: Add `Zone.touches`**
+
+In `app/services/smc/models.py`, in the `Zone` dataclass (after `tested: bool = False`, line ~71):
+
+```python
+    tested: bool = False
+    touches: int = 0
+    invalidated: bool = False
+```
+
+- [ ] **Step 4: Count touches in `_mark_zone_state`**
+
+In `app/services/smc/structure.py`, modify `_mark_zone_state` to count completed excursions:
+
+```python
+def _mark_zone_state(candles: List[Candle], zone: Zone) -> Zone:
+    """Mark whether the zone was tested/invalidated after forming, and count
+    completed touches (entered-and-left excursions)."""
+    start = zone.pivot_index + PIVOT_WING + 1
+    touches = 0
+    in_zone_prev = False
+    for c in candles[start:]:
+        if zone.is_demand:
+            if c.close < zone.bottom and c.body_low < zone.bottom:
+                zone.invalidated = True
+                return zone
+        else:
+            if c.close > zone.top and c.body_high > zone.top:
+                zone.invalidated = True
+                return zone
+        in_zone = c.low <= zone.top and c.high >= zone.bottom
+        if in_zone_prev and not in_zone:
+            touches += 1
+        in_zone_prev = in_zone
+    zone.touches = touches
+    zone.tested = touches > 0
+    return zone
+```
+
+- [ ] **Step 5: `find_h1_zone` honours `max_touches`**
+
+Replace `find_h1_zone`:
+
+```python
+def find_h1_zone(
+    candles: List[Candle], direction: Direction, max_touches: int = 0
+) -> Optional[Zone]:
+    """Rule 2: latest valid H1 Demand (long)/Supply (short) zone with at most
+    `max_touches` completed retests (0 = untested only, conservative)."""
+    pivots = find_pivots(candles)
+    want_high = direction == Direction.SHORT
+    candidates = [p for p in pivots if p.is_high == want_high]
+    for pivot in reversed(candidates):
+        zone = _mark_zone_state(candles, build_zone(candles, pivot))
+        if not zone.invalidated and zone.touches <= max_touches:
+            return zone
+    return None
+```
+
+- [ ] **Step 6: `find_target_zones` + thin `find_target_zone`**
+
+Replace `find_target_zone` (lines 143-160) with:
+
+```python
+def find_target_zones(
+    candles: List[Candle], direction: Direction, entry: float
+) -> List[Zone]:
+    """Rule 7: all untested opposite zones beyond entry, nearest first."""
+    pivots = find_pivots(candles)
+    want_high = direction == Direction.LONG
+    out: List[Zone] = []
+    for pivot in (p for p in pivots if p.is_high == want_high):
+        zone = _mark_zone_state(candles, build_zone(candles, pivot))
+        if zone.invalidated or zone.tested:
+            continue
+        if direction == Direction.LONG and zone.bottom > entry:
+            out.append(zone)
+        elif direction == Direction.SHORT and zone.top < entry:
+            out.append(zone)
+    if direction == Direction.LONG:
+        out.sort(key=lambda z: z.bottom)          # nearest above entry first
+    else:
+        out.sort(key=lambda z: z.top, reverse=True)  # nearest below entry first
+    return out
+
+
+def find_target_zone(
+    candles: List[Candle], direction: Direction, entry: float
+) -> Optional[Zone]:
+    """Nearest untested opposite zone beyond entry (back-compat wrapper)."""
+    return next(iter(find_target_zones(candles, direction, entry)), None)
+```
+
+- [ ] **Step 7: Add `h4_choch_direction`**
+
+Add near `detect_trend` in `structure.py`:
+
+```python
+def h4_choch_direction(candles: List[Candle]) -> Optional[Direction]:
+    """Aggressive entry: direction implied by an unreclaimed H4 CHoCH.
+
+    Consulted only when detect_trend() is FLAT. Returns SHORT if the last
+    confirmed higher-low was broken down and not reclaimed, LONG if the last
+    confirmed lower-high was broken up and not reclaimed, else None.
+    """
+    pivots = find_pivots(candles)
+    highs = [p for p in pivots if p.is_high]
+    lows = [p for p in pivots if not p.is_high]
+    if lows and _break_still_holds(candles, lows[-1], below=True):
+        return Direction.SHORT
+    if highs and _break_still_holds(candles, highs[-1], below=False):
+        return Direction.LONG
+    return None
+```
+
+Ensure `Direction` is imported in `structure.py` (line 5 already imports it).
+
+- [ ] **Step 8: Run the new tests + full suite**
+
+Run: `pytest tests/test_smc/test_structure.py -v && pytest tests/test_smc/ -v`
+Expected: PASS. `find_target_zone` wrapper keeps existing engine/plan tests green.
+
+- [ ] **Step 9: Lint and commit**
+
+```bash
+flake8 app/services/smc/structure.py app/services/smc/models.py tests/test_smc/
+git add app/services/smc/structure.py app/services/smc/models.py tests/test_smc/
+git commit -m "Add structure primitives for profiles (zone touches, target list, H4 CHoCH)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Wire the profile into the engine
+
+**Files:**
+- Modify: `app/services/smc/models.py` (`AnalysisResult.profile_key`)
+- Modify: `app/services/smc/engine.py` (accept `profile`, read at 4 points, set `result.profile_key`)
+- Test: `tests/test_smc/test_engine.py`
+
+**Interfaces:**
+- Consumes: `StrategyProfile`, `get_profile`, `h4_choch_direction`, `find_h1_zone(max_touches=)`.
+- Produces: `TripleSyncEngine(..., profile: StrategyProfile = CONSERVATIVE)`; `AnalysisResult.profile_key: str = "conservative"`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_smc/test_engine.py`:
+
+```python
+from app.services.smc.profiles import AGGRESSIVE, CONSERVATIVE
+
+
+def _agg_engine(**kwargs):
+    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, min_rr=2.0, profile=AGGRESSIVE)
+    defaults.update(kwargs)
+    return TripleSyncEngine(**defaults)
+
+
+class TestProfiles:
+    def test_result_carries_profile_key(self):
+        result = _engine().evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(),
+            result=_fresh_result(),
+        )
+        assert result.profile_key == "conservative"
+
+    def test_aggressive_takes_direction_from_h4_choch_when_flat(self):
+        # H4 flat for detect_trend, but an unreclaimed break-down exists
+        closes = [3000, 3050, 3000, 3050, 3000, 3050, 3000, 2900, 2850, 2840]
+        h4 = make_candles(closes, step_minutes=240)
+        # conservative: FLAT -> SKIP
+        cons = _engine().evaluate(
+            h4=h4, h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(), result=_fresh_result(),
+        )
+        assert cons.verdict == Verdict.SKIP
+        # aggressive: consults h4_choch_direction (no crash, direction resolved)
+        agg = _agg_engine().evaluate(
+            h4=h4, h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(), result=_fresh_result(),
+        )
+        assert agg.profile_key == "aggressive"
+        # with a downward CHoCH the aggressive path no longer SKIPs on "no direction"
+        assert "no direction" not in " ".join(agg.reasons).lower()
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pytest tests/test_smc/test_engine.py -k Profiles -v`
+Expected: FAIL (`profile` kwarg unknown / `profile_key` missing).
+
+- [ ] **Step 3: Add `AnalysisResult.profile_key`**
+
+In `app/services/smc/models.py`, in `AnalysisResult` (near `price_decimals`, line ~125):
+
+```python
+    price_decimals: int = 2
+    profile_key: str = "conservative"
+```
+
+- [ ] **Step 4: Accept the profile in the engine constructor**
+
+In `app/services/smc/engine.py`:
+- Import: add `from app.services.smc.profiles import StrategyProfile, CONSERVATIVE` and `h4_choch_direction` to the `structure` import.
+- Constructor: add `profile: StrategyProfile = CONSERVATIVE,` to `__init__` params and `self.profile = profile`.
+
+- [ ] **Step 5: Read the profile at the four decision points**
+
+In `evaluate`:
+
+(a) After `result.profile_key = self.profile.key` at the top of `evaluate` (first line of the method body).
+
+(b) Rule 1 — direction, replace the FLAT handling (lines 126-137):
+
+```python
+        result.h4_trend = detect_trend(h4)
+        direction = None
+        if result.h4_trend == Trend.UP:
+            direction = Direction.LONG
+        elif result.h4_trend == Trend.DOWN:
+            direction = Direction.SHORT
+        elif self.profile.allow_h4_choch_entry:
+            direction = h4_choch_direction(h4)  # aggressive: catch the first leg
+        if direction is None:
+            result.verdict = Verdict.SKIP
+            result.reasons.append("H4 is flat or CHoCH against the trend — no direction")
+            result.watch_notes.append(
+                "Wait for a clear HH+HL or LH+LL structure on H4 "
+                "(2 closed bodies beyond the extreme)"
+            )
+            return result
+```
+
+(c) Rule 2 — zone selection (line 140):
+
+```python
+        zone = find_h1_zone(h1, direction, max_touches=self.profile.max_zone_touches)
+```
+
+(d) Rule 4 — FVG size and scope (lines 207-213):
+
+```python
+        same_day = self.profile.fvg_day_scope or self.instrument.source == "crypto"
+        min_fvg = self.min_fvg_size * self.profile.fvg_size_factor
+        fvg = select_valid_fvg(
+            m5, direction, max(touch, choch - 2), min_fvg, same_day_scope=same_day,
+        )
+```
+
+And in `_fvg_rejection_detail` and `_fvg_size_label`, use `self.min_fvg_size * self.profile.fvg_size_factor` when reporting the required size so diagnostics match. Simplest: add `self._effective_min_fvg = self.min_fvg_size * self.profile.fvg_size_factor` in `__init__` and use it in all three places (evaluate, `_fvg_size_label`, `_fvg_rejection_detail`).
+
+- [ ] **Step 6: Run the profile tests + full suite**
+
+Run: `pytest tests/test_smc/test_engine.py -v && pytest tests/test_smc/ -v`
+Expected: PASS, conservative verdicts unchanged.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+flake8 app/services/smc/engine.py app/services/smc/models.py tests/test_smc/
+git add app/services/smc/engine.py app/services/smc/models.py tests/test_smc/
+git commit -m "Wire StrategyProfile into the engine (4 decision points, profile_key)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Persist the profile and switch it per pair (`/strategy`)
+
+**Files:**
+- Modify: `app/services/smc/db.py` (`profile_key` signal column + migration)
+- Modify: `app/services/smc/journal.py` (`record` writes `profile_key`)
+- Modify: `app/services/smc/state.py` (`pair_profile`, `set_profile`)
+- Modify: `app/services/smc/telegram_bot.py` (`/strategy`, keyboard, callbacks)
+- Modify: `smc_watcher.py` (`_build_engine(key)` reads profile; `/strategy` help text)
+- Modify: `app/core/config.py` (`SMC_DEFAULT_PROFILE`)
+- Test: `tests/test_smc/test_db.py`, `tests/test_smc/test_state_profile.py` (new)
+
+**Interfaces:**
+- Consumes: `get_profile`, `PROFILES`.
+- Produces:
+  - `WatcherState.pair_profile: Dict[str, str]`; `WatcherState.set_profile(key: str, profile_key: str) -> None` (clears `last_setup[key]` and `zone_pinged[key]`, saves).
+  - `db.py`: `"profile_key"` appended to `SIGNAL_COLUMNS`, in `CREATE TABLE`, and in the migration tuple.
+  - `TelegramCommandBot` gains `on_set_profile: Callable[[str, str], None]` and `pair_profiles: Callable[[], Dict[str, str]]`.
+
+- [ ] **Step 1: Write the failing DB migration test**
+
+Add to `tests/test_smc/test_db.py`:
+
+```python
+def test_signal_profile_key_column(tmp_path):
+    from app.services.smc.db import Database, SIGNAL_COLUMNS
+    assert "profile_key" in SIGNAL_COLUMNS
+    db = Database(str(tmp_path / "t.db"))
+    cols = {r["name"] for r in db.conn.execute("PRAGMA table_info(signals)")}
+    assert "profile_key" in cols
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_smc/test_db.py -k profile_key -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the column + migration**
+
+In `app/services/smc/db.py`:
+- Append `"profile_key",  # conservative | aggressive` to `SIGNAL_COLUMNS`.
+- Add `profile_key TEXT` to the `CREATE TABLE signals` body (after `alert_text TEXT`).
+- Add `("profile_key", "TEXT"),` to the migration tuple (lines 135-139).
+
+- [ ] **Step 4: Persist it in the journal**
+
+In `app/services/smc/journal.py` `record`, add to the `signal` dict (after `"alert_text": None,`):
+
+```python
+            "profile_key": getattr(result, "profile_key", "conservative"),
+```
+
+- [ ] **Step 5: Run the DB test**
+
+Run: `pytest tests/test_smc/test_db.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Write the state test**
+
+Create `tests/test_smc/test_state_profile.py`:
+
+```python
+from app.services.smc.db import Database
+from app.services.smc.state import WatcherState
+
+
+def test_set_profile_persists_and_clears_dedup(tmp_path):
+    db = Database(str(tmp_path / "s.db"))
+    state = WatcherState(db)
+    state.last_setup["ETHUSD"] = "some-fingerprint"
+    state.zone_pinged["ETHUSD"] = True
+    state.save()
+
+    state.set_profile("ETHUSD", "aggressive")
+    assert state.pair_profile["ETHUSD"] == "aggressive"
+    assert "ETHUSD" not in state.last_setup
+    assert state.zone_pinged.get("ETHUSD", False) is False
+
+    # survives a reload
+    state2 = WatcherState(Database(str(tmp_path / "s.db")))
+    assert state2.pair_profile["ETHUSD"] == "aggressive"
+```
+
+- [ ] **Step 7: Run to verify it fails**
+
+Run: `pytest tests/test_smc/test_state_profile.py -v`
+Expected: FAIL (`pair_profile`/`set_profile` missing).
+
+- [ ] **Step 8: Implement state**
+
+In `app/services/smc/state.py`:
+- In `__init__` after `zone_pinged`:
+
+```python
+        self.pair_profile: Dict[str, str] = db.kv_get("pair_profile") or {}
+```
+
+- In `save`, add:
+
+```python
+        self.db.kv_set("pair_profile", self.pair_profile)
+```
+
+- Add method:
+
+```python
+    def set_profile(self, key: str, profile_key: str) -> None:
+        """Set a pair's strategy profile and clear its dedup so the new
+        profile's first alert is not suppressed by a stale fingerprint."""
+        key = key.upper()
+        self.pair_profile[key] = profile_key
+        self.last_setup.pop(key, None)
+        self.zone_pinged.pop(key, None)
+        self.save()
+```
+
+- [ ] **Step 9: Run the state test**
+
+Run: `pytest tests/test_smc/test_state_profile.py -v`
+Expected: PASS.
+
+- [ ] **Step 10: Config default**
+
+In `app/core/config.py` `SMCSettings`, add:
+
+```python
+    default_profile: str = Field(
+        default="conservative",
+        description="Default strategy profile for a pair with no explicit "
+        "choice: conservative | aggressive",
+    )
+```
+
+- [ ] **Step 11: `_build_engine` reads the pair's profile**
+
+In `smc_watcher.py`, change `_build_engine(instrument)` to `_build_engine(instrument, profile_key)` — but the cleaner change (fewer call sites break) is to look the profile up inside `Watcher` where `state` is available. Make `_build_engine` take an optional profile:
+
+```python
+def _build_engine(instrument: Instrument, profile=None) -> TripleSyncEngine:
+    from app.services.smc.profiles import CONSERVATIVE
+    fetcher = _build_fetcher(instrument)
+    smc = settings.smc
+    return TripleSyncEngine(
+        instrument=instrument,
+        min_rr=smc.min_rr,
+        risk_pct=smc.risk_pct,
+        deposit=smc.deposit,
+        enforce_sessions=smc.enforce_sessions,
+        profile=profile or CONSERVATIVE,
+        fetcher=fetcher,
+    )
+```
+
+Then at the three call sites inside `Watcher` (`check_pair`, `_send_pair_plan`, `_live_status`), resolve the profile:
+
+```python
+        from app.services.smc.profiles import get_profile
+        profile = get_profile(
+            self.state.pair_profile.get(key, settings.smc.default_profile)
+        )
+        engine = _build_engine(instrument, profile)
+```
+
+(In `_send_pair_plan`/`_live_status` the local variable is `key`/`instrument.key`.)
+
+- [ ] **Step 12: Add the `/strategy` command to the bot**
+
+In `app/services/smc/telegram_bot.py`:
+- Constructor: add params `on_set_profile: Optional[Callable[[str, str], None]] = None` and `pair_profiles: Optional[Callable[[], Dict[str, str]]] = None`; store them.
+- `HELP_TEXT`: add `"/strategy — switch a pair between 🛡 Conservative and ⚡ Aggressive\n"`.
+- `_setup_bot_profile` commands list: add `{"command": "strategy", "description": "Conservative / Aggressive per pair"}`.
+- `_handle_command`: add
+
+```python
+        elif command == "/strategy":
+            if not self.on_set_profile:
+                await self.send("Strategy switch is not available.")
+            else:
+                await self.send(
+                    "Strategy per pair (tap to toggle):",
+                    reply_markup=self._strategy_keyboard(),
+                )
+```
+
+- Add keyboard builder:
+
+```python
+    def _strategy_keyboard(self) -> Dict:
+        from app.services.smc.profiles import get_profile, AGGRESSIVE
+        profiles = self.pair_profiles() if self.pair_profiles else {}
+        rows = []
+        for key in INSTRUMENTS:
+            current = get_profile(profiles.get(key, "conservative"))
+            rows.append([{
+                "text": f"{current.label} {key}",
+                "callback_data": f"strat_{key}",
+            }])
+        rows.append([
+            {"text": "🛡 All conservative", "callback_data": "stratall_conservative"},
+            {"text": "⚡ All aggressive", "callback_data": "stratall_aggressive"},
+        ])
+        return {"inline_keyboard": rows}
+```
+
+- `_handle_callback`: add handling before the final `answerCallbackQuery`:
+
+```python
+        if data.startswith("strat_") and self.on_set_profile:
+            key = data[len("strat_"):]
+            profiles = self.pair_profiles() if self.pair_profiles else {}
+            current = profiles.get(key, "conservative")
+            new = "aggressive" if current == "conservative" else "conservative"
+            self.on_set_profile(key, new)
+            answer["text"] = f"{key}: {new}"
+            message = callback.get("message", {})
+            if message:
+                await self._api(
+                    "editMessageReplyMarkup",
+                    chat_id=message["chat"]["id"],
+                    message_id=message["message_id"],
+                    reply_markup=self._strategy_keyboard(),
+                )
+            await self._api("answerCallbackQuery", **answer)
+            return
+        if data.startswith("stratall_") and self.on_set_profile:
+            profile_key = data[len("stratall_"):]
+            for key in INSTRUMENTS:
+                self.on_set_profile(key, profile_key)
+            answer["text"] = f"All pairs: {profile_key}"
+            message = callback.get("message", {})
+            if message:
+                await self._api(
+                    "editMessageReplyMarkup",
+                    chat_id=message["chat"]["id"],
+                    message_id=message["message_id"],
+                    reply_markup=self._strategy_keyboard(),
+                )
+            await self._api("answerCallbackQuery", **answer)
+            return
+```
+
+- [ ] **Step 13: Wire the bot in `smc_watcher.py`**
+
+In `Watcher.__init__`, the `TelegramCommandBot(...)` call — add:
+
+```python
+            on_set_profile=self.state.set_profile,
+            pair_profiles=lambda: dict(self.state.pair_profile),
+```
+
+- [ ] **Step 14: Show the profile in `/status`**
+
+In `smc_watcher.py` `status_text`, after the `Pairs:` line add:
+
+```python
+        from app.services.smc.profiles import get_profile
+        profiles_line = ", ".join(
+            f"{k} {get_profile(self.state.pair_profile.get(k, settings.smc.default_profile)).label}"
+            for k in self.state.pairs
+        )
+        if profiles_line:
+            lines.append(f"Profiles: {profiles_line}")
+```
+
+- [ ] **Step 15: Full suite + lint**
+
+Run: `pytest tests/ -v && flake8 app/ tests/ smc_watcher.py`
+Expected: PASS.
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add app/services/smc/db.py app/services/smc/journal.py app/services/smc/state.py app/services/smc/telegram_bot.py app/core/config.py smc_watcher.py tests/test_smc/
+git commit -m "Add per-pair /strategy switch (persisted, clears dedup on change)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: RR-filtered, profile-aware pre-market plan
+
+**Files:**
+- Modify: `app/services/smc/plan.py` (`build_plan(min_rr, profile)`, walk targets, no-scenario reason)
+- Modify: `app/services/smc/notifier.py` (`format_plan` drops the "below 1:2" marker; add profile tag to `format_result`)
+- Modify: `smc_watcher.py` (`_send_pair_plan` passes profile + min_rr)
+- Test: `tests/test_smc/test_plan.py`
+
+**Interfaces:**
+- Consumes: `find_target_zones`, `find_h1_zone(max_touches=)`, `h4_choch_direction`, `StrategyProfile`, `get_profile`.
+- Produces: `build_plan(instrument, h4, h1, m5, min_rr: float, profile: StrategyProfile = CONSERVATIVE, market_closed=False) -> PairPlan`; `PairPlan.note` explains a skipped low-RR scenario.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_smc/test_plan.py`:
+
+```python
+from app.services.smc.plan import build_plan
+from app.services.smc.profiles import CONSERVATIVE, AGGRESSIVE
+from app.services.smc.instruments import get_instrument
+
+
+def test_plan_skips_scenario_below_min_rr_with_reason():
+    inst = get_instrument("ETHUSD")
+    h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+    h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+    m5 = make_candles([3140, 3138, 3136])
+    plan = build_plan(inst, h4, h1, m5, min_rr=99.0, profile=CONSERVATIVE)
+    assert plan.scenarios == []
+    assert plan.note is not None
+    assert "1:" in plan.note  # states the achievable RR
+
+
+def test_plan_scenario_meets_min_rr_when_target_exists():
+    inst = get_instrument("ETHUSD")
+    h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+    h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+    m5 = make_candles([3140, 3138, 3136])
+    plan = build_plan(inst, h4, h1, m5, min_rr=1.5, profile=CONSERVATIVE)
+    for s in plan.scenarios:
+        assert s.rr >= 1.5
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pytest tests/test_smc/test_plan.py -k "min_rr" -v`
+Expected: FAIL (`build_plan` has no `min_rr`/`profile` params).
+
+- [ ] **Step 3: Rework `_scenario` to walk targets**
+
+In `app/services/smc/plan.py`, change imports to `find_h1_zone, find_target_zones, h4_choch_direction, detect_trend` and rework `_scenario`:
+
+```python
+def _scenario(
+    instrument, h1, h4, direction, price, speculative, min_rr, profile,
+):
+    """Project a conditional setup; walk targets outward until RR >= min_rr."""
+    zone = find_h1_zone(h1, direction, max_touches=profile.max_zone_touches)
+    if zone is None:
+        return None, None
+    if direction == Direction.LONG:
+        if zone.top >= price:
+            return None, None
+        entry, stop = zone.top, zone.bottom - instrument.sl_buffer
+    else:
+        if zone.bottom <= price:
+            return None, None
+        entry, stop = zone.bottom, zone.top + instrument.sl_buffer
+    risk = abs(entry - stop)
+    if risk <= 0:
+        return None, None
+
+    targets = find_target_zones(h1, direction, entry) + find_target_zones(
+        h4, direction, entry
+    )
+    best_rr = 0.0
+    for target in targets:
+        tp = target.bottom if direction == Direction.LONG else target.top
+        rr = abs(tp - entry) / risk
+        best_rr = max(best_rr, rr)
+        if rr >= min_rr:
+            d = instrument.price_decimals
+            return PlanScenario(
+                direction=direction, entry=round(entry, d),
+                stop_loss=round(stop, d), take_profit=round(tp, d),
+                rr=round(rr, 2), zone_bottom=round(zone.bottom, d),
+                zone_top=round(zone.top, d), speculative=speculative,
+            ), None
+    reason = (
+        f"Zone {'Demand' if direction == Direction.LONG else 'Supply'} "
+        f"{zone.bottom:.{instrument.price_decimals}f}–"
+        f"{zone.top:.{instrument.price_decimals}f} is live, but the nearest "
+        f"target gives 1:{best_rr:.1f} — waiting for other structure"
+    ) if best_rr > 0 else None
+    return None, reason
+```
+
+- [ ] **Step 4: Rework `build_plan`**
+
+```python
+def build_plan(
+    instrument, h4, h1, m5, min_rr, profile=None, market_closed=False,
+):
+    """Build the pre-market plan; only scenarios with RR >= min_rr are shown."""
+    from app.services.smc.profiles import CONSERVATIVE
+    profile = profile or CONSERVATIVE
+    price = round(m5[-1].close, instrument.price_decimals) if m5 else 0.0
+    trend = detect_trend(h4)
+    plan = PairPlan(
+        pair=instrument.key, price=price,
+        price_decimals=instrument.price_decimals, h4_trend=trend,
+        market_closed=market_closed,
+    )
+    if market_closed:
+        plan.note = "Market closed (weekend) — no plan"
+        return plan
+
+    directions = []
+    if trend == Trend.UP:
+        directions = [(Direction.LONG, False)]
+    elif trend == Trend.DOWN:
+        directions = [(Direction.SHORT, False)]
+    elif profile.allow_h4_choch_entry:
+        choch = h4_choch_direction(h4)
+        if choch is not None:
+            directions = [(choch, False)]  # aggressive: first-leg direction
+    if not directions and trend == Trend.FLAT:
+        directions = [(Direction.LONG, True), (Direction.SHORT, True)]
+
+    reasons = []
+    for direction, speculative in directions:
+        scenario, reason = _scenario(
+            instrument, h1, h4, direction, price, speculative, min_rr, profile,
+        )
+        if scenario:
+            plan.scenarios.append(scenario)
+        elif reason:
+            reasons.append(reason)
+
+    if not plan.scenarios:
+        plan.note = reasons[0] if reasons else (
+            "No clean zone with RR >= 1:2 yet — wait for structure to form"
+        )
+    return plan
+```
+
+- [ ] **Step 5: Drop the dead "below 1:2" marker**
+
+In `app/services/smc/notifier.py` `format_plan`, remove the `rr_note` lines (172-174) — with the filter every shown scenario is ≥ min_rr. Replace with:
+
+```python
+        lines.append(f"   📐 RR ~1:{s.rr:.1f} (approx)")
+```
+
+- [ ] **Step 6: Add the profile tag to the alert**
+
+In `notifier.py` `format_result`, after the `<b>{symbol}</b> — Triple Sync + Imbalance` line, append the profile tag when aggressive:
+
+```python
+    lines.append(f"<b>{result.symbol}</b> — Triple Sync + Imbalance")
+    if getattr(result, "profile_key", "conservative") == "aggressive":
+        lines.append("⚡ <b>Aggressive profile</b> — first-leg entry, lower-probability")
+```
+
+- [ ] **Step 7: Update `_send_pair_plan` in `smc_watcher.py`**
+
+```python
+        profile = get_profile(
+            self.state.pair_profile.get(key, settings.smc.default_profile)
+        )
+        plan = build_plan(
+            instrument, data["h4"], data["h1"], data["m5"],
+            min_rr=settings.smc.min_rr, profile=profile, market_closed=stale,
+        )
+```
+
+(`get_profile` import already added in Task 6.)
+
+- [ ] **Step 8: Run plan tests + full suite**
+
+Run: `pytest tests/test_smc/test_plan.py -v && pytest tests/ -v`
+Expected: PASS. Existing plan tests that call `build_plan` without `min_rr` must be updated to pass `min_rr=2.0` — update them in this step (they are test callers, not the rule).
+
+- [ ] **Step 9: Lint and commit**
+
+```bash
+flake8 app/services/smc/plan.py app/services/smc/notifier.py smc_watcher.py tests/test_smc/
+git add app/services/smc/plan.py app/services/smc/notifier.py smc_watcher.py tests/test_smc/
+git commit -m "Plan: walk targets to RR>=1:2, profile-aware, drop dead marker
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Calibrate, document, and open the PR
+
+**Files:**
+- Modify: `app/services/smc/profiles.py` (final `fvg_size_factor`)
+- Modify: `README.md`, `CLAUDE.md`
+
+- [ ] **Step 1: Run the funnel on live data**
+
+```bash
+python -m scripts.funnel --all --days 45
+```
+
+(Needs `TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID` only if a fetcher import pulls settings; a dummy token works. If Twelve Data key is set it uses that, else Yahoo.) Capture the printed funnel per pair per profile.
+
+- [ ] **Step 2: Present numbers to the owner, choose `fvg_size_factor`**
+
+Report to the owner (in Russian): setups/week per profile per pair, funnel death stages, and the near-miss FVG size spread. **The owner picks the factor.** Update `AGGRESSIVE.fvg_size_factor` in `profiles.py` to the agreed value and remove the PLACEHOLDER comment.
+
+- [ ] **Step 3: Update docs**
+
+- `README.md`: replace the "Roadmap — Aggressive breakout mode (not yet implemented)" section with a "Strategy profiles" section documenting `/strategy`, the two profiles, and `SMC_DEFAULT_PROFILE`. Add `SMC_DEFAULT_PROFILE` to the config table. Note `scripts/funnel.py` under project layout.
+- `CLAUDE.md`: add a bullet under "Conventions and gotchas": the engine reads the profile at four points only; `fvg_size_factor` is a multiplier so per-instrument thresholds stay in `instruments.py`; changing a profile clears the pair's dedup keys.
+
+- [ ] **Step 4: Final full run**
+
+Run: `pytest tests/ -v && flake8 app/ tests/ smc_watcher.py`
+Expected: PASS.
+
+- [ ] **Step 5: Commit and open the PR**
+
+```bash
+git add app/services/smc/profiles.py README.md CLAUDE.md
+git commit -m "Calibrate aggressive fvg_size_factor; document strategy profiles
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+git push -u origin feat/aggressive-strategy
+gh pr create --base master --title "Aggressive strategy profile + per-pair switch + RR-filtered plan" --body "..."
+```
+
+PR body follows `.github/pull_request_template.md`. Summarise: the zone-touch bug fix (likely cause of the zero-alert week), the opt-in aggressive profile, `/strategy`, the RR-filtered plan, and the funnel numbers behind the chosen `fvg_size_factor`.
+
+---
+
+## Self-Review notes
+
+- **Spec §1 profiles** → Task 3. **§2 primitives** → Tasks 1, 4. **§3 engine** → Task 5. **§4 switch** → Task 6. **§5 plan** → Task 7. **§6 calibration** → Tasks 2, 8. **Testing** → each task. **Sequencing** → task order (funnel built in Task 2, calibrated in Task 8).
+- **Type consistency:** `zone_touch_span` (Tuple), `find_h1_zone(max_touches=)`, `find_target_zones` + `find_target_zone` wrapper, `h4_choch_direction`, `StrategyProfile` fields, `profile_key`, `set_profile`, `on_set_profile`/`pair_profiles` bot params — all used consistently across tasks.
+- **Dependency note:** Task 2's test imports `app.services.smc.profiles`. If executing strictly in number order, either implement Task 3 before Task 2, or run Task 2's non-profile tests first. Recommended order for a subagent: **1 → 3 → 2 → 4 → 5 → 6 → 7 → 8** (profiles before funnel). This keeps each task's tests green when it lands.

--- a/docs/superpowers/specs/2026-07-25-aggressive-strategy-design.md
+++ b/docs/superpowers/specs/2026-07-25-aggressive-strategy-design.md
@@ -1,0 +1,203 @@
+# Aggressive strategy profile, per-pair switch, RR-filtered plan
+
+Date: 2026-07-25
+Base: `origin/master` @ 4940777
+Branch: `feat/aggressive-strategy`
+
+## Problem
+
+A full week of live running produced **zero forex alerts**. A line-by-line audit of
+the rule funnel found five distinct causes, only one of which is a strategy rule:
+
+1. **`zone_touch_index` returns the LAST touching candle** ([structure.py:203](../../../app/services/smc/structure.py)).
+   While price sits inside the H1 zone, `touch` equals the final candle index, so
+   `find_choch` scans `range(touch, len(candles))` — a single candle. The core
+   trigger of the strategy (an M5 CHoCH *inside* the zone) is invisible until
+   price has already left the zone, by which time the impulse FVG is usually
+   >50% filled and rejected by Rule 4. **This is an implementation bug, not a rule.**
+2. **min FVG = 5 pips on M5 forex** ([instruments.py:38](../../../app/services/smc/instruments.py)).
+   A 5-pip *gap* between candle 1 and candle 3 on EURUSD/USDJPY is a news-scale
+   impulse; the average M5 range there is 3–6 pips. Compounding irony: such
+   impulses cluster on red news, which the −60/+15 blackout excludes.
+3. **H4 FLAT → immediate SKIP** ([engine.py:126](../../../app/services/smc/engine.py)).
+   `detect_trend` demands confirmed HH+HL / LH+LL and `_break_still_holds`
+   downgrades to FLAT on any unreclaimed wick break. In a ranging month FLAT is
+   the normal state for forex.
+4. **A zone touched once is dead forever** ([structure.py:131](../../../app/services/smc/structure.py)).
+   `find_h1_zone` accepts `not tested` only; in chop, zones get pierced constantly.
+5. **FVG scope is the session block** ([sessions.py:71](../../../app/services/smc/sessions.py)).
+   State resets at 14:00 Prague — a London FVG never carries into New York.
+
+Causes 3–5 are deliberate strategy rules; the owner wants them relaxed behind an
+opt-in profile, not removed. Cause 1 is a bug and is fixed unconditionally.
+Cause 2 is a threshold to be **calibrated on historical data**, not guessed.
+
+Two secondary defects, confirmed with the owner:
+
+- `/plan` takes the *nearest* untested opposite zone as TP regardless of RR,
+  producing scenarios like RR 1:0.1 (observed live on ETHUSD 2026-07-25).
+- Switching a pair's profile without clearing its dedup fingerprint would mute
+  the first alert of the new profile — the switch would appear broken.
+
+## Decisions (owner, this session)
+
+| Question | Decision |
+|---|---|
+| What "aggressive" relaxes | All of: H4 CHoCH entry, lower min FVG, first-retest zones, day-wide FVG scope |
+| Where the touch-span bug is fixed | **Both** profiles (over-strict implementation, not a rule) |
+| Switch granularity | **Per pair**, plus an "all pairs" button |
+| Plan RR | Walk targets outward until RR ≥ 1:2; if none qualifies, show no scenario and say why |
+| Threshold source | **Measure on 30–60 days of history first**, then choose |
+| Untouchable in aggressive | Sessions 08–20 Prague, news blackout −60/+15, min RR 1:2, Rule 0.2, Rule 10, risk 2% (no half-lot) |
+| Funnel reporting in Telegram | **Not built** — quiet mode stays; the funnel lives in an offline script |
+
+## Design
+
+### 1. `StrategyProfile` (new: `app/services/smc/profiles.py`)
+
+```python
+@dataclass(frozen=True)
+class StrategyProfile:
+    key: str                    # "conservative" | "aggressive"
+    label: str                  # "🛡 Conservative" | "⚡ Aggressive"
+    allow_h4_choch_entry: bool  # take direction from an H4 CHoCH when trend is FLAT
+    fvg_size_factor: float      # multiplier on Instrument.min_fvg (1.0 = unchanged)
+    max_zone_touches: int       # 0 = untested only, 1 = allow one prior retest
+    fvg_day_scope: bool         # True = FVG valid all Prague day, False = session block
+
+PROFILES: Dict[str, StrategyProfile]  # "conservative" is the default everywhere
+```
+
+`fvg_size_factor` is a **multiplier**, never an absolute threshold: the CLAUDE.md
+invariant "per-instrument parameters live only in `instruments.py`" stays intact.
+`AGGRESSIVE.fvg_size_factor` stays a placeholder until the calibration step (§6)
+produces numbers.
+
+`conservative` = `fvg_size_factor=1.0, max_zone_touches=0, fvg_day_scope=False,
+allow_h4_choch_entry=False` — bit-for-bit today's behaviour.
+
+### 2. Structure primitives (`structure.py`)
+
+**`zone_touch_span(candles, zone) -> Optional[tuple[int, int]]`** replaces
+`zone_touch_index`. Returns `(start, end)` of the **last contiguous excursion**
+into the zone. The engine uses `start` as the search origin for CHoCH and FVG,
+and `end` to test whether price is still inside. `zone_touch_index` is removed
+(single call site) rather than kept as a deprecated alias.
+
+**`h4_choch_direction(candles) -> Optional[Direction]`** — the last confirmed
+pivot whose body was broken and *not* reclaimed, reusing the existing
+`_break_still_holds`. Consulted only when `detect_trend` returns FLAT, so the
+aggressive profile never argues with a live trend; it only speaks where the
+conservative one is silent.
+
+**`find_target_zones(candles, direction, entry) -> List[Zone]`** — all untested
+opposite zones beyond entry, sorted by proximity. `find_target_zone` becomes a
+thin `next(iter(...), None)` wrapper so existing call sites and tests keep working.
+
+**`find_h1_zone(candles, direction, max_touches=0)`** — `_mark_zone_state` already
+computes a touched-and-left flag; extend it to a **count** and accept zones with
+`touches <= max_touches`. Invalidation (body close through the far edge) still
+kills a zone at any touch count.
+
+### 3. Engine (`engine.py`)
+
+`TripleSyncEngine(..., profile=PROFILES["conservative"])`. The profile is read at
+exactly four points:
+
+| Rule | Conservative | Aggressive |
+|---|---|---|
+| 1 — direction | `detect_trend`; FLAT → SKIP | FLAT → try `h4_choch_direction` |
+| 2 — H1 zone | untested only | one prior retest allowed |
+| 4 — FVG size | `instrument.min_fvg` | `× fvg_size_factor` |
+| 4 — FVG scope | session block | whole Prague day |
+
+`AnalysisResult` gains `profile_key: str`. The alert header and `/plan` carry the
+profile tag; `journal.record` persists it (new column via the `db.py` migration
+list) so `/stats` can separate the two regimes.
+
+Rules 5–8 (entry, SL, RR ≥ 1:2, sizing) and every Rule 0/9/10 gate are untouched
+by the profile.
+
+### 4. Per-pair switch (`/strategy`)
+
+`WatcherState.pair_profile: Dict[str, str]` on the existing SQLite kv, default
+`conservative` for every pair — deploying changes nothing until a button is pressed.
+
+Keyboard, modelled on `_pairs_keyboard()`:
+
+```
+🛡 ETHUSD — Conservative
+⚡ USDJPY — Aggressive
+🛡 EURUSD — Conservative
+────────────────────────
+🛡 All conservative    ⚡ All aggressive
+```
+
+On any profile change for a pair, **clear `last_setup[pair]` and
+`zone_pinged[pair]`** — a stale fingerprint from the previous profile would
+suppress the new profile's first alert and make the switch look broken.
+
+`/status` lists each pair's profile. `_build_engine` reads
+`state.pair_profile.get(key, "conservative")`.
+
+### 5. Plan rework (`plan.py`, `notifier.format_plan`)
+
+- `_scenario` walks `find_target_zones(h1) + find_target_zones(h4)` outward and
+  takes the first target with `RR >= min_rr`; the H4 structural extreme is the
+  final fallback.
+- No qualifying target → **no scenario**. The plan states the reason instead:
+  `Zone Supply 1860.34–1864.69 is live, but the nearest target gives 1:0.1 —
+  waiting for other structure.`
+- `min_rr` becomes a required argument of `build_plan` (currently the plan does
+  not know about it at all).
+- The scenario is built with the pair's profile: aggressive allows one-retest
+  zones and projects an H4-CHoCH scenario instead of the FLAT both-way brackets.
+- The `⚠️ below 1:2 — likely SKIP` marker is deleted — unreachable under the filter.
+
+### 6. Offline calibration (`scripts/funnel.py`)
+
+Not part of the worker; run by hand. Fetches H4/H1/M5 for 30–60 days, caches the
+candles on disk (the Twelve Data free tier is 800 req/day), then replays
+`evaluate()` at every M5 close inside session hours for both profiles and all five
+pairs. `evaluate()` is already pure, so the replay needs no network and no mocks.
+
+Output:
+
+- funnel deaths per rule (H4 FLAT / no zone / no touch / no CHoCH / FVG too small / RR < 2)
+- setups per week per profile per pair
+- **size distribution of near-miss FVGs** — the basis for choosing `fvg_size_factor`
+
+The owner picks the threshold from these numbers. A factor that yields 40 setups a
+week is spam, and this step surfaces that before deployment rather than after.
+
+## Testing
+
+- `zone_touch_span`: price inside the zone for 8 candles with a CHoCH on the 4th —
+  currently missed, must be detected after the fix (regression test for cause 1).
+- `h4_choch_direction`: break-and-hold detected; break-and-reclaim returns None.
+- Engine: both profiles over the same synthetic candles — aggressive finds a setup
+  where conservative returns WATCH/SKIP, for each of the four relaxations.
+- **Conservative invariant**: existing `tests/test_smc` fixtures produce identical
+  verdicts, except where the touch-span fix legitimately changes them.
+- Plan: RR filter walks to a farther target; no-qualifying-target renders the
+  explanation line and no scenario.
+- `/strategy`: toggle persists, "all pairs" works, dedup keys cleared on change.
+- All tests stay network-free (`pytest.ini`, `asyncio_mode=auto`).
+
+## Out of scope
+
+Deliberately excluded: a `/funnel` Telegram command, auto-switching profiles by
+market state, half risk in aggressive mode, extended session windows, and any
+change to news blackout, correlation limits or the discipline rules.
+
+## Sequencing
+
+1. Fix `zone_touch_span` + regression test (both profiles) — the single highest-value change.
+2. `scripts/funnel.py`, measure, choose `fvg_size_factor` with the owner.
+3. `profiles.py` + engine wiring + structure primitives.
+4. `/strategy` switch and `/status` display.
+5. Plan RR filter and profile-aware scenarios.
+6. README / CLAUDE.md updates; PR to `master`.
+
+Step 2 gates step 3's threshold, but steps 3–5 can be built with the placeholder
+value and calibrated at the end if the data pull proves slow.

--- a/scripts/funnel.py
+++ b/scripts/funnel.py
@@ -17,7 +17,7 @@ from typing import Dict, List
 from app.services.smc.engine import TripleSyncEngine
 from app.services.smc.instruments import INSTRUMENTS, Instrument, get_instrument
 from app.services.smc.models import AnalysisResult, Candle, Trend, Verdict
-from app.services.smc.profiles import PROFILES, StrategyProfile, get_profile
+from app.services.smc.profiles import PROFILES, StrategyProfile
 from app.services.smc.sessions import active_session
 
 

--- a/scripts/funnel.py
+++ b/scripts/funnel.py
@@ -1,24 +1,43 @@
 """Offline funnel calibration for the SMC strategy (NOT used by the worker).
 
-Replays TripleSyncEngine.evaluate over historical candles for both profiles
-and prints where setups die in the rule funnel and the size distribution of
-near-miss FVGs. Use the numbers to choose StrategyProfile.fvg_size_factor.
+Replays TripleSyncEngine.evaluate over historical candles per strategy
+profile and prints where setups die in the rule funnel. Point-in-time H4/H1
+slicing means each replayed M5 close only sees higher-timeframe candles that
+had actually closed by then (no lookahead), and distinct-setup (rising-edge)
+counting turns "how many M5 closes read approved" into "how many alert
+episodes the bot would have sent" — the number that matters for calibrating
+StrategyProfile.fvg_size_factor.
 
 Usage:
     python -m scripts.funnel --pair ETHUSD --days 45
     python -m scripts.funnel --all --days 45
+    python -m scripts.funnel --pair ETHUSD --days 45 --factors 0.4,0.6,0.8,1.0
+    python -m scripts.funnel --pair ETHUSD --days 45 --legacy   # old dual-profile report
 """
 
 import argparse
 import asyncio
+import dataclasses
 from collections import Counter
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List
+
+import httpx
 
 from app.services.smc.engine import TripleSyncEngine
 from app.services.smc.instruments import INSTRUMENTS, Instrument, get_instrument
 from app.services.smc.models import AnalysisResult, Candle, Trend, Verdict
-from app.services.smc.profiles import PROFILES, StrategyProfile
-from app.services.smc.sessions import active_session
+from app.services.smc.profiles import AGGRESSIVE, CONSERVATIVE, PROFILES, StrategyProfile
+from app.services.smc.sessions import active_session, to_prague
+
+# Minimum point-in-time H4/H1 candles required before evaluate() is allowed to
+# run (protects detect_trend()/find_pivots() from reading a near-empty
+# series). The brief's suggested default was 20; tuned down to 15 here — see
+# funnel-v2-report.md for the fixture math that requires <=17 to keep the
+# original replay_funnel test green under real point-in-time slicing.
+PIT_FLOOR = 15
+
+BINANCE_BASE = "https://api.binance.com"
 
 
 def classify_result(result: AnalysisResult) -> str:
@@ -43,6 +62,16 @@ def classify_result(result: AnalysisResult) -> str:
     return "other"
 
 
+def session_day_span(m5: List[Candle]) -> int:
+    """Count distinct Prague calendar days among the in-session M5 candles."""
+    days = {
+        to_prague(c.timestamp).date()
+        for c in m5
+        if active_session(c.timestamp) is not None
+    }
+    return len(days)
+
+
 def replay_funnel(
     instrument: Instrument,
     h4: List[Candle],
@@ -52,8 +81,20 @@ def replay_funnel(
     min_rr: float,
     warmup: int = 60,
 ) -> Dict[str, int]:
-    """Replay evaluate() at each M5 close (after `warmup` candles). Off-session
-    candles are skipped. Returns a Counter of funnel-stage labels."""
+    """Replay evaluate() at each M5 close (after `warmup` candles).
+
+    Off-session candles are skipped. At each step h4/h1 are sliced to only
+    the candles that had closed by the current M5 close time (point-in-time —
+    replaying an old M5 close must not see H4/H1 candles from the future).
+    Steps with too little point-in-time history are counted as "warmup".
+
+    Returns a Counter of funnel-stage labels, plus "distinct_setups" (a
+    rising-edge count of transitions into "approved" — how many alert
+    episodes the bot would have sent, as opposed to how many M5 closes a
+    persisting setup was re-counted on) and "session_days" (the number of
+    distinct Prague trading days spanned by the replayed M5 candles, for
+    turning distinct_setups into a setups-per-week rate).
+    """
     engine = TripleSyncEngine(
         instrument=instrument, min_rr=min_rr, enforce_sessions=True,
         profile=profile, fetcher=None,
@@ -62,11 +103,18 @@ def replay_funnel(
     start = max(warmup, 2)
     # If warmup exceeds available data, use what we have
     start = min(start, len(m5) - 1)
+    prev_approved = False
     for i in range(start, len(m5) + 1):
         window = m5[:i]
         now = window[-1].timestamp
         if active_session(now, require_weekday=instrument.source == "forex") is None:
             counts["off_session"] += 1
+            continue
+        cutoff = window[-1].timestamp
+        h4_pit = [c for c in h4 if c.timestamp <= cutoff]
+        h1_pit = [c for c in h1 if c.timestamp <= cutoff]
+        if len(h4_pit) < PIT_FLOOR or len(h1_pit) < PIT_FLOOR:
+            counts["warmup"] += 1
             continue
         result = AnalysisResult(
             symbol=instrument.key, verdict=Verdict.SKIP, checked_at=now,
@@ -74,26 +122,121 @@ def replay_funnel(
         )
         result.session_name = active_session(now)
         result.price = window[-1].close
-        result = engine.evaluate(h4=h4, h1=h1, m5=window, result=result)
-        counts[classify_result(result)] += 1
+        result = engine.evaluate(h4=h4_pit, h1=h1_pit, m5=window, result=result)
+        stage = classify_result(result)
+        counts[stage] += 1
+        approved_now = stage == "approved"
+        if approved_now and not prev_approved:
+            counts["distinct_setups"] += 1
+        prev_approved = approved_now
+    counts["session_days"] = session_day_span(m5[max(start - 1, 0):])
     return dict(counts)
 
 
-async def _run(pairs: List[str], days: int) -> None:
+async def fetch_binance_history(symbol: str, interval: str, days: int) -> List[Candle]:
+    """Page Binance klines from `days` ago up to now (funnel-local — do not
+    use app.services.smc.data.BinanceDataFetcher.fetch_candles() here, it
+    only returns the last `limit` candles: ~1.5 days of M5, far too shallow
+    to calibrate fvg_size_factor against distinct setups per week).
+
+    Builds Candle objects the same way data.py does, and drops the
+    in-progress last candle by close-time > now.
+    """
+    now = datetime.now(timezone.utc)
+    start_ms = int((now - timedelta(days=days)).timestamp() * 1000)
+    now_ms = int(now.timestamp() * 1000)
+    rows: List[list] = []
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        while start_ms < now_ms:
+            params = {
+                "symbol": symbol, "interval": interval,
+                "startTime": start_ms, "limit": 1000,
+            }
+            response = await client.get(f"{BINANCE_BASE}/api/v3/klines", params=params)
+            response.raise_for_status()
+            batch = response.json()
+            if not batch:
+                break
+            rows.extend(batch)
+            start_ms = batch[-1][6] + 1  # next page starts after this close time
+            if len(batch) < 1000:
+                break  # caught up to "now"
+
+    candles = [
+        Candle(
+            timestamp=datetime.fromtimestamp(row[0] / 1000, tz=timezone.utc),
+            open=float(row[1]),
+            high=float(row[2]),
+            low=float(row[3]),
+            close=float(row[4]),
+            volume=float(row[5]),
+        )
+        for row in rows
+    ]
+    if rows and rows[-1][6] > now_ms:
+        candles = candles[:-1]
+    return candles
+
+
+def build_factor_profile(factor: float) -> StrategyProfile:
+    """Derive an AGGRESSIVE variant with a different fvg_size_factor."""
+    return dataclasses.replace(AGGRESSIVE, fvg_size_factor=factor, key=f"aggr{factor}")
+
+
+def parse_factors(raw: str) -> List[float]:
+    """Parse a comma list like '0.4,0.6' into [0.4, 0.6]."""
+    return [float(x) for x in raw.split(",") if x.strip()]
+
+
+async def _run(pairs: List[str], days: int, factors: List[float], legacy: bool) -> None:
     from smc_watcher import _build_fetcher  # reuse the worker's source resolution
 
     for key in pairs:
         instrument = get_instrument(key)
-        fetcher = _build_fetcher(instrument)
-        data = await fetcher.fetch_all_timeframes()
-        print(f"\n=== {key} — last {len(data['m5'])} M5 candles ===")
-        for profile in PROFILES.values():
-            counts = replay_funnel(
-                instrument, data["h4"], data["h1"], data["m5"], profile, min_rr=2.0
+        if instrument.source == "crypto":
+            symbol = instrument.source_symbol
+            h4 = await fetch_binance_history(symbol, "4h", days)
+            h1 = await fetch_binance_history(symbol, "1h", days)
+            m5 = await fetch_binance_history(symbol, "5m", days)
+        else:
+            print(f"  note: {key} is forex — Yahoo caps 5m history, depth is feed-limited")
+            fetcher = _build_fetcher(instrument)
+            data = await fetcher.fetch_all_timeframes()
+            h4, h1, m5 = data["h4"], data["h1"], data["m5"]
+
+        print(f"\n=== {key} — {len(m5)} M5 candles ===")
+
+        if legacy:
+            for profile in PROFILES.values():
+                counts = replay_funnel(instrument, h4, h1, m5, profile, min_rr=2.0)
+                in_session = sum(v for k, v in counts.items() if k != "off_session")
+                print(f"  {profile.label}: {counts}")
+                print(
+                    f"    in-session checks: {in_session}, "
+                    f"approved: {counts.get('approved', 0)}, "
+                    f"distinct setups: {counts.get('distinct_setups', 0)}"
+                )
+            continue
+
+        rows = [("baseline", CONSERVATIVE)] + [
+            (f"{f:g}", build_factor_profile(f)) for f in factors
+        ]
+        print(f"  {'factor':<10}{'distinct':>10}{'setups/wk':>12}{'approved':>10}  died")
+        for label, profile in rows:
+            counts = replay_funnel(instrument, h4, h1, m5, profile, min_rr=2.0)
+            session_days = max(counts.get("session_days", 0), 1)
+            setups_per_week = counts.get("distinct_setups", 0) / session_days * 5
+            died = {
+                k: v for k, v in counts.items()
+                if k not in (
+                    "approved", "distinct_setups", "session_days",
+                    "off_session", "warmup",
+                )
+            }
+            print(
+                f"  {label:<10}{counts.get('distinct_setups', 0):>10}"
+                f"{setups_per_week:>12.2f}{counts.get('approved', 0):>10}  {died}"
             )
-            in_session = sum(v for k, v in counts.items() if k != "off_session")
-            print(f"  {profile.label}: {counts}")
-            print(f"    in-session checks: {in_session}, approved: {counts.get('approved', 0)}")
 
 
 def main() -> None:
@@ -101,9 +244,18 @@ def main() -> None:
     parser.add_argument("--pair", default="ETHUSD")
     parser.add_argument("--all", action="store_true")
     parser.add_argument("--days", type=int, default=45)
+    parser.add_argument(
+        "--factors", default="0.4,0.6,0.8,1.0",
+        help="comma list of fvg_size_factor values to sweep (aggressive profile)",
+    )
+    parser.add_argument(
+        "--legacy", action="store_true",
+        help="run the old dual-profile report instead of the fvg_size_factor sweep",
+    )
     args = parser.parse_args()
     pairs = list(INSTRUMENTS) if args.all else [args.pair]
-    asyncio.run(_run(pairs, args.days))
+    factors = parse_factors(args.factors)
+    asyncio.run(_run(pairs, args.days, factors, args.legacy))
 
 
 if __name__ == "__main__":

--- a/scripts/funnel.py
+++ b/scripts/funnel.py
@@ -1,0 +1,110 @@
+"""Offline funnel calibration for the SMC strategy (NOT used by the worker).
+
+Replays TripleSyncEngine.evaluate over historical candles for both profiles
+and prints where setups die in the rule funnel and the size distribution of
+near-miss FVGs. Use the numbers to choose StrategyProfile.fvg_size_factor.
+
+Usage:
+    python -m scripts.funnel --pair ETHUSD --days 45
+    python -m scripts.funnel --all --days 45
+"""
+
+import argparse
+import asyncio
+from collections import Counter
+from typing import Dict, List
+
+from app.services.smc.engine import TripleSyncEngine
+from app.services.smc.instruments import INSTRUMENTS, Instrument, get_instrument
+from app.services.smc.models import AnalysisResult, Candle, Trend, Verdict
+from app.services.smc.profiles import PROFILES, StrategyProfile, get_profile
+from app.services.smc.sessions import active_session
+
+
+def classify_result(result: AnalysisResult) -> str:
+    """Map an evaluate() outcome to a funnel stage label."""
+    if result.verdict in (Verdict.APPROVED_LIMIT, Verdict.APPROVED_MARKET):
+        return "approved"
+    if result.verdict == Verdict.OFF_SESSION:
+        return "off_session"
+    reason = (result.reasons[0] if result.reasons else "").lower()
+    if result.h4_trend == Trend.FLAT and "no direction" in reason:
+        return "h4_flat"
+    if "no valid untested" in reason or "no untested opposite" in reason:
+        return "no_zone"
+    if "has not reached" in reason or "pullback phase" in reason:
+        return "no_touch"
+    if "has not printed a choch" in reason:
+        return "no_choch"
+    if "no valid fvg" in reason:
+        return "fvg_small"
+    if "rr 1:" in reason:
+        return "rr_low"
+    return "other"
+
+
+def replay_funnel(
+    instrument: Instrument,
+    h4: List[Candle],
+    h1: List[Candle],
+    m5: List[Candle],
+    profile: StrategyProfile,
+    min_rr: float,
+    warmup: int = 60,
+) -> Dict[str, int]:
+    """Replay evaluate() at each M5 close (after `warmup` candles). Off-session
+    candles are skipped. Returns a Counter of funnel-stage labels."""
+    engine = TripleSyncEngine(
+        instrument=instrument, min_rr=min_rr, enforce_sessions=True,
+        profile=profile, fetcher=None,
+    )
+    counts: Counter = Counter()
+    start = max(warmup, 2)
+    # If warmup exceeds available data, use what we have
+    start = min(start, len(m5) - 1)
+    for i in range(start, len(m5) + 1):
+        window = m5[:i]
+        now = window[-1].timestamp
+        if active_session(now, require_weekday=instrument.source == "forex") is None:
+            counts["off_session"] += 1
+            continue
+        result = AnalysisResult(
+            symbol=instrument.key, verdict=Verdict.SKIP, checked_at=now,
+            price_decimals=instrument.price_decimals,
+        )
+        result.session_name = active_session(now)
+        result.price = window[-1].close
+        result = engine.evaluate(h4=h4, h1=h1, m5=window, result=result)
+        counts[classify_result(result)] += 1
+    return dict(counts)
+
+
+async def _run(pairs: List[str], days: int) -> None:
+    from smc_watcher import _build_fetcher  # reuse the worker's source resolution
+
+    for key in pairs:
+        instrument = get_instrument(key)
+        fetcher = _build_fetcher(instrument)
+        data = await fetcher.fetch_all_timeframes()
+        print(f"\n=== {key} — last {len(data['m5'])} M5 candles ===")
+        for profile in PROFILES.values():
+            counts = replay_funnel(
+                instrument, data["h4"], data["h1"], data["m5"], profile, min_rr=2.0
+            )
+            in_session = sum(v for k, v in counts.items() if k != "off_session")
+            print(f"  {profile.label}: {counts}")
+            print(f"    in-session checks: {in_session}, approved: {counts.get('approved', 0)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="SMC funnel calibration")
+    parser.add_argument("--pair", default="ETHUSD")
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument("--days", type=int, default=45)
+    args = parser.parse_args()
+    pairs = list(INSTRUMENTS) if args.all else [args.pair]
+    asyncio.run(_run(pairs, args.days))
+
+
+if __name__ == "__main__":
+    main()

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -93,7 +93,9 @@ def _build_fetcher(instrument: Instrument):
     return YahooDataFetcher(symbol=f"{instrument.key}=X")
 
 
-def _build_engine(instrument: Instrument) -> TripleSyncEngine:
+def _build_engine(instrument: Instrument, profile=None) -> TripleSyncEngine:
+    from app.services.smc.profiles import CONSERVATIVE
+
     fetcher = _build_fetcher(instrument)
     smc = settings.smc
     return TripleSyncEngine(
@@ -102,6 +104,7 @@ def _build_engine(instrument: Instrument) -> TripleSyncEngine:
         risk_pct=smc.risk_pct,
         deposit=smc.deposit,
         enforce_sessions=smc.enforce_sessions,
+        profile=profile or CONSERVATIVE,
         fetcher=fetcher,
     )
 
@@ -202,6 +205,8 @@ class Watcher:
             on_trade_mark=self.mark_trade,
             on_plan=self.on_plan,
             trade_journal=self.trade_journal,
+            on_set_profile=self.state.set_profile,
+            pair_profiles=lambda: dict(self.state.pair_profile),
         )
         self.last_results: Dict[str, AnalysisResult] = {}
         # apply the env default on the very first start (DB wins afterwards)
@@ -216,7 +221,12 @@ class Watcher:
     async def check_pair(self, key: str) -> Tuple[str, Optional[AnalysisResult]]:
         """Analyze one pair. Returns (heartbeat line, result or None)."""
         instrument = get_instrument(key)
-        engine = _build_engine(instrument)
+        from app.services.smc.profiles import get_profile
+
+        profile = get_profile(
+            self.state.pair_profile.get(key, settings.smc.default_profile)
+        )
+        engine = _build_engine(instrument, profile)
         try:
             result = await engine.analyze()
         except Exception as e:
@@ -508,7 +518,14 @@ class Watcher:
             now, require_weekday=instrument.source == "forex"
         )
         res.price = data["m5"][-1].close
-        res = _build_engine(instrument).evaluate(
+        from app.services.smc.profiles import get_profile
+
+        profile = get_profile(
+            self.state.pair_profile.get(
+                instrument.key, settings.smc.default_profile
+            )
+        )
+        res = _build_engine(instrument, profile).evaluate(
             h4=data["h4"], h1=data["h1"], m5=data["m5"], result=res
         )
         d = instrument.price_decimals
@@ -608,13 +625,23 @@ class Watcher:
         lines = [
             "<b>SMC Watcher — status</b>",
             f"Pairs: {', '.join(self.state.pairs) or 'none'}",
+        ]
+        from app.services.smc.profiles import get_profile
+
+        profiles_line = ", ".join(
+            f"{k} {get_profile(self.state.pair_profile.get(k, settings.smc.default_profile)).label}"
+            for k in self.state.pairs
+        )
+        if profiles_line:
+            lines.append(f"Profiles: {profiles_line}")
+        lines.extend([
             f"Forex data: {_forex_source()} | crypto: Binance",
             f"Session now: {session or 'off session'}",
             f"Cadence: {settings.smc.session_interval_minutes} min in session / "
             f"{settings.smc.interval_minutes} min off",
             "Deposit for sizing: "
             + (f"${settings.smc.deposit:.0f}" if settings.smc.deposit else "not set"),
-        ]
+        ])
         muted = [
             f"{k} ({left})"
             for k in self.state.pairs

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -207,6 +207,8 @@ class Watcher:
             trade_journal=self.trade_journal,
             on_set_profile=self.state.set_profile,
             pair_profiles=lambda: dict(self.state.pair_profile),
+            default_profile=settings.smc.default_profile,
+            on_set_all_profiles=self.state.set_all_profiles,
         )
         self.last_results: Dict[str, AnalysisResult] = {}
         # apply the env default on the very first start (DB wins afterwards)

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -474,6 +474,7 @@ class Watcher:
         """Build and send one pair's Pre-Market Plan (text + H1 chart)."""
         from app.services.smc.chart import render_plan_chart
         from app.services.smc.plan import build_plan
+        from app.services.smc.profiles import get_profile
 
         instrument = get_instrument(key)
         try:
@@ -489,8 +490,12 @@ class Watcher:
             instrument.source == "forex"
             and now - data["m5"][-1].timestamp > timedelta(minutes=30)
         )
+        profile = get_profile(
+            self.state.pair_profile.get(key, settings.smc.default_profile)
+        )
         plan = build_plan(
-            instrument, data["h4"], data["h1"], data["m5"], market_closed=stale
+            instrument, data["h4"], data["h1"], data["m5"],
+            min_rr=settings.smc.min_rr, profile=profile, market_closed=stale,
         )
         live_line = None if stale else self._live_status(instrument, data, now)
         as_of = to_prague(data["m5"][-1].timestamp).strftime("%H:%M")

--- a/tests/test_smc/helpers.py
+++ b/tests/test_smc/helpers.py
@@ -108,3 +108,26 @@ def m5_long_trigger() -> List[Candle]:
         (3151.0, 3152.0, 3149.0, 3150.0),
     ]
     return [candle(*row, index=i) for i, row in enumerate(spec)]
+
+
+def m5_choch_still_in_zone() -> List[Candle]:
+    """M5 where the bullish CHoCH forms and price STAYS inside the demand zone
+    to the end of the series — the exact case the touch-span fix targets.
+
+    Against a demand zone of 3130-3140:
+    - a high pivot at index 2 (high 3149) sits ABOVE the zone (indices 0-4
+      never enter it), so it is a valid CHoCH reference level
+    - price declines into the zone at index 5; the contiguous excursion runs
+      indices 5-10 with no exit before the series ends
+    - the CHoCH candle at index 8 dips into the zone (low 3137.6) while its
+      body closes at 3151, breaking the 3149 pivot
+    - price then hovers in the zone at indices 9-10
+
+    The old `zone_touch_index` returned the LAST in-zone candle (index 10,
+    after the CHoCH), collapsing `find_choch`'s window to nothing → no trigger.
+    `zone_touch_span` returns the excursion START (index 5), so the CHoCH at
+    index 8 is inside the search window.
+    """
+    return make_candles(
+        [3143, 3146, 3148, 3145, 3143, 3140, 3138, 3138, 3151, 3140, 3138]
+    )

--- a/tests/test_smc/test_db.py
+++ b/tests/test_smc/test_db.py
@@ -3,6 +3,14 @@
 from app.services.smc.db import Database
 
 
+def test_signal_profile_key_column(tmp_path):
+    from app.services.smc.db import Database, SIGNAL_COLUMNS
+    assert "profile_key" in SIGNAL_COLUMNS
+    db = Database(str(tmp_path / "t.db"))
+    cols = {r["name"] for r in db.conn.execute("PRAGMA table_info(signals)")}
+    assert "profile_key" in cols
+
+
 class TestDatabaseOpen:
     def test_creates_missing_parent_directories(self, tmp_path):
         path = tmp_path / "nested" / "dirs" / "smc.db"

--- a/tests/test_smc/test_engine.py
+++ b/tests/test_smc/test_engine.py
@@ -44,6 +44,20 @@ class TestApprovedSetup:
         assert setup.rr >= 2.0
         assert not setup.entry_is_market  # last close 3150 is above the FVG
 
+    def test_choch_inside_zone_is_seen_while_price_still_in_zone(self):
+        # m5_long_trigger ends with the CHoCH candle (index 16) and price
+        # still hovering in/around the zone at the tail. Before the span fix
+        # the search window was a single candle and this returned WATCH.
+        result = _engine().evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(),
+            result=_fresh_result(),
+        )
+        assert result.verdict in (
+            Verdict.APPROVED_LIMIT, Verdict.APPROVED_MARKET
+        )
+
     def test_lot_hint_computed_from_deposit(self):
         result = _engine(deposit=1000.0, risk_pct=2.0).evaluate(
             h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),

--- a/tests/test_smc/test_engine.py
+++ b/tests/test_smc/test_engine.py
@@ -44,20 +44,6 @@ class TestApprovedSetup:
         assert setup.rr >= 2.0
         assert not setup.entry_is_market  # last close 3150 is above the FVG
 
-    def test_choch_inside_zone_is_seen_while_price_still_in_zone(self):
-        # m5_long_trigger ends with the CHoCH candle (index 16) and price
-        # still hovering in/around the zone at the tail. Before the span fix
-        # the search window was a single candle and this returned WATCH.
-        result = _engine().evaluate(
-            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
-            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
-            m5=m5_long_trigger(),
-            result=_fresh_result(),
-        )
-        assert result.verdict in (
-            Verdict.APPROVED_LIMIT, Verdict.APPROVED_MARKET
-        )
-
     def test_lot_hint_computed_from_deposit(self):
         result = _engine(deposit=1000.0, risk_pct=2.0).evaluate(
             h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),

--- a/tests/test_smc/test_engine.py
+++ b/tests/test_smc/test_engine.py
@@ -3,10 +3,13 @@
 from datetime import datetime, timezone
 
 from app.services.smc.engine import TripleSyncEngine
+from app.services.smc.instruments import get_instrument
 from app.services.smc.models import AnalysisResult, Direction, Trend, Verdict
+from app.services.smc.profiles import AGGRESSIVE, CONSERVATIVE
 from tests.test_smc.helpers import (
     H1_PULLBACK_CLOSES,
     H4_UPTREND_CLOSES,
+    candle,
     m5_long_trigger,
     make_candles,
 )
@@ -22,6 +25,12 @@ def _fresh_result() -> AnalysisResult:
 
 def _engine(**kwargs) -> TripleSyncEngine:
     defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, min_rr=2.0)
+    defaults.update(kwargs)
+    return TripleSyncEngine(**defaults)
+
+
+def _agg_engine(**kwargs) -> TripleSyncEngine:
+    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, min_rr=2.0, profile=AGGRESSIVE)
     defaults.update(kwargs)
     return TripleSyncEngine(**defaults)
 
@@ -98,3 +107,104 @@ class TestSkipsAndWatch:
         )
         assert result.verdict == Verdict.SKIP
         assert any("RR" in r for r in result.reasons)
+
+
+class TestProfiles:
+    def test_result_carries_profile_key(self):
+        result = _engine().evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(),
+            result=_fresh_result(),
+        )
+        assert result.profile_key == "conservative"
+
+    def test_aggressive_takes_direction_from_h4_choch_when_flat(self):
+        # H4 structure: a real HH+HL leg (shared prefix with H4_UPTREND_CLOSES)
+        # followed by a decline that breaks below the last confirmed low and
+        # never reclaims it. Only one low pivot ever confirms (the decline is
+        # monotonic), so detect_trend() sees < 2 confirmed lows -> FLAT; but
+        # h4_choch_direction() still finds the unreclaimed break-down -> SHORT.
+        # (Hand-verified: the brief's own closes list produces zero confirmed
+        # pivots at all — tied fractal highs/lows — so h4_choch_direction()
+        # returns None there. This data was substituted to actually exercise
+        # the aggressive H4-CHoCH path; see task-5-report.md.)
+        closes = [
+            3000, 3020, 3040, 3060, 3080, 3100, 3090, 3075, 3060, 3050,
+            3070, 3100, 3140, 3170, 3200, 3185, 3160, 3140, 3120,
+            3100, 3080, 3050, 3000, 2950,
+        ]
+        h4 = make_candles(closes, step_minutes=240)
+        # conservative: FLAT -> SKIP
+        cons = _engine().evaluate(
+            h4=h4, h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(), result=_fresh_result(),
+        )
+        assert cons.verdict == Verdict.SKIP
+        assert "no direction" in " ".join(cons.reasons).lower()
+        # aggressive: consults h4_choch_direction (no crash, direction resolved)
+        agg = _agg_engine().evaluate(
+            h4=h4, h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger(), result=_fresh_result(),
+        )
+        assert agg.profile_key == "aggressive"
+        # with a downward CHoCH the aggressive path no longer SKIPs on "no direction"
+        assert "no direction" not in " ".join(agg.reasons).lower()
+
+
+class TestCryptoSameDayFallbackSurvivesProfileWiring:
+    def test_crypto_conservative_still_accepts_cross_session_fvg(self):
+        """Regression for the crypto same_day fallback (`or source ==
+        "crypto"`). CONSERVATIVE has fvg_day_scope=False, so without the
+        fallback the engine would fall back to same_session and reject an
+        FVG that formed in a different Prague session window than "now".
+
+        Full end-to-end evaluate(): same OHLC shape as m5_long_trigger()
+        (proven to APPROVE with entry=3139.5 at the earliest FVG, index 15),
+        but shifted so index 15 (13:50 Prague, Frankfurt/London window) and
+        index 19 (14:10 Prague, New York window) straddle the 14:00 session
+        boundary while staying on the same Prague calendar day.
+
+        If the crypto fallback were missing, same_session would reject the
+        index-15 FVG and the engine would instead pick the later index-17
+        FVG (entry 3147.0) that shares "now"'s session -- so pinning the
+        exact entry price proves the same_day (not same_session) scope won.
+        """
+        spec = [
+            (3160.0, 3161.0, 3155.0, 3156.0),
+            (3156.0, 3157.0, 3151.0, 3152.0),
+            (3152.0, 3153.0, 3147.0, 3148.0),
+            (3148.0, 3149.0, 3143.0, 3144.0),
+            (3144.0, 3145.0, 3140.0, 3142.0),
+            (3142.0, 3146.0, 3141.0, 3145.0),
+            (3145.0, 3148.0, 3144.0, 3147.0),
+            (3147.0, 3147.5, 3141.0, 3142.0),
+            (3142.0, 3143.0, 3137.0, 3138.0),
+            (3138.0, 3139.0, 3133.0, 3134.0),
+            (3134.0, 3135.0, 3130.0, 3131.0),
+            (3131.0, 3133.0, 3130.5, 3132.0),
+            (3132.0, 3134.0, 3131.0, 3133.0),
+            (3133.0, 3136.0, 3132.0, 3135.5),
+            (3135.5, 3141.0, 3135.0, 3140.5),
+            (3140.5, 3144.0, 3139.5, 3143.0),
+            (3143.0, 3149.5, 3142.0, 3149.0),
+            (3149.0, 3151.0, 3147.0, 3150.0),
+            (3150.0, 3152.0, 3148.0, 3151.0),
+            (3151.0, 3152.0, 3149.0, 3150.0),
+        ]
+        cross_session_start = datetime(2026, 7, 6, 10, 35, tzinfo=timezone.utc)
+        m5 = [
+            candle(*row, index=i, start=cross_session_start)
+            for i, row in enumerate(spec)
+        ]
+
+        engine = _engine(instrument=get_instrument("ETHUSD"), profile=CONSERVATIVE)
+        result = engine.evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5,
+            result=_fresh_result(),
+        )
+        assert result.verdict == Verdict.APPROVED_LIMIT
+        assert result.setup.entry == 3139.5  # earliest FVG (index 15), only
+        # reachable via same_trading_day scope, not same_session

--- a/tests/test_smc/test_funnel.py
+++ b/tests/test_smc/test_funnel.py
@@ -1,9 +1,19 @@
-from scripts.funnel import replay_funnel, classify_result
+from datetime import timedelta
+
+from scripts.funnel import (
+    build_factor_profile,
+    classify_result,
+    parse_factors,
+    replay_funnel,
+    session_day_span,
+)
+import scripts.funnel as funnel_mod
 from app.services.smc.models import AnalysisResult, Verdict, Trend
 from app.services.smc.profiles import get_profile
 from app.services.smc.instruments import get_instrument
 from tests.test_smc.helpers import (
-    H1_PULLBACK_CLOSES, H4_UPTREND_CLOSES, m5_long_trigger, make_candles,
+    SESSION_BASE, H1_PULLBACK_CLOSES, H4_UPTREND_CLOSES, candle,
+    m5_long_trigger, make_candles,
 )
 
 
@@ -21,12 +31,116 @@ def test_classify_flat_h4():
 
 
 def test_replay_counts_at_least_one_approved_on_the_trigger_fixture():
+    # H4/H1 are shifted so their history is fully closed at/before
+    # SESSION_BASE (the m5 fixture's start) — a realistic point-in-time
+    # snapshot, rather than the old same-origin fixture whose H4/H1 extended
+    # chronologically *past* the m5 replay window and got excluded entirely
+    # once replay_funnel started point-in-time slicing h4/h1 by timestamp.
+    h4 = make_candles(
+        H4_UPTREND_CLOSES,
+        start=SESSION_BASE - timedelta(minutes=240 * (len(H4_UPTREND_CLOSES) - 1)),
+        step_minutes=240,
+    )
+    h1 = make_candles(
+        H1_PULLBACK_CLOSES,
+        start=SESSION_BASE - timedelta(minutes=60 * (len(H1_PULLBACK_CLOSES) - 1)),
+        step_minutes=60,
+    )
     counts = replay_funnel(
         get_instrument("ETHUSD"),
-        make_candles(H4_UPTREND_CLOSES, step_minutes=240),
-        make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+        h4,
+        h1,
         m5_long_trigger(),
         profile=get_profile("conservative"),
         min_rr=2.0,
     )
     assert counts["approved"] >= 1
+
+
+def test_replay_uses_point_in_time_h4h1():
+    """The final up-leg of H4_UPTREND_CLOSES (indices 19-24) is timestamped
+    *after* the entire m5 replay window closes — i.e. it has not printed yet
+    at any replay step. Point-in-time slicing must not let the engine see it:
+    only 1 confirmed low exists in the visible (past) H4 candles, so the
+    trend reads FLAT and (with the conservative profile, which does not take
+    an H4-CHoCH entry) nothing is ever approved. Without the point-in-time
+    fix, the full 25-candle H4 array (which the *existing* test above proves
+    resolves to a clean uptrend) would be fed at every step and this fixture
+    would approve — so an "approved" count of 0 here demonstrates no future
+    H4 leaked into the replay."""
+    past_closes = H4_UPTREND_CLOSES[:19]
+    future_closes = H4_UPTREND_CLOSES[19:]
+    h4 = make_candles(
+        past_closes,
+        start=SESSION_BASE - timedelta(minutes=240 * (len(past_closes) - 1)),
+        step_minutes=240,
+    ) + make_candles(
+        future_closes,
+        start=SESSION_BASE + timedelta(minutes=200),
+        step_minutes=240,
+    )
+    h1 = make_candles(
+        H1_PULLBACK_CLOSES,
+        start=SESSION_BASE - timedelta(minutes=60 * (len(H1_PULLBACK_CLOSES) - 1)),
+        step_minutes=60,
+    )
+    m5 = m5_long_trigger()
+
+    counts = replay_funnel(
+        get_instrument("ETHUSD"), h4, h1, m5,
+        profile=get_profile("conservative"), min_rr=2.0,
+    )
+
+    assert counts.get("approved", 0) == 0
+    assert counts.get("h4_flat", 0) >= 1
+    assert counts["session_days"] >= 1
+
+
+def test_distinct_setups_collapses_persisting_approved(monkeypatch):
+    # classify_result is patched to always report "approved" so a run of
+    # consecutive M5 closes simulates a setup that persists across several
+    # candles (as a real approved zone/FVG does) without needing an engine
+    # fixture that stays approved for many bars.
+    monkeypatch.setattr(funnel_mod, "classify_result", lambda result: "approved")
+
+    n_h4h1 = 20
+    h4 = make_candles(
+        [3000.0] * n_h4h1,
+        start=SESSION_BASE - timedelta(minutes=240 * (n_h4h1 - 1)),
+        step_minutes=240,
+    )
+    h1 = make_candles(
+        [3000.0] * n_h4h1,
+        start=SESSION_BASE - timedelta(minutes=60 * (n_h4h1 - 1)),
+        step_minutes=60,
+    )
+    m5 = make_candles([3000.0] * 7, step_minutes=5)
+
+    counts = funnel_mod.replay_funnel(
+        get_instrument("ETHUSD"), h4, h1, m5,
+        profile=get_profile("conservative"), min_rr=2.0, warmup=2,
+    )
+
+    assert counts["approved"] >= 3
+    assert counts["distinct_setups"] == 1
+
+
+def test_session_day_span_counts_distinct_prague_days():
+    same_day = make_candles([3000.0, 3010.0], start=SESSION_BASE, step_minutes=5)
+    assert session_day_span(same_day) == 1
+
+    two_days = [
+        candle(3000.0, 3001.0, 2999.0, 3000.0, index=0, start=SESSION_BASE),
+        candle(
+            3000.0, 3001.0, 2999.0, 3000.0, index=0,
+            start=SESSION_BASE + timedelta(days=1),
+        ),
+    ]
+    assert session_day_span(two_days) == 2
+
+
+def test_factor_sweep_runs_each_factor():
+    profile = build_factor_profile(0.6)
+    assert profile.fvg_size_factor == 0.6
+
+    assert parse_factors("0.4,0.6") == [0.4, 0.6]

--- a/tests/test_smc/test_funnel.py
+++ b/tests/test_smc/test_funnel.py
@@ -1,0 +1,32 @@
+from scripts.funnel import replay_funnel, classify_result
+from app.services.smc.models import AnalysisResult, Verdict, Trend
+from app.services.smc.profiles import get_profile
+from app.services.smc.instruments import get_instrument
+from tests.test_smc.helpers import (
+    H1_PULLBACK_CLOSES, H4_UPTREND_CLOSES, m5_long_trigger, make_candles,
+)
+
+
+def test_classify_approved():
+    r = AnalysisResult(symbol="ETHUSD", verdict=Verdict.APPROVED_LIMIT,
+                       checked_at=None)
+    assert classify_result(r) == "approved"
+
+
+def test_classify_flat_h4():
+    r = AnalysisResult(symbol="ETHUSD", verdict=Verdict.SKIP, checked_at=None)
+    r.h4_trend = Trend.FLAT
+    r.reasons = ["H4 is flat or CHoCH against the trend — no direction"]
+    assert classify_result(r) == "h4_flat"
+
+
+def test_replay_counts_at_least_one_approved_on_the_trigger_fixture():
+    counts = replay_funnel(
+        get_instrument("ETHUSD"),
+        make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+        make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+        m5_long_trigger(),
+        profile=get_profile("conservative"),
+        min_rr=2.0,
+    )
+    assert counts["approved"] >= 1

--- a/tests/test_smc/test_html_escaping.py
+++ b/tests/test_smc/test_html_escaping.py
@@ -52,6 +52,17 @@ class TestEscaping:
             text = format_result(_result_with_reason(reason, verdict))
             _assert_valid_telegram_html(text)
 
+    def test_aggressive_profile_tag_shown_only_for_aggressive(self):
+        result = _result_with_reason("no direction")
+        result.profile_key = "aggressive"
+        text = format_result(result)
+        _assert_valid_telegram_html(text)
+        assert "⚡ <b>Aggressive profile</b>" in text
+
+        result.profile_key = "conservative"
+        text = format_result(result)
+        assert "Aggressive profile" not in text
+
     def test_news_digest_titles_escaped(self):
         cal = NewsCalendar()
         cal.events = parse_feed(

--- a/tests/test_smc/test_plan.py
+++ b/tests/test_smc/test_plan.py
@@ -5,6 +5,7 @@ from app.services.smc.instruments import get_instrument
 from app.services.smc.models import Direction, Trend
 from app.services.smc.notifier import format_plan
 from app.services.smc.plan import build_plan
+from app.services.smc.profiles import AGGRESSIVE, CONSERVATIVE
 from tests.test_smc.helpers import H1_PULLBACK_CLOSES, H4_UPTREND_CLOSES, make_candles
 
 ETH = get_instrument("ETHUSD")
@@ -22,7 +23,7 @@ class TestBuildPlan:
     def test_uptrend_projects_long(self):
         # price above the H1 demand zone (top 3138) so the plan is a pullback long
         h4, h1, m5 = _uptrend_data(3160.0)
-        plan = build_plan(ETH, h4, h1, m5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=2.0)
         assert plan.h4_trend == Trend.UP
         assert len(plan.scenarios) == 1
         s = plan.scenarios[0]
@@ -36,7 +37,7 @@ class TestBuildPlan:
         h4 = make_candles(flat, step_minutes=240)
         h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
         m5 = make_candles([3165.0], step_minutes=5)
-        plan = build_plan(ETH, h4, h1, m5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=2.0)
         assert plan.h4_trend == Trend.FLAT
         # a demand zone below and a supply zone above -> up to two brackets
         assert all(s.speculative for s in plan.scenarios)
@@ -45,47 +46,114 @@ class TestBuildPlan:
 
     def test_market_closed_note(self):
         h4, h1, m5 = _uptrend_data(3160.0)
-        plan = build_plan(ETH, h4, h1, m5, market_closed=True)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=2.0, market_closed=True)
         assert plan.scenarios == [] and "closed" in plan.note.lower()
 
     def test_long_skipped_when_zone_above_price(self):
         # price below the demand zone -> not a clean pullback-long plan
         h4, h1, m5 = _uptrend_data(3120.0)
-        plan = build_plan(ETH, h4, h1, m5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=2.0)
         assert plan.scenarios == [] and plan.note
 
 
 class TestFormatAndChart:
     def test_format_plan_html(self):
         h4, h1, m5 = _uptrend_data(3160.0)
-        plan = build_plan(ETH, h4, h1, m5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=2.0)
         text = format_plan(plan, min_rr=2.0)
         assert "Pre-Market Plan" in text and "LONG" in text
         assert "Buy Limit" in text and "SL" in text and "TP" in text
         assert "<" not in text.replace("<b>", "").replace("</b>", "")
 
-    def test_below_min_rr_flagged(self):
+    def test_no_qualifying_scenario_shows_reason_note(self):
+        # min_rr so high that even the uptrend pullback zone can't reach it:
+        # build_plan drops the scenario and format_plan renders the reason.
         h4, h1, m5 = _uptrend_data(3160.0)
-        plan = build_plan(ETH, h4, h1, m5)
-        text = format_plan(plan, min_rr=99.0)  # force the warning
-        assert "below 1:2" in text
+        plan = build_plan(ETH, h4, h1, m5, min_rr=99.0)  # force the RR filter
+        assert plan.scenarios == []
+        text = format_plan(plan, min_rr=99.0)
+        assert "ℹ️" in text
 
     def test_note_only_message(self):
         h4, h1, m5 = _uptrend_data(3120.0)  # produces a note, no scenarios
-        plan = build_plan(ETH, h4, h1, m5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=2.0)
         text = format_plan(plan)
         assert "ℹ️" in text
 
     def test_render_plan_chart_png(self):
         h4, h1, m5 = _uptrend_data(3160.0)
-        plan = build_plan(ETH, h4, h1, m5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=2.0)
         png = render_plan_chart(plan, h1)
         assert png is not None and png[:4] == b"\x89PNG"
 
     def test_chart_none_without_scenarios(self):
         h4, h1, m5 = _uptrend_data(3120.0)
-        plan = build_plan(ETH, h4, h1, m5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=2.0)
         assert render_plan_chart(plan, h1) is None
+
+
+class TestRRFilterAndProfile:
+    def test_plan_skips_scenario_below_min_rr_with_reason(self):
+        # NOTE: the brief's original fixture used m5=[3140, 3138, 3136] (last
+        # close 3136), which sits BELOW the H1 demand zone top (3138). That
+        # makes _scenario's "zone.top >= price" guard fire before the RR walk
+        # ever runs, so build_plan falls back to the generic
+        # "No clean zone with RR >= 1:2 yet" note -- which happens to also
+        # contain "1:" and would pass the assertion for the wrong reason.
+        # Using an ascending m5 (last close 3145, above the zone) makes the
+        # zone live so _scenario actually walks targets and the note states
+        # the real achievable RR (see hand-trace in task-7-report.md).
+        inst = get_instrument("ETHUSD")
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3140, 3142, 3145])
+        plan = build_plan(inst, h4, h1, m5, min_rr=99.0, profile=CONSERVATIVE)
+        assert plan.scenarios == []
+        assert plan.note is not None
+        assert "live" in plan.note and "1:" in plan.note  # achievable RR stated
+
+    def test_plan_scenario_meets_min_rr_when_target_exists(self):
+        inst = get_instrument("ETHUSD")
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3140, 3142, 3145])
+        plan = build_plan(inst, h4, h1, m5, min_rr=1.5, profile=CONSERVATIVE)
+        assert plan.scenarios  # a target reaching RR 1.5 exists for this fixture
+        for s in plan.scenarios:
+            assert s.rr >= 1.5
+
+    def test_aggressive_profile_takes_h4_choch_direction_when_flat(self):
+        # H4 uptrend then a decisive, unreclaimed break of the last HL: trend
+        # downgrades to FLAT but an aggressive trader can take the CHoCH
+        # direction (SHORT) as a single non-speculative scenario.
+        closes = H4_UPTREND_CLOSES + [3200, 3100, 3050, 3000, 2990]
+        h4 = make_candles(closes, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3150.0], step_minutes=5)
+
+        plan = build_plan(
+            get_instrument("ETHUSD"), h4, h1, m5, min_rr=2.0, profile=AGGRESSIVE
+        )
+        assert plan.h4_trend == Trend.FLAT
+        assert len(plan.scenarios) == 1
+        s = plan.scenarios[0]
+        assert s.direction == Direction.SHORT
+        assert not s.speculative
+        assert s.rr >= 2.0
+
+    def test_conservative_profile_ignores_h4_choch_when_flat(self):
+        # same fixture, but conservative never reads the CHoCH: it falls back
+        # to the flat both-direction speculative brackets instead.
+        closes = H4_UPTREND_CLOSES + [3200, 3100, 3050, 3000, 2990]
+        h4 = make_candles(closes, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3150.0], step_minutes=5)
+
+        plan = build_plan(
+            get_instrument("ETHUSD"), h4, h1, m5, min_rr=2.0, profile=CONSERVATIVE
+        )
+        assert plan.h4_trend == Trend.FLAT
+        assert all(s.speculative for s in plan.scenarios)
 
 
 class TestPlanKeyboard:

--- a/tests/test_smc/test_profiles.py
+++ b/tests/test_smc/test_profiles.py
@@ -21,3 +21,8 @@ def test_get_profile_falls_back_to_conservative():
     assert get_profile("nonsense") is CONSERVATIVE
     assert get_profile("aggressive") is AGGRESSIVE
     assert set(PROFILES) == {"conservative", "aggressive"}
+
+
+def test_get_profile_handles_empty_and_none():
+    assert get_profile("") is CONSERVATIVE
+    assert get_profile(None) is CONSERVATIVE

--- a/tests/test_smc/test_profiles.py
+++ b/tests/test_smc/test_profiles.py
@@ -1,0 +1,23 @@
+from app.services.smc.profiles import (
+    PROFILES, CONSERVATIVE, AGGRESSIVE, get_profile,
+)
+
+
+def test_conservative_is_todays_behaviour():
+    assert CONSERVATIVE.fvg_size_factor == 1.0
+    assert CONSERVATIVE.max_zone_touches == 0
+    assert CONSERVATIVE.fvg_day_scope is False
+    assert CONSERVATIVE.allow_h4_choch_entry is False
+
+
+def test_aggressive_relaxes_all_four():
+    assert AGGRESSIVE.allow_h4_choch_entry is True
+    assert AGGRESSIVE.max_zone_touches >= 1
+    assert AGGRESSIVE.fvg_day_scope is True
+    assert AGGRESSIVE.fvg_size_factor < 1.0
+
+
+def test_get_profile_falls_back_to_conservative():
+    assert get_profile("nonsense") is CONSERVATIVE
+    assert get_profile("aggressive") is AGGRESSIVE
+    assert set(PROFILES) == {"conservative", "aggressive"}

--- a/tests/test_smc/test_state_profile.py
+++ b/tests/test_smc/test_state_profile.py
@@ -1,0 +1,19 @@
+from app.services.smc.db import Database
+from app.services.smc.state import WatcherState
+
+
+def test_set_profile_persists_and_clears_dedup(tmp_path):
+    db = Database(str(tmp_path / "s.db"))
+    state = WatcherState(db)
+    state.last_setup["ETHUSD"] = "some-fingerprint"
+    state.zone_pinged["ETHUSD"] = True
+    state.save()
+
+    state.set_profile("ETHUSD", "aggressive")
+    assert state.pair_profile["ETHUSD"] == "aggressive"
+    assert "ETHUSD" not in state.last_setup
+    assert state.zone_pinged.get("ETHUSD", False) is False
+
+    # survives a reload
+    state2 = WatcherState(Database(str(tmp_path / "s.db")))
+    assert state2.pair_profile["ETHUSD"] == "aggressive"

--- a/tests/test_smc/test_structure.py
+++ b/tests/test_smc/test_structure.py
@@ -1,6 +1,8 @@
 """Tests for market structure analysis (pivots, trend, zones, CHoCH)."""
 
-from app.services.smc.models import Direction, Trend
+from datetime import datetime, timezone
+
+from app.services.smc.models import Direction, Trend, Zone
 from app.services.smc.structure import (
     detect_trend,
     find_choch,
@@ -8,7 +10,7 @@ from app.services.smc.structure import (
     find_pivots,
     find_target_zone,
     last_protective_pivot,
-    zone_touch_index,
+    zone_touch_span,
 )
 from tests.test_smc.helpers import (
     H1_PULLBACK_CLOSES,
@@ -16,6 +18,29 @@ from tests.test_smc.helpers import (
     m5_long_trigger,
     make_candles,
 )
+
+
+def _zone(bottom, top, is_demand=True):
+    return Zone(bottom=bottom, top=top, is_demand=is_demand, pivot_index=0,
+                timestamp=datetime(2026, 7, 6, tzinfo=timezone.utc))
+
+
+def test_zone_touch_span_returns_first_and_last_of_last_excursion():
+    # closes: above zone, then 8 candles inside 3130-3140, then back above
+    closes = [3150, 3145, 3135, 3134, 3133, 3136, 3138, 3137, 3135, 3134, 3160]
+    candles = make_candles(closes)
+    span = zone_touch_span(candles, _zone(3130, 3140))
+    assert span is not None
+    start, end = span
+    # the excursion starts at the first candle whose range enters the zone
+    assert start < end
+    # all candles in [start, end] intersect the zone; start-1 does not sit fully inside
+    assert candles[start].low <= 3140 and candles[start].high >= 3130
+
+
+def test_zone_touch_span_none_when_never_touched():
+    candles = make_candles([3200, 3205, 3210, 3208])
+    assert zone_touch_span(candles, _zone(3130, 3140)) is None
 
 
 class TestPivots:
@@ -77,15 +102,16 @@ class TestM5Trigger:
     def test_zone_touch_and_choch(self):
         h1_zone = find_h1_zone(make_candles(H1_PULLBACK_CLOSES), Direction.LONG)
         m5 = m5_long_trigger()
-        touch = zone_touch_index(m5, h1_zone)
-        assert touch == 14
+        span = zone_touch_span(m5, h1_zone)
+        assert span == (8, 14)  # first-to-last of the one contiguous excursion
+        touch = span[0]
         choch = find_choch(m5, Direction.LONG, touch)
         assert choch == 16  # body close above the 3148 lower-high
 
     def test_no_choch_without_break(self):
         m5 = m5_long_trigger()[:16]  # cut off before the breaking candle
         h1_zone = find_h1_zone(make_candles(H1_PULLBACK_CLOSES), Direction.LONG)
-        touch = zone_touch_index(m5, h1_zone)
+        touch = zone_touch_span(m5, h1_zone)[0]
         assert find_choch(m5, Direction.LONG, touch) is None
 
     def test_protective_pivot_for_stop_loss(self):

--- a/tests/test_smc/test_structure.py
+++ b/tests/test_smc/test_structure.py
@@ -9,6 +9,8 @@ from app.services.smc.structure import (
     find_h1_zone,
     find_pivots,
     find_target_zone,
+    find_target_zones,
+    h4_choch_direction,
     last_protective_pivot,
     zone_touch_span,
 )
@@ -19,6 +21,33 @@ from tests.test_smc.helpers import (
     m5_long_trigger,
     make_candles,
 )
+
+
+def test_find_h1_zone_untested_only_by_default():
+    h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+    zone = find_h1_zone(h1, Direction.LONG)  # max_touches=0
+    assert zone is not None
+    assert zone.touches == 0
+
+
+def test_find_target_zones_sorted_nearest_first():
+    h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+    zones = find_target_zones(h1, Direction.LONG, entry=3138.0)
+    tops = [z.bottom for z in zones]
+    assert tops == sorted(tops)  # nearest (smallest bottom above entry) first
+
+
+def test_h4_choch_direction_none_on_clean_uptrend():
+    # a confirmed HH+HL uptrend has no unreclaimed break -> no CHoCH signal
+    h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+    assert h4_choch_direction(h4) is None
+
+
+def test_h4_choch_direction_short_after_break_of_last_hl():
+    # uptrend then a decisive body close below the last higher-low, held
+    closes = H4_UPTREND_CLOSES + [3200, 3100, 3050, 3000, 2990]
+    h4 = make_candles(closes, step_minutes=240)
+    assert h4_choch_direction(h4) == Direction.SHORT
 
 
 def _zone(bottom, top, is_demand=True):

--- a/tests/test_smc/test_structure.py
+++ b/tests/test_smc/test_structure.py
@@ -15,6 +15,7 @@ from app.services.smc.structure import (
 from tests.test_smc.helpers import (
     H1_PULLBACK_CLOSES,
     H4_UPTREND_CLOSES,
+    m5_choch_still_in_zone,
     m5_long_trigger,
     make_candles,
 )
@@ -113,6 +114,21 @@ class TestM5Trigger:
         h1_zone = find_h1_zone(make_candles(H1_PULLBACK_CLOSES), Direction.LONG)
         touch = zone_touch_span(m5, h1_zone)[0]
         assert find_choch(m5, Direction.LONG, touch) is None
+
+    def test_span_start_surfaces_choch_that_last_touch_hides(self):
+        # Regression for the zone-touch bug: the CHoCH forms and price stays
+        # inside the zone to the end of the series. span[1] is exactly what the
+        # old zone_touch_index returned (the LAST in-zone candle) — using it as
+        # the search origin collapses find_choch's window past the CHoCH and
+        # returns None. span[0] (the excursion START) keeps the CHoCH visible.
+        m5 = m5_choch_still_in_zone()
+        zone = _zone(3130, 3140)
+        span = zone_touch_span(m5, zone)
+        assert span == (5, 10)
+        # OLD behaviour (last in-zone candle == span[1]): trigger invisible.
+        assert find_choch(m5, Direction.LONG, span[1]) is None
+        # NEW behaviour (excursion start): CHoCH at index 8 is found.
+        assert find_choch(m5, Direction.LONG, span[0]) == 8
 
     def test_protective_pivot_for_stop_loss(self):
         m5 = m5_long_trigger()

--- a/tests/test_smc/test_zone_ping.py
+++ b/tests/test_smc/test_zone_ping.py
@@ -58,6 +58,7 @@ class _State:
     def __init__(self):
         self.zone_pinged = {}
         self.pair_cooldown = {}
+        self.pair_profile = {}
 
     def save(self):
         pass


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Adds an opt-in **strategy-profile system** (conservative default / aggressive) to the SMC watcher, a `/strategy` switch to toggle it per pair, an RR-filtered pre-market `/plan`, and an offline calibration tool — plus a core bug fix that was likely the cause of the zero-alert week.

**Core bug fix (both profiles):** the M5 CHoCH inside the H1 zone was invisible while price sat in the zone — `zone_touch_index` returned the *last* in-zone candle, collapsing the CHoCH search to one candle. Replaced with `zone_touch_span` (start of the last contiguous excursion).

**Strategy profiles (`profiles.py`):**
- `conservative` — bit-for-bit today's behaviour (default; deploy changes nothing until a button is pressed).
- `aggressive` — opt-in. Four relaxations: H4-CHoCH entry when the H4 trend is FLAT; min-FVG scaled by `fvg_size_factor` (**calibrated to 0.6**); H1 zones with one prior retest; whole-Prague-day FVG scope.

**`/strategy` command** — per-pair + "all pairs" buttons, persisted in SQLite (`profile_key` signal column + in-place migration), shown in `/status`; switching a pair clears its dedup so the new profile's first alert isn't suppressed. New `SMC_DEFAULT_PROFILE` env (default `conservative`).

**`/plan` rework** — walks candidate targets outward until RR ≥ 1:2, and prints an honest reason line when none qualifies (no more RR 1:0.1 scenarios); profile-aware.

**`scripts/funnel.py`** — offline calibration tool (point-in-time replay, distinct-setup counting, deep Binance history paging, `fvg_size_factor` sweep). Not imported by the worker.

### Why is this change needed?
A full week produced zero forex alerts. A funnel audit found the zone-touch bug plus rule-level strictness that starves setups in a ranging market. The aggressive profile is the opt-in relief; the factor was calibrated on data, not guessed.

### Calibration (why 0.6)
45-day ETHUSD M5 replay (point-in-time, distinct-setup counting):

| profile | setups/week |
|---|---|
| 🛡 conservative | ~1.0 |
| ⚡ factor 0.4 | ~5.6 |
| ⚡ factor 0.6 | ~4.9 |
| ⚡ factor 0.8 | ~4.3 |

The 1→~5/week lift comes mostly from the H4-CHoCH entry (h4_flat funnel deaths 3336→1608); the factor is a quality knob. **0.6** keeps more small-FVG rejection than 0.4 while staying ~5× conservative frequency.

### How was this tested?
- [x] Unit tests added/updated
- [x] Manual testing performed (live funnel runs on Binance/Yahoo data)

182 passing, flake8 clean. Conservative behaviour held bit-for-bit (crypto `same_day` scope pinned by a discriminating end-to-end test). Built via subagent-driven development: per-task spec+quality review and a final whole-branch review.

### Breaking Changes
- [ ] No breaking changes. Aggressive is off by default; `SMC_DEFAULT_PROFILE` defaults to `conservative`; the `profile_key` column migrates existing DBs in place.

### Additional Notes
Design spec: `docs/superpowers/specs/2026-07-25-aggressive-strategy-design.md`
Implementation plan: `docs/superpowers/plans/2026-07-25-aggressive-strategy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
