### PR TITLE
Fix API-key leak in logs + deep TwelveData M5 history for forex funnel

### DIFF
--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -37,6 +37,12 @@ def configure_logging(
             stream=sys.stdout,
         )
 
+    # HTTP client libraries log full request URLs at INFO, which can include
+    # API keys passed as query params (e.g. TwelveData apikey=...). Silence
+    # their request-line logging so secrets never reach stdout / Railway logs.
+    for noisy in ("httpx", "httpcore"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
     # Configure structlog
     structlog.configure(
         processors=[

--- a/scripts/funnel.py
+++ b/scripts/funnel.py
@@ -198,11 +198,20 @@ async def _run(pairs: List[str], days: int, factors: List[float], legacy: bool) 
             h4 = await fetch_binance_history(symbol, "4h", days)
             h1 = await fetch_binance_history(symbol, "1h", days)
             m5 = await fetch_binance_history(symbol, "5m", days)
-        else:
-            print(f"  note: {key} is forex — Yahoo caps 5m history, depth is feed-limited")
+        else:  # forex
+            from smc_watcher import _forex_source
             fetcher = _build_fetcher(instrument)
-            data = await fetcher.fetch_all_timeframes()
-            h4, h1, m5 = data["h4"], data["h1"], data["m5"]
+            src = _forex_source()
+            if src == "twelvedata":
+                # TwelveData: outputsize up to 5000 in one request — deep M5.
+                m5 = await fetcher.fetch_candles("5m", limit=5000)
+                h1 = await fetcher.fetch_candles("1h", limit=min(5000, days * 24 + 100))
+                h4 = await fetcher.fetch_candles("4h", limit=min(5000, days * 6 + 50))
+                print(f"  note: {key} via TwelveData — deep M5 (outputsize up to 5000)")
+            else:
+                data = await fetcher.fetch_all_timeframes()
+                h4, h1, m5 = data["h4"], data["h1"], data["m5"]
+                print(f"  note: {key} via {src} — 5m history is feed-limited (~1.5d)")
 
         print(f"\n=== {key} — {len(m5)} M5 candles ===")
 

--- a/tests/test_core/test_logging_secrets.py
+++ b/tests/test_core/test_logging_secrets.py
@@ -1,0 +1,9 @@
+import logging
+
+from app.core.logging import configure_logging
+
+
+def test_httpx_request_logging_is_silenced():
+    configure_logging()
+    assert logging.getLogger("httpx").level >= logging.WARNING
+    assert logging.getLogger("httpcore").level >= logging.WARNING


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Two fixes surfaced while calibrating forex on TwelveData:

1. **Security — stop leaking API keys into logs.** `httpx` logs every request line at INFO, and TwelveData passes the key as an `apikey=` query param, so the key was written to stdout/Railway logs on every request. `configure_logging` now raises the `httpx`/`httpcore` loggers to WARNING, so request URLs (which carry secrets and are just noise) are no longer emitted.

2. **Deep TwelveData M5 history in `scripts/funnel.py`.** The forex funnel path only pulled ~400 M5 candles (~1.5 days); TwelveData supports `outputsize` up to 5000 in a single request, so forex now replays ~3 weeks of M5 for a real per-pair calibration. The status note is now source-aware (previously hardcoded "Yahoo" even when the source was TwelveData).

### Why is this change needed?
Calibrating USDJPY revealed that Yahoo's resampled H4 was falsely reporting the pair as flat (100% `h4_flat`), while TwelveData's native H4 shows real structure and the funnel reaches the M5 trigger stage. Getting an accurate forex calibration requires (a) not leaking the key that makes TwelveData usable, and (b) enough M5 depth to count setups per week.

### How was this tested?
- [x] Unit test added: `tests/test_core/test_logging_secrets.py` asserts httpx/httpcore logging is silenced.
- [x] Manual: confirmed live funnel run now hits `api.twelvedata.com` with native H4 (no false `h4_flat`).

183 passing, flake8 clean.

### Security note
Any TwelveData API key used before this change should be rotated — it was logged in plaintext (stdout + Railway) on every request.

### Breaking Changes
- [ ] None. httpx WARNING-level only suppresses request-line INFO noise; errors still log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
