### PR TITLE
Tune aggressive fvg_size_factor 0.6 -> 0.4 (forex participation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,11 @@ The aggressive profile relaxes:
    only catches the second leg — see the ETHUSD/GBPUSD breakout days).
 2. **Smaller minimum FVG** — the per-instrument minimum FVG size
    (`instruments.py`) is scaled by `AGGRESSIVE.fvg_size_factor`, calibrated to
-   `0.6` via `scripts/funnel.py` (45 days of ETHUSD M5, point-in-time replay):
-   ~4.9 setups/week vs ~1.0 for conservative. Re-run the funnel to recalibrate.
+   `0.4` via `scripts/funnel.py` (~21-45 days of M5, point-in-time replay).
+   Conservative yields ~0 setups/week on forex and ~1 on ETHUSD; aggressive at
+   0.4 gives ~5.5/wk on ETHUSD and ~1.4-2.5/wk per forex pair. A higher factor
+   starves forex (its M5 FVGs are small vs the 5-pip minimum). Re-run the funnel
+   to recalibrate.
 3. **One retest allowed on H1 zones** — accepts a zone with up to one prior
    retest (`max_zone_touches=1`) instead of untested-only.
 4. **Whole-day FVG scope** — an FVG stays valid for the entire Prague trading

--- a/app/services/smc/profiles.py
+++ b/app/services/smc/profiles.py
@@ -5,10 +5,14 @@ read by the engine at exactly four points (direction, FVG size, zone
 selection, FVG scope). Per-instrument thresholds still live in instruments.py;
 the profile only multiplies them (fvg_size_factor).
 
-AGGRESSIVE.fvg_size_factor was calibrated to 0.6 via scripts/funnel.py over
-45 days of ETHUSD M5 (point-in-time replay, distinct-setup counting): ~4.9
-setups/week vs ~1.0 for conservative, while keeping more small-FVG rejection
-than 0.4. Re-run the funnel to recalibrate.
+AGGRESSIVE.fvg_size_factor is 0.4, chosen via scripts/funnel.py over ~21-45
+days of M5 across all pairs (point-in-time replay, distinct-setup counting).
+Conservative produces ~0 setups/week on forex and ~1 on ETHUSD; aggressive at
+0.4 gives ~5.5/wk on ETHUSD and ~1.4-2.5/wk per forex pair. Forex M5 FVGs are
+small relative to the 5-pip minimum, so a higher factor starves forex (0.6 →
+~1/wk/pair); 0.4 keeps forex participating while ETHUSD stays sane (not a
+firehose — distinct-setup counting confirms ~0.8/day). Re-run the funnel to
+recalibrate.
 """
 
 from dataclasses import dataclass
@@ -34,13 +38,13 @@ CONSERVATIVE = StrategyProfile(
     fvg_day_scope=False,
 )
 
-# fvg_size_factor calibrated to 0.6 (see module docstring). Re-run
+# fvg_size_factor calibrated to 0.4 (see module docstring). Re-run
 # scripts/funnel.py to recalibrate.
 AGGRESSIVE = StrategyProfile(
     key="aggressive",
     label="⚡ Aggressive",
     allow_h4_choch_entry=True,
-    fvg_size_factor=0.6,
+    fvg_size_factor=0.4,
     max_zone_touches=1,
     fvg_day_scope=True,
 )


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Sets `AGGRESSIVE.fvg_size_factor` from `0.6` to **`0.4`**, and updates the docstring/README to match.

### Why is this change needed?
A deep ~21-day funnel calibration across all pairs (now possible after the TwelveData deep-history fix in #41) showed:

| pair | conservative | 0.4 | 0.6 |
|---|---|---|---|
| ETHUSD | 0.95 | 5.48 | 4.76 |
| USDJPY | 0 | 1.39 | 0.83 |
| GBPUSD | 0 | 2.50 | 1.39 |
| USDCAD | 0 | 1.94 | 1.11 |
| EURUSD | 0 | 0 | 0 |

*(distinct setups per week)*

Conservative produces **~0 setups/week on every forex pair** — the fundamental cause of the zero-alert weeks, independent of the (now-fixed) Yahoo H4 data issue. Forex M5 FVGs are small relative to the 5-pip minimum, so factor `0.6` starved forex (~1/wk per pair). `0.4` keeps forex participating while ETHUSD stays sane at ~5.5/wk (distinct-setup counting confirms this is not a firehose — ~0.8/day).

### How was this tested?
- [x] Existing unit tests pass (183), flake8 clean.
- [x] Calibration via `scripts/funnel.py` over deep M5 history.

### Note on methodology
The funnel measures setup **frequency**, not win-rate. `0.4` on forex accepts ~2-pip M5 FVGs; whether those weaker imbalances are worth trading is a discretionary call. Win-rate per factor is not modelled here. `AGGRESSIVE` remains **opt-in** (conservative is the default), so this changes nothing until a pair is switched via `/strategy`.

### Breaking Changes
- [ ] None. Aggressive is off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
