### PR TITLE
Add /pause + /resume, quiet zone ping by default, 384-candle alert chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ setup appears.
   together with the **live checklist status** (projection + where the pair is
   right now); conditional entry/SL/TP/RR + H1 chart, both-way brackets when flat
 - 🔔 **Zone-touch ping** — a light "get ready" nudge the moment price reaches a
-  live H1 zone, before the full 🚨 setup forms (`SMC_ZONE_PING`)
+  live H1 zone, before the full 🚨 setup forms (opt-in via `SMC_ZONE_PING=true`)
+- ⏸ **`/pause` / `/resume`** — mute everything (alerts, digest, warnings)
+  until you switch it back on; survives restarts
 - 📒 **Signal journal**: every alert is auto-tracked to its TP/SL outcome;
   `/stats` shows signal winrate and your personal (taken) winrate separately
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -81,9 +81,10 @@ class SMCSettings(BaseSettings):
         "for this many hours (you are managing the position)",
     )
     zone_ping: bool = Field(
-        default=True,
+        default=False,
         description="Send a 'get ready' ping when price first reaches a live "
-        "H1 zone, before the full setup forms",
+        "H1 zone, before the full setup forms (off by default — the owner "
+        "found it noisy)",
     )
     notify_no_setup: bool = Field(
         default=False,

--- a/app/services/smc/chart.py
+++ b/app/services/smc/chart.py
@@ -71,9 +71,9 @@ def _level(ax, price: float, color: str, label: str, x_right: int) -> None:
     )
 
 
-# ~16h of M5 by default: enough to show the swing HH/HL structure behind the
-# setup. Tunable via SMC_CHART_CANDLES.
-CHART_CANDLES = int(os.getenv("SMC_CHART_CANDLES", "192"))
+# ~32h of M5 by default: enough context to see the swing HH/HL structure and
+# the move into the zone behind the setup. Tunable via SMC_CHART_CANDLES.
+CHART_CANDLES = int(os.getenv("SMC_CHART_CANDLES", "384"))
 
 
 def render_setup_chart(
@@ -85,15 +85,15 @@ def render_setup_chart(
     candles = result.m5_candles[-candles_back:]
     setup = result.setup
 
-    # Wider canvas + thinner wicks so twice as many candles stay legible.
-    fig, ax = plt.subplots(figsize=(13, 6), dpi=110)
+    # Wide canvas + thin wicks so ~384 candles stay legible.
+    fig, ax = plt.subplots(figsize=(20, 6), dpi=110)
     fig.patch.set_facecolor(BG)
     ax.set_facecolor(BG)
 
     # Candles
     for i, c in enumerate(candles):
         color = UP_COLOR if c.close >= c.open else DOWN_COLOR
-        ax.plot([i, i], [c.low, c.high], color=color, linewidth=0.7, zorder=2)
+        ax.plot([i, i], [c.low, c.high], color=color, linewidth=0.6, zorder=2)
         body_bottom = min(c.open, c.close)
         body_height = max(abs(c.close - c.open), (c.high - c.low) * 0.02 or 1e-9)
         ax.add_patch(

--- a/app/services/smc/state.py
+++ b/app/services/smc/state.py
@@ -29,6 +29,8 @@ class WatcherState:
         # the current in-zone episode (reset when price leaves the zone)
         self.zone_pinged: Dict[str, bool] = db.kv_get("zone_pinged") or {}
         self.pair_profile: Dict[str, str] = db.kv_get("pair_profile") or {}
+        # global mute: scheduler cycles are no-ops until /resume
+        self.paused: bool = bool(db.kv_get("paused") or False)
 
     def save(self) -> None:
         self.db.kv_set("pairs", self.pairs)
@@ -39,6 +41,11 @@ class WatcherState:
         self.db.kv_set("pair_cooldown", self.pair_cooldown)
         self.db.kv_set("zone_pinged", self.zone_pinged)
         self.db.kv_set("pair_profile", self.pair_profile)
+        self.db.kv_set("paused", self.paused)
+
+    def set_paused(self, paused: bool) -> None:
+        self.paused = paused
+        self.save()
 
     def set_profile(self, key: str, profile_key: str) -> None:
         """Set a pair's strategy profile and clear its dedup so the new

--- a/app/services/smc/telegram_bot.py
+++ b/app/services/smc/telegram_bot.py
@@ -7,6 +7,7 @@ Commands:
     /pairs  — toggle watched pairs with inline buttons
     /status — enabled pairs, session, last verdicts
     /check  — run the strategy cycle right now
+    /pause, /resume — global mute of all watcher messages
     /start, /help — description
 """
 
@@ -35,6 +36,8 @@ HELP_TEXT = (
     "/stats — signal journal: setups, TP/SL, winrate\n"
     "/journal — trade journal: send an MT4 history screenshot to log trades\n"
     "/news — today's red news (Forex Factory)\n"
+    "/pause — mute all alerts until /resume\n"
+    "/resume — resume alerts\n"
     "/help — this help"
 )
 
@@ -158,6 +161,8 @@ class TelegramCommandBot:
                 {"command": "stats", "description": "Signal journal and winrate"},
                 {"command": "journal", "description": "Trade journal from MT4 screenshots"},
                 {"command": "news", "description": "Today's red news (Forex Factory)"},
+                {"command": "pause", "description": "Mute all alerts until /resume"},
+                {"command": "resume", "description": "Resume alerts"},
                 {"command": "help", "description": "What this bot does"},
             ],
         )
@@ -216,6 +221,19 @@ class TelegramCommandBot:
                 )
         elif command == "/status":
             await self.send(self.status_text())
+        elif command == "/pause":
+            self.state.set_paused(True)
+            await self.send(
+                "⏸ <b>Paused</b> — no alerts or messages until you resume.",
+                reply_markup={
+                    "inline_keyboard": [
+                        [{"text": "▶️ Resume", "callback_data": "resume"}]
+                    ]
+                },
+            )
+        elif command == "/resume":
+            self.state.set_paused(False)
+            await self.send("▶️ <b>Resumed</b> — watching pairs again.")
         elif command == "/journal":
             if self.trade_journal:
                 await self.send(self.trade_journal.stats_text())
@@ -316,6 +334,24 @@ class TelegramCommandBot:
             return
         if data == "noop":
             await self._api("answerCallbackQuery", **answer)
+            return
+        if data == "resume":
+            self.state.set_paused(False)
+            answer["text"] = "Resumed"
+            message = callback.get("message", {})
+            if message:
+                await self._api(
+                    "editMessageReplyMarkup",
+                    chat_id=message["chat"]["id"],
+                    message_id=message["message_id"],
+                    reply_markup={
+                        "inline_keyboard": [
+                            [{"text": "▶️ Resumed", "callback_data": "noop"}]
+                        ]
+                    },
+                )
+            await self._api("answerCallbackQuery", **answer)
+            await self.send("▶️ <b>Resumed</b> — watching pairs again.")
             return
         if data.startswith("plan_") and self.on_plan:
             key = data[5:]

--- a/docs/superpowers/specs/2026-07-30-pause-zoneping-chart-design.md
+++ b/docs/superpowers/specs/2026-07-30-pause-zoneping-chart-design.md
@@ -1,0 +1,50 @@
+# Pause button, quiet zone ping, wider alert chart — design
+
+Date: 2026-07-30. Approved by the owner in chat.
+
+## Goals
+
+1. A "turn the bot off" control (owner request): mute everything until
+   explicitly resumed.
+2. Stop the "price reached the zone — get ready" pings by default (owner:
+   "это лишнее уже").
+3. Double the number of M5 candles on the alert chart so the setup context
+   is visible.
+
+## 1. /pause and /resume
+
+- `WatcherState.paused: bool`, persisted in the SQLite kv store (key
+  `paused`) — survives Railway restarts. New `WatcherState.set_paused()`.
+- `Watcher.run_cycle()` returns early with "⏸ Bot is paused — /resume to
+  continue" when paused: no news refresh, no data fetches, no alerts, no
+  digest, no Rule 0.4 warnings, no journal tracking. The scheduler keeps
+  ticking but each tick is a cheap no-op. `/check` while paused therefore
+  answers with the paused message instead of silently waking the bot.
+- On resume the next cycle catches up naturally (journal tracking fetches
+  enough M5 history).
+- Telegram: `/pause` command confirms with an inline "▶️ Resume" button;
+  `/resume` command or the button clears the flag. Both commands are added
+  to the slash menu and /help. `/status` shows a prominent paused line.
+- Bot commands (/status, /stats, /plan, …) keep answering while paused —
+  pause silences outbound-initiated messages only.
+
+## 2. Zone ping off by default
+
+- `SMCSettings.zone_ping` default flips `True` → `False`. Code stays; the
+  owner can re-enable with `SMC_ZONE_PING=true`. env.example updated.
+
+## 3. Alert chart: 384 candles
+
+- `SMC_CHART_CANDLES` default 192 → 384 (~32h of M5). Canvas widens
+  (figsize 13×6 → 20×6) and wicks stay thin so candles remain legible.
+- Note: an explicit `SMC_CHART_CANDLES=192` in Railway variables would
+  override the new default and must be removed there.
+
+## Testing
+
+- New `tests/test_smc/test_pause.py`: state persistence across reload,
+  run_cycle no-op + message while paused, /pause and /resume commands and
+  the resume callback, /status paused line.
+- Config default test: `SMCSettings().zone_ping is False` with the env var
+  unset; `chart.CHART_CANDLES == 384`.
+- Existing zone-ping tests already force the flag on and stay green.

--- a/env.example
+++ b/env.example
@@ -34,8 +34,8 @@ SMC_RISK_PCT=2.0
 SMC_ENFORCE_SESSIONS=true
 SMC_NOTIFY_NO_SETUP=false         # true = also send 15-min "no setup" heartbeats
 SMC_TAKEN_COOLDOWN_HOURS=4        # after "Took it", mute that pair's alerts
-SMC_ZONE_PING=true               # 'get ready' ping when price reaches an H1 zone
-SMC_CHART_CANDLES=192            # M5 candles on the alert chart (~16h)
+SMC_ZONE_PING=false              # 'get ready' ping when price reaches an H1 zone (off by default)
+SMC_CHART_CANDLES=384            # M5 candles on the alert chart (~32h)
 # SMC_CHAT_ID=                    # override TELEGRAM_CHAT_ID for alerts
 
 # --- Storage (SQLite: signals journal + runtime state) ---

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -246,6 +246,8 @@ class Watcher:
 
     async def run_cycle(self) -> str:
         """Run the strategy for all enabled pairs; send alerts; return summary."""
+        if self.state.paused:
+            return "⏸ Bot is paused — /resume to continue"
         if not self.state.pairs:
             return "⚠️ No active pairs — enable at least one via /pairs"
 
@@ -631,8 +633,10 @@ class Watcher:
         session = active_session(datetime.now(tz=timezone.utc))
         lines = [
             "<b>SMC Watcher — status</b>",
-            f"Pairs: {', '.join(self.state.pairs) or 'none'}",
         ]
+        if self.state.paused:
+            lines.append("⏸ <b>PAUSED</b> — no alerts, /resume to continue")
+        lines.append(f"Pairs: {', '.join(self.state.pairs) or 'none'}")
         from app.services.smc.profiles import get_profile
 
         profiles_line = ", ".join(

--- a/tests/test_smc/test_multipair.py
+++ b/tests/test_smc/test_multipair.py
@@ -35,7 +35,9 @@ class TestInstruments:
         from app.services.smc.yahoo import YahooDataFetcher
         from app.services.smc.oanda import OandaDataFetcher
 
+        monkeypatch.setattr(settings.smc, "forex_source", "auto")
         monkeypatch.setattr(settings.oanda, "api_token", None)
+        monkeypatch.setattr(settings.twelvedata, "api_key", None)
         fetcher = _build_fetcher(get_instrument("USDJPY"))
         assert isinstance(fetcher, YahooDataFetcher)
         assert fetcher.symbol == "USDJPY=X"

--- a/tests/test_smc/test_pause.py
+++ b/tests/test_smc/test_pause.py
@@ -1,0 +1,146 @@
+"""Tests for /pause–/resume: global mute of scheduler cycles until resumed."""
+
+import pytest
+
+from app.core.config import settings
+from app.services.smc.db import Database
+from app.services.smc.telegram_bot import TelegramCommandBot
+
+
+@pytest.fixture
+def watcher(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings.telegram, "bot_token", "123:dummy")
+    monkeypatch.setattr(settings.telegram, "chat_id", "1")
+    monkeypatch.setattr(settings.smc, "chat_id", None)
+    monkeypatch.setenv("SMC_DB_FILE", str(tmp_path / "smc.db"))
+    import importlib
+
+    import smc_watcher
+
+    importlib.reload(smc_watcher)
+    monkeypatch.setattr(smc_watcher, "DB_FILE", str(tmp_path / "smc.db"))
+    return smc_watcher.Watcher()
+
+
+class TestPausedWatcher:
+    @pytest.mark.asyncio
+    async def test_run_cycle_is_noop_while_paused(self, watcher, monkeypatch):
+        watcher.state.pairs = ["ETHUSD"]
+        watcher.state.set_paused(True)
+
+        async def _fail(*args, **kwargs):
+            raise AssertionError("must not check pairs while paused")
+
+        monkeypatch.setattr(watcher, "check_pair", _fail)
+        summary = await watcher.run_cycle()
+        assert "paused" in summary.lower() and "/resume" in summary
+
+    def test_paused_persists_across_reload(self, watcher, tmp_path):
+        watcher.state.set_paused(True)
+        from app.services.smc.state import WatcherState
+
+        reloaded = WatcherState(Database(str(tmp_path / "smc.db")))
+        assert reloaded.paused is True
+        reloaded.set_paused(False)
+        assert WatcherState(Database(str(tmp_path / "smc.db"))).paused is False
+
+    def test_status_shows_paused(self, watcher):
+        watcher.state.set_paused(True)
+        assert "PAUSED" in watcher.status_text()
+        watcher.state.set_paused(False)
+        assert "PAUSED" not in watcher.status_text()
+
+
+class _State:
+    def __init__(self):
+        self.paused = False
+        self.pairs = ["ETHUSD"]
+
+    def set_paused(self, paused):
+        self.paused = paused
+
+
+def _bot(state):
+    async def run_cycle():
+        return "ok"
+
+    bot = TelegramCommandBot(
+        bot_token="123:dummy",
+        owner_chat_id="1",
+        state=state,
+        run_cycle=run_cycle,
+        status_text=lambda: "status",
+    )
+    bot.api_calls = []
+
+    async def _api(method, http_timeout=35.0, **payload):
+        bot.api_calls.append((method, payload))
+        return {"ok": True}
+
+    bot._api = _api
+    return bot
+
+
+class TestPauseCommands:
+    @pytest.mark.asyncio
+    async def test_pause_command_sets_flag_and_offers_resume(self):
+        state = _State()
+        bot = _bot(state)
+        await bot._handle_command("/pause")
+        assert state.paused is True
+        method, payload = bot.api_calls[-1]
+        assert method == "sendMessage" and "Paused" in payload["text"]
+        buttons = payload["reply_markup"]["inline_keyboard"][0]
+        assert buttons[0]["callback_data"] == "resume"
+
+    @pytest.mark.asyncio
+    async def test_resume_command_clears_flag(self):
+        state = _State()
+        state.paused = True
+        bot = _bot(state)
+        await bot._handle_command("/resume")
+        assert state.paused is False
+        method, payload = bot.api_calls[-1]
+        assert method == "sendMessage" and "Resumed" in payload["text"]
+
+    @pytest.mark.asyncio
+    async def test_resume_callback_clears_flag(self):
+        state = _State()
+        state.paused = True
+        bot = _bot(state)
+        callback = {
+            "id": "cb1",
+            "data": "resume",
+            "message": {"chat": {"id": 1}, "message_id": 7},
+        }
+        await bot._handle_callback(callback)
+        assert state.paused is False
+        methods = [m for m, _ in bot.api_calls]
+        assert "editMessageReplyMarkup" in methods
+        assert "answerCallbackQuery" in methods
+
+    @pytest.mark.asyncio
+    async def test_pause_message_is_current_help(self):
+        from app.services.smc.telegram_bot import HELP_TEXT
+
+        assert "/pause" in HELP_TEXT and "/resume" in HELP_TEXT
+
+
+class TestNewDefaults:
+    def test_zone_ping_default_off(self, monkeypatch):
+        monkeypatch.delenv("SMC_ZONE_PING", raising=False)
+        from app.core.config import SMCSettings
+
+        assert SMCSettings().zone_ping is False
+
+    def test_chart_candles_default_doubled(self):
+        from app.services.smc import chart
+
+        assert chart.CHART_CANDLES == 384
+
+
+def test_paused_flag_default_false(tmp_path):
+    from app.services.smc.state import WatcherState
+
+    state = WatcherState(Database(str(tmp_path / "fresh.db")))
+    assert state.paused is False


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?
Three owner-requested changes from the bot audit:
1. **/pause and /resume** — a global off switch: while paused the scheduler cycle is a no-op (no alerts, no digest, no Rule 0.4 warnings, no journal tracking, no data fetches). The flag is persisted in the SQLite kv store, so it survives Railway restarts. The pause confirmation carries an inline "▶️ Resume" button; /status shows a prominent PAUSED line; both commands are in the slash menu and /help. Bot commands keep answering while paused.
2. **Zone-touch ping off by default** — `SMC_ZONE_PING` default flips to `false` (the "price reached the zone — get ready" messages became noise). The feature stays available via `SMC_ZONE_PING=true`.
3. **Alert chart doubled** — `SMC_CHART_CANDLES` default 192 → 384 (~32h of M5), canvas widened 13×6 → 20×6 with thinner wicks so it stays legible.

Also fixes a pre-existing test env leak: `test_forex_uses_yahoo_without_oanda_token` failed on machines whose local `.env` sets `TWELVEDATA_API_KEY` / `SMC_FOREX_SOURCE`; the test now monkeypatches all three source settings.

### Why is this change needed?
Owner audit requests (2026-07-30): an off button, less noise, more chart context.

### How was this tested?
- [x] Unit tests added/updated — new `tests/test_smc/test_pause.py` (paused cycle no-op, kv persistence, /pause & /resume commands, resume callback, /status line, new defaults)
- [ ] Integration tests added/updated
- [x] Manual testing performed — rendered a 384-candle sample chart PNG to verify legibility
- [ ] Performance testing (if applicable)

`pytest tests/ -v`: 193 passed. `flake8 app/ tests/ smc_watcher.py`: clean.

### Checklist
- [x] Code follows the project's style guidelines
- [x] Self-review of the code has been performed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Corresponding changes to documentation have been made (README, env.example, help text, spec in docs/superpowers/specs/)
- [x] Changes generate no new warnings
- [x] Tests pass locally
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published

### Breaking Changes
- [ ] This PR contains breaking changes
- [ ] Migration guide provided (if applicable)

None. Note: if Railway explicitly sets `SMC_CHART_CANDLES=192` or `SMC_ZONE_PING=true`, those env vars override the new defaults and should be removed.

### Additional Notes
Rest of the audit (weekly MT4-based digest, spread-aware RR display, /plan error replies, outcome-replay funnel) intentionally left for follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)