### PR TITLE
Rule 7: take-profit at the nearest unswept liquidity; sweep-based stop; entry staleness gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __pycache__/
 # OS files
 .DS_Store
 Thumbs.db
+key.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,15 @@ Imbalance** SMC (Smart Money Concepts) setups and sends an urgent alert when
 one is found. There is no web server, no Redis, no Postgres — one worker
 (`smc_watcher.py`) with a SQLite file. It runs on Railway.
 
-The **strategy specification is law**: rules −1 through 11 (H4 trend → H1 zone
-→ M5 CHoCH + FVG, entry skipped once price has run more than
-`SMC_MAX_ENTRY_GAP_R` past it — Rule 5.1, owner decision 2026-08-05 — TP at
-the nearest unswept liquidity level with RR ≥ `SMC_MIN_RR` — owner decision
-2026-08-05 replacing the fixed 1:2.5 multiple, session windows, news
-blackouts, correlation limits) come from the owner's
-written trading system. Never relax or "improve"
-a strategy rule without the owner's explicit decision — implementation
-over-strictness may be fixed, the rules themselves may not. "Almost valid"
-does not exist in this system.
+The **strategy specification is law**: rules −1 through 11 (H4 trend → H1
+zone → M5 CHoCH + FVG → entry skipped once price has run more than
+`SMC_MAX_ENTRY_GAP_R` past it, Rule 5.1, owner decision 2026-08-05 → TP at
+the nearest unswept liquidity level with RR ≥ `SMC_MIN_RR`, owner decision
+2026-08-05 replacing the fixed 1:2.5 multiple → session windows → news
+blackouts → correlation limits) come from the owner's written trading
+system. Never relax or "improve" a strategy rule without the owner's
+explicit decision — implementation over-strictness may be fixed, the rules
+themselves may not. "Almost valid" does not exist in this system.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,11 @@ one is found. There is no web server, no Redis, no Postgres — one worker
 (`smc_watcher.py`) with a SQLite file. It runs on Railway.
 
 The **strategy specification is law**: rules −1 through 11 (H4 trend → H1 zone
-→ M5 CHoCH + FVG, TP at the nearest unswept liquidity level with RR ≥
-`SMC_MIN_RR` — owner decision 2026-08-05 replacing the fixed 1:2.5 multiple,
-session windows, news blackouts, correlation limits) come from the owner's
+→ M5 CHoCH + FVG, entry skipped once price has run more than
+`SMC_MAX_ENTRY_GAP_R` past it — Rule 5.1, owner decision 2026-08-05 — TP at
+the nearest unswept liquidity level with RR ≥ `SMC_MIN_RR` — owner decision
+2026-08-05 replacing the fixed 1:2.5 multiple, session windows, news
+blackouts, correlation limits) come from the owner's
 written trading system. Never relax or "improve"
 a strategy rule without the owner's explicit decision — implementation
 over-strictness may be fixed, the rules themselves may not. "Almost valid"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,10 @@ one is found. There is no web server, no Redis, no Postgres — one worker
 (`smc_watcher.py`) with a SQLite file. It runs on Railway.
 
 The **strategy specification is law**: rules −1 through 11 (H4 trend → H1 zone
-→ M5 CHoCH + FVG, fixed TP at 1:2.5 (`SMC_TP_RR`) with an untested opposite
-zone required at/beyond the TP — owner decision 2026-07-30 after the outcome
-replay showed zone-chain targets were unreachable, session
-windows, news blackouts, correlation
-limits) come from the owner's written trading system. Never relax or "improve"
+→ M5 CHoCH + FVG, TP at the nearest unswept liquidity level with RR ≥
+`SMC_MIN_RR` — owner decision 2026-08-05 replacing the fixed 1:2.5 multiple,
+session windows, news blackouts, correlation limits) come from the owner's
+written trading system. Never relax or "improve"
 a strategy rule without the owner's explicit decision — implementation
 over-strictness may be fixed, the rules themselves may not. "Almost valid"
 does not exist in this system.
@@ -47,6 +46,8 @@ app/services/smc/
 ├── structure.py          fractal-5 pivots (2-closed-candle confirmation),
 │                         H4 trend HH+HL/LH+LL with fakeout-reclaim, H1 zones
 │                         (untested only), M5 CHoCH, TP target zones
+├── liquidity.py          unswept swing highs/lows + EQH/EQL pools; Rule 7
+│                         targets and the sweep-extreme stop reference
 ├── fvg.py                FVG detection, validation (size/fill/session) and
 │                         rejection diagnostics (best_rejected_fvg)
 ├── sessions.py           trading hours 08:00-20:00 Prague, two blocks split
@@ -121,6 +122,11 @@ tracking → live-card edits on fill/TP/SL events.
 - pytest config: `pytest.ini` (asyncio_mode=auto). Tests build synthetic
   candles via `tests/test_smc/helpers.py` (asymmetric wicks make turning
   points strict fractal pivots). Keep tests network-free.
+- Liquidity (`liquidity.py`) and zones (`structure.py`) are different objects:
+  a zone is an order block price reacts from, a liquidity level is the stop
+  pool behind a swing extreme. Rule 7 aims at liquidity; Rule 2 enters at a
+  zone. Sweep detection is wick-based with a tolerance of the raw per-
+  instrument `min_fvg` — never the profile-scaled value.
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,10 @@ app/services/smc/
 │                         evaluate() is fully unit-testable on synthetic candles
 ├── structure.py          fractal-5 pivots (2-closed-candle confirmation),
 │                         H4 trend HH+HL/LH+LL with fakeout-reclaim, H1 zones
-│                         (untested only), M5 CHoCH, TP target zones
+│                         (untested only), M5 CHoCH, sweep_extreme (Rule 6
+│                         stop reference)
 ├── liquidity.py          unswept swing highs/lows + EQH/EQL pools; Rule 7
-│                         targets and the sweep-extreme stop reference
+│                         take-profit targets
 ├── fvg.py                FVG detection, validation (size/fill/session) and
 │                         rejection diagnostics (best_rejected_fvg)
 ├── sessions.py           trading hours 08:00-20:00 Prague, two blocks split

--- a/README.md
+++ b/README.md
@@ -137,9 +137,10 @@ disabled.
 5. **FVG validation** — min size per instrument, fill < 50%; session scope:
    forex per London/NY block, crypto per whole Prague day. Rejections are
    explained in logs (best candidate size / fill / session).
-6. **SL** — behind the confirmed M5 pivot + buffer; **TP** — fixed at
-   **1:2.5** (`SMC_TP_RR`): entry ± 2.5 × risk, and an untested opposite
-   H1/H4 zone must sit at/beyond the TP (room to run) or SKIP.
+6. **SL** — behind the sweep extreme (the wick that ran the liquidity just
+   before the CHoCH, not the last fractal pivot) + buffer; **TP** — the
+   nearest unswept liquidity level (an unswept swing high/low, or an EQH/EQL
+   pool) minus one buffer. RR must be ≥ `SMC_MIN_RR` (default `1.0`) or SKIP.
 7. **Position size** — from `SMC_DEPOSIT` at 2% risk (crypto qty / forex lots).
 8. **Rule 9 correlation guard** — warns about forbidden USD combinations
    (e.g. EURUSD + GBPUSD in the same direction).
@@ -229,8 +230,9 @@ CLAUDE.md                   # guidance for AI-assisted development
 ## Strategy profiles
 
 Each watched pair runs under one of two **strategy profiles**. Both share the
-same rulebook (H4 trend → H1 zone → M5 CHoCH + FVG, fixed 1:2.5 TP, sessions, news,
-correlation); a profile only scales strictness — it never bends a rule.
+same rulebook (H4 trend → H1 zone → M5 CHoCH + FVG, TP at the nearest unswept
+liquidity level with RR ≥ `SMC_MIN_RR`, sessions, news, correlation); a
+profile only scales strictness — it never bends a rule.
 
 | Profile | Label | Behaviour |
 |---|---|---|

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -67,7 +67,7 @@ class SMCSettings(BaseSettings):
         "setups below it are skipped (owner decision 2026-08-05)",
     )
     max_entry_gap_r: float = Field(
-        default=0.5,
+        default=0.75,
         description="Skip a setup once price has run this many R past the "
         "entry — the limit would sit too far from market to fill "
         "(owner decision 2026-08-05). 0 = price may not have moved past the "

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -70,8 +70,9 @@ class SMCSettings(BaseSettings):
         default=0.5,
         description="Skip a setup once price has run this many R past the "
         "entry — the limit would sit too far from market to fill "
-        "(owner decision 2026-08-05). 0 = market entries only; a large "
-        "value disables the gate",
+        "(owner decision 2026-08-05). 0 = price may not have moved past the "
+        "entry at all (a limit further from the entry, i.e. not yet reached, "
+        "still passes); a large value disables the gate",
     )
     risk_pct: float = Field(default=2.0, description="Risk percent per trade")
     deposit: Optional[float] = Field(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -61,10 +61,10 @@ class SMCSettings(BaseSettings):
         default=5,
         description="Check interval inside session windows (M5 cadence), minutes",
     )
-    tp_rr: float = Field(
-        default=2.5,
-        description="Fixed take-profit distance in R: TP = entry ± tp_rr × risk "
-        "(owner decision 2026-07-30, replaces zone-chain targets)",
+    min_rr: float = Field(
+        default=1.0,
+        description="Minimum risk/reward to the nearest unswept liquidity; "
+        "setups below it are skipped (owner decision 2026-08-05)",
     )
     risk_pct: float = Field(default=2.0, description="Risk percent per trade")
     deposit: Optional[float] = Field(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -66,6 +66,13 @@ class SMCSettings(BaseSettings):
         description="Minimum risk/reward to the nearest unswept liquidity; "
         "setups below it are skipped (owner decision 2026-08-05)",
     )
+    max_entry_gap_r: float = Field(
+        default=0.5,
+        description="Skip a setup once price has run this many R past the "
+        "entry — the limit would sit too far from market to fill "
+        "(owner decision 2026-08-05). 0 = market entries only; a large "
+        "value disables the gate",
+    )
     risk_pct: float = Field(default=2.0, description="Risk percent per trade")
     deposit: Optional[float] = Field(
         default=None, description="Deposit size in USD for lot calculation"

--- a/app/services/smc/chart.py
+++ b/app/services/smc/chart.py
@@ -7,7 +7,7 @@ Rendering failures must never block an alert: callers wrap in try/except.
 
 import os
 from io import BytesIO
-from typing import Optional
+from typing import List, Optional, Sequence, Tuple
 
 import matplotlib
 
@@ -63,7 +63,74 @@ def _style_axes(ax, candles, x_right: int, tf_label: str) -> None:
     ax.set_xlim(-1, x_right + 8)
 
 
-def _level(ax, price: float, color: str, label: str, x_right: int) -> None:
+# Fraction of the (candle + entry/SL) span added above and below as breathing
+# room when clamping the y-axis. Keeps the price action from touching the
+# frame edge without letting a single outlier level reopen the autoscale.
+YLIM_MARGIN_FRAC = 0.08
+
+
+def _price_ylim(
+    candles: Sequence, in_range_prices: Sequence[Optional[float]],
+    margin_frac: float = YLIM_MARGIN_FRAC,
+) -> Tuple[float, float]:
+    """Y-axis window: candle high/low extended to bracket entry/SL, plus a
+    margin. Deliberately excludes the take-profit — a liquidity target can
+    sit hundreds of points away, and letting it into this computation is
+    exactly the autoscale blowout this function exists to prevent.
+    """
+    highs = [c.high for c in candles]
+    lows = [c.low for c in candles]
+    hi = max(highs)
+    lo = min(lows)
+    for p in in_range_prices:
+        if p is not None:
+            hi = max(hi, p)
+            lo = min(lo, p)
+    span = hi - lo
+    if span <= 0:
+        span = max(abs(hi), 1.0) * 0.02
+    margin = span * margin_frac
+    return lo - margin, hi + margin
+
+
+def _level(
+    ax,
+    price: float,
+    color: str,
+    label: str,
+    x_right: int,
+    y_bounds: Optional[Tuple[float, float]] = None,
+) -> None:
+    """Draw a horizontal level line + label.
+
+    When `y_bounds` is given and `price` falls outside it, an autoscaling
+    `axhline` would reopen the y-axis to include it (the bug this guards
+    against — a far-away liquidity target flattening the whole chart).
+    Instead draw a fixed edge annotation naming the price and the direction
+    it sits in, so the owner still sees the number.
+    """
+    if y_bounds is not None:
+        lo, hi = y_bounds
+        if price > hi:
+            ax.annotate(
+                f"{label} ↑",
+                xy=(0.99, 0.98), xycoords="axes fraction",
+                color=color, fontsize=9, fontweight="bold",
+                ha="right", va="top",
+                bbox=dict(boxstyle="round,pad=0.25", fc=BG, ec=color, lw=0.8),
+                zorder=5,
+            )
+            return
+        if price < lo:
+            ax.annotate(
+                f"{label} ↓",
+                xy=(0.99, 0.02), xycoords="axes fraction",
+                color=color, fontsize=9, fontweight="bold",
+                ha="right", va="bottom",
+                bbox=dict(boxstyle="round,pad=0.25", fc=BG, ec=color, lw=0.8),
+                zorder=5,
+            )
+            return
     ax.axhline(price, color=color, linewidth=1.1, linestyle="--", zorder=4)
     ax.text(
         x_right, price, f" {label}", color=color, fontsize=9,
@@ -130,6 +197,14 @@ def render_setup_chart(
         )
     )
 
+    # Clamp the y-axis to the candle range (extended to bracket entry/SL,
+    # which sit close to price by construction) before drawing levels. A
+    # liquidity take-profit can be an H4 pool hundreds of points away; left
+    # to autoscale, its axhline would flatten the whole chart (Important
+    # finding 1). take_profit is deliberately excluded from the window.
+    ylim = _price_ylim(candles, (setup.entry, setup.stop_loss))
+    ax.set_ylim(*ylim)
+
     # Entry / SL / TP levels
     d = result.price_decimals
     for price, color, label in (
@@ -137,17 +212,7 @@ def render_setup_chart(
         (setup.stop_loss, "#f23645", f"SL {setup.stop_loss:.{d}f}"),
         (setup.take_profit, "#089981", f"TP {setup.take_profit:.{d}f}"),
     ):
-        ax.axhline(price, color=color, linewidth=1.1, linestyle="--", zorder=4)
-        ax.text(
-            x_right,
-            price,
-            f" {label}",
-            color=color,
-            fontsize=9,
-            fontweight="bold",
-            va="center",
-            ha="left",
-        )
+        _level(ax, price, color, label, x_right, y_bounds=ylim)
 
     # Sparse Prague time labels on the x axis
     ticks = list(range(0, len(candles), max(1, len(candles) // 8)))
@@ -195,13 +260,26 @@ def render_plan_chart(plan, h1_candles, candles_back: int = 120) -> Optional[byt
     x_right = len(candles) + 6
 
     for s in plan.scenarios:
+        zone_color = DEMAND_COLOR if s.direction == Direction.LONG else SUPPLY_COLOR
+        ax.axhspan(s.zone_bottom, s.zone_top, color=zone_color, alpha=0.12, zorder=1)
+
+    # Clamp the y-axis to the H1 candle range (extended to bracket every
+    # scenario's entry/SL) before drawing levels — same fix as the alert
+    # chart (Important finding 1): a liquidity take-profit projected off H4
+    # can sit far outside the visible candles.
+    in_range: List[Optional[float]] = []
+    for s in plan.scenarios:
+        in_range.extend([s.entry, s.stop_loss])
+    ylim = _price_ylim(candles, in_range)
+    ax.set_ylim(*ylim)
+
+    for s in plan.scenarios:
         is_long = s.direction == Direction.LONG
         zone_color = DEMAND_COLOR if is_long else SUPPLY_COLOR
-        ax.axhspan(s.zone_bottom, s.zone_top, color=zone_color, alpha=0.12, zorder=1)
         tag = "L" if is_long else "S"
-        _level(ax, s.entry, zone_color, f"{tag} Entry {s.entry:.{d}f}", x_right)
-        _level(ax, s.stop_loss, SUPPLY_COLOR, f"{tag} SL {s.stop_loss:.{d}f}", x_right)
-        _level(ax, s.take_profit, TP_COLOR, f"{tag} TP {s.take_profit:.{d}f}", x_right)
+        _level(ax, s.entry, zone_color, f"{tag} Entry {s.entry:.{d}f}", x_right, ylim)
+        _level(ax, s.stop_loss, SUPPLY_COLOR, f"{tag} SL {s.stop_loss:.{d}f}", x_right, ylim)
+        _level(ax, s.take_profit, TP_COLOR, f"{tag} TP {s.take_profit:.{d}f}", x_right, ylim)
 
     _style_axes(ax, candles, x_right, "%d.%m")
     ax.set_title(

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -8,6 +8,7 @@ import structlog
 from app.services.smc.data import BinanceDataFetcher
 from app.services.smc.fvg import best_rejected_fvg, select_valid_fvg
 from app.services.smc.instruments import Instrument, get_instrument
+from app.services.smc.liquidity import find_liquidity, nearest_liquidity
 from app.services.smc.models import (
     AnalysisResult,
     Candle,
@@ -22,7 +23,6 @@ from app.services.smc.structure import (
     detect_trend,
     find_choch,
     find_h1_zone,
-    find_target_zone,
     h4_choch_direction,
     sweep_extreme,
     zone_touch_span,
@@ -48,7 +48,7 @@ class TripleSyncEngine:
         instrument: Optional[Instrument] = None,
         min_fvg_size: Optional[float] = None,
         sl_buffer: Optional[float] = None,
-        tp_rr: float = 2.5,
+        min_rr: float = 1.0,
         risk_pct: float = 2.0,
         deposit: Optional[float] = None,
         enforce_sessions: bool = True,
@@ -65,7 +65,7 @@ class TripleSyncEngine:
         self.sl_buffer = (
             sl_buffer if sl_buffer is not None else self.instrument.sl_buffer
         )
-        self.tp_rr = tp_rr
+        self.min_rr = min_rr
         self.risk_pct = risk_pct
         self.deposit = deposit
         self.enforce_sessions = enforce_sessions
@@ -248,34 +248,38 @@ class TripleSyncEngine:
             result.reasons.append("Invalid trade geometry: SL at the entry level")
             return result
 
-        # Rule 7 (owner decision 2026-07-30) — fixed take-profit at
-        # tp_rr × risk. The old zone-chain TARGETS averaged 1:6–1:18 planned
-        # RR and were almost never reached, but the zone requirement itself
-        # is a proven quality filter (replay: +14R with it vs +1R without),
-        # so an untested opposite zone must still sit at/beyond the TP —
-        # the trade needs room to run before opposing liquidity.
-        if direction == Direction.LONG:
-            take_profit = entry + self.tp_rr * risk
-        else:
-            take_profit = entry - self.tp_rr * risk
-        rr = self.tp_rr
-
-        has_room = False
-        for tf_candles in (h1, h4):
-            target = find_target_zone(tf_candles, direction, entry)
-            if target is None:
-                continue
-            edge = target.bottom if direction == Direction.LONG else target.top
-            if (direction == Direction.LONG and edge >= take_profit) or (
-                direction == Direction.SHORT and edge <= take_profit
-            ):
-                has_room = True
-                break
-        if not has_room:
+        # Rule 7 (owner decision 2026-08-05) — take-profit at the nearest
+        # unswept liquidity: the pool the move is actually reaching for. The
+        # TP sits one buffer short of the level so the trade is out before
+        # the sweep itself. Liquidity uses the raw per-instrument minimum FVG
+        # as its tolerance — it is a property of the chart, not of the
+        # profile the owner is trading.
+        tolerance = self.min_fvg_size
+        levels = (
+            find_liquidity(m5, "M5", tolerance)
+            + find_liquidity(h1, "H1", tolerance)
+            + find_liquidity(h4, "H4", tolerance)
+        )
+        target = nearest_liquidity(levels, direction, entry)
+        if target is None:
             result.verdict = Verdict.SKIP
             result.reasons.append(
-                f"No untested opposite H1/H4 zone at/beyond the 1:{self.tp_rr:g} "
-                "take-profit — no room to run"
+                "No unswept liquidity beyond the entry — nothing to aim at"
+            )
+            return result
+
+        if direction == Direction.LONG:
+            take_profit = target.price - self.sl_buffer
+        else:
+            take_profit = target.price + self.sl_buffer
+        rr = abs(take_profit - entry) / risk
+        if rr < self.min_rr:
+            result.verdict = Verdict.SKIP
+            result.reasons.append(
+                f"RR 1:{rr:.1f} < minimum 1:{self.min_rr:g} to the nearest "
+                f"liquidity ({target.timeframe} "
+                f"{'swing high' if target.is_high else 'swing low'} "
+                f"{target.price:.{self.instrument.price_decimals}f})"
             )
             return result
 
@@ -296,6 +300,7 @@ class TripleSyncEngine:
             fvg=fvg,
             entry_is_market=entry_is_market,
             lot_hint=lot_hint,
+            target=target,
         )
         result.verdict = (
             Verdict.APPROVED_MARKET if entry_is_market else Verdict.APPROVED_LIMIT

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -49,6 +49,7 @@ class TripleSyncEngine:
         min_fvg_size: Optional[float] = None,
         sl_buffer: Optional[float] = None,
         min_rr: float = 1.0,
+        max_entry_gap_r: float = 0.5,
         risk_pct: float = 2.0,
         deposit: Optional[float] = None,
         enforce_sessions: bool = True,
@@ -66,6 +67,7 @@ class TripleSyncEngine:
             sl_buffer if sl_buffer is not None else self.instrument.sl_buffer
         )
         self.min_rr = min_rr
+        self.max_entry_gap_r = max_entry_gap_r
         self.risk_pct = risk_pct
         self.deposit = deposit
         self.enforce_sessions = enforce_sessions
@@ -248,6 +250,26 @@ class TripleSyncEngine:
             result.reasons.append("Invalid trade geometry: SL at the entry level")
             return result
 
+        # Rule 5.1 (owner decision 2026-08-05) — entry staleness. The Rule 7
+        # gate below can only pass once the near liquidity has been swept,
+        # which is to say once price has already left the entry; the entry
+        # itself stays anchored to an FVG formed hours earlier. Replaying the
+        # rule without this check, 80-90% of the limit orders never filled.
+        # A negative gap means price has not run past the entry (for a long
+        # that includes sitting inside the FVG), so market entries are never
+        # affected.
+        price = result.price or m5[-1].close
+        gap = price - entry if direction == Direction.LONG else entry - price
+        if gap > self.max_entry_gap_r * risk:
+            result.verdict = Verdict.SKIP
+            result.reasons.append(
+                f"Price has run {gap / risk:.1f}R past the entry "
+                f"{entry:.{self.instrument.price_decimals}f} "
+                f"(max {self.max_entry_gap_r:g}R) — the limit would sit too "
+                "far from market"
+            )
+            return result
+
         # Rule 7 (owner decision 2026-08-05) — take-profit at the nearest
         # unswept liquidity: the pool the move is actually reaching for. The
         # TP sits one buffer short of the level so the trade is out before
@@ -303,7 +325,7 @@ class TripleSyncEngine:
         lot_hint = self._lot_hint(entry, risk)
 
         # Market entry allowed only if price is inside the FVG right now
-        price = result.price or m5[-1].close
+        # (`price` was already bound by the Rule 5.1 gate above)
         entry_is_market = fvg.bottom <= price <= fvg.top
 
         d = self.instrument.price_decimals

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -270,9 +270,23 @@ class TripleSyncEngine:
 
         if direction == Direction.LONG:
             take_profit = target.price - self.sl_buffer
+            reward = take_profit - entry
         else:
             take_profit = target.price + self.sl_buffer
-        rr = abs(take_profit - entry) / risk
+            reward = entry - take_profit
+        # A target inside one sl_buffer of the entry would otherwise put the
+        # TP on the wrong side of the entry while abs() still reports a
+        # positive RR — unreachable at the default min_rr (risk always
+        # exceeds the buffer) but SMC_MIN_RR is an owner-tunable env float,
+        # so this must not depend on the threshold.
+        if reward <= 0:
+            result.verdict = Verdict.SKIP
+            result.reasons.append(
+                "Nearest liquidity sits inside the SL buffer — no positive "
+                "reward to aim at"
+            )
+            return result
+        rr = reward / risk
         if rr < self.min_rr:
             result.verdict = Verdict.SKIP
             result.reasons.append(

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -24,7 +24,7 @@ from app.services.smc.structure import (
     find_h1_zone,
     find_target_zone,
     h4_choch_direction,
-    last_protective_pivot,
+    sweep_extreme,
     zone_touch_span,
 )
 
@@ -235,18 +235,12 @@ class TripleSyncEngine:
         # Rule 5 — entry level: proximal FVG boundary
         entry = fvg.top if direction == Direction.LONG else fvg.bottom
 
-        # Rule 6 — stop loss behind the last confirmed M5 pivot + buffer
-        pivot = last_protective_pivot(m5, direction, choch)
-        if pivot is None:
-            result.verdict = Verdict.SKIP
-            result.reasons.append(
-                "No confirmed M5 pivot for the stop (2 closed bodies) — no SL, no trade"
-            )
-            return result
+        # Rule 6 — stop behind the swept extreme of the zone excursion
+        extreme = sweep_extreme(m5, direction, touch, choch)
         if direction == Direction.LONG:
-            stop_loss = pivot.price - self.sl_buffer
+            stop_loss = extreme - self.sl_buffer
         else:
-            stop_loss = pivot.price + self.sl_buffer
+            stop_loss = extreme + self.sl_buffer
 
         risk = abs(entry - stop_loss)
         if risk <= 0:

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -49,7 +49,7 @@ class TripleSyncEngine:
         min_fvg_size: Optional[float] = None,
         sl_buffer: Optional[float] = None,
         min_rr: float = 1.0,
-        max_entry_gap_r: float = 0.5,
+        max_entry_gap_r: float = 0.75,
         risk_pct: float = 2.0,
         deposit: Optional[float] = None,
         enforce_sessions: bool = True,

--- a/app/services/smc/engine.py
+++ b/app/services/smc/engine.py
@@ -253,8 +253,10 @@ class TripleSyncEngine:
         # TP sits one buffer short of the level so the trade is out before
         # the sweep itself. Liquidity uses the raw per-instrument minimum FVG
         # as its tolerance — it is a property of the chart, not of the
-        # profile the owner is trading.
-        tolerance = self.min_fvg_size
+        # profile the owner is trading, so this reads Instrument.min_fvg
+        # directly rather than self.min_fvg_size (which a caller could
+        # override independently of the instrument).
+        tolerance = self.instrument.min_fvg
         levels = (
             find_liquidity(m5, "M5", tolerance)
             + find_liquidity(h1, "H1", tolerance)

--- a/app/services/smc/instruments.py
+++ b/app/services/smc/instruments.py
@@ -12,7 +12,8 @@ class Instrument:
     source: str  # "crypto" (Binance) | "forex" (OANDA if token set, else Yahoo)
     source_symbol: str  # Binance symbol for crypto, OANDA instrument for forex
     min_fvg: float  # Rule 4: minimal FVG size in price units
-    sl_buffer: float  # Rule 6: buffer beyond the M5 pivot in price units
+    sl_buffer: float  # Rule 6 stop buffer beyond the sweep extreme AND
+    # Rule 7 take-profit setback from the liquidity level, in price units
     pip: float  # pip size in price units (for lot math / messages)
     price_decimals: int  # formatting precision
     check_funding: bool  # Rule 9.3: funding rate advisory (crypto only)

--- a/app/services/smc/liquidity.py
+++ b/app/services/smc/liquidity.py
@@ -46,7 +46,14 @@ def _is_swept(candles: List[Candle], pivot: Pivot, tolerance: float) -> bool:
 def _cluster(
     pivots: List[Pivot], is_high: bool, timeframe: str, tolerance: float
 ) -> List[LiquidityLevel]:
-    """Group same-side pivots within `tolerance` into single pools."""
+    """Group same-side pivots within `tolerance` into single pools.
+
+    Tolerance is measured from the group's first (lowest-price) member, not
+    pairwise between neighbors — a run of 3+ near-equal levels each within
+    `tolerance` of its immediate neighbor but where the span from first to
+    last exceeds `tolerance` splits into a pair plus a singleton, not one
+    pool of 3.
+    """
     group = sorted(
         (p for p in pivots if p.is_high == is_high), key=lambda p: p.price
     )

--- a/app/services/smc/liquidity.py
+++ b/app/services/smc/liquidity.py
@@ -1,0 +1,108 @@
+"""Liquidity levels: unswept swing highs/lows and EQH/EQL pools (Rule 7).
+
+A zone (structure.py) is an order block — an area price reacted from. A
+liquidity level is the resting stop-loss pool behind a swing extreme. They
+are different objects: the take-profit targets liquidity, the H1 entry
+targets a zone.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+from app.services.smc.models import Candle, Direction, Pivot
+from app.services.smc.structure import find_pivots
+
+# Higher timeframes break ties last; a pool on H4 outranks the same price on M5.
+_TF_RANK = {"M5": 0, "H1": 1, "H4": 2}
+
+
+@dataclass(frozen=True)
+class LiquidityLevel:
+    """An unswept swing extreme, or a pool of equal ones."""
+
+    price: float
+    is_high: bool
+    timeframe: str  # "M5" | "H1" | "H4"
+    equal_count: int  # 1 = single swing, 2+ = EQH/EQL pool
+    timestamp: Optional[datetime] = None
+
+
+def _is_swept(candles: List[Candle], pivot: Pivot, tolerance: float) -> bool:
+    """True once a later candle traded beyond the level by more than
+    `tolerance`.
+
+    Wick-based on purpose: liquidity is taken by the wick that runs the stops,
+    not by a body close (that is zone invalidation, a different rule). The
+    tolerance is what makes equal highs possible — a poke smaller than the
+    instrument's minimum FVG has not taken the pool.
+    """
+    later = candles[pivot.index + 1:]
+    if pivot.is_high:
+        return any(c.high > pivot.price + tolerance for c in later)
+    return any(c.low < pivot.price - tolerance for c in later)
+
+
+def _cluster(
+    pivots: List[Pivot], is_high: bool, timeframe: str, tolerance: float
+) -> List[LiquidityLevel]:
+    """Group same-side pivots within `tolerance` into single pools."""
+    group = sorted(
+        (p for p in pivots if p.is_high == is_high), key=lambda p: p.price
+    )
+    out: List[LiquidityLevel] = []
+    i = 0
+    while i < len(group):
+        j = i
+        while j + 1 < len(group) and group[j + 1].price - group[i].price <= tolerance:
+            j += 1
+        members = group[i:j + 1]
+        # Price meets the pool from one side: the lowest high, the highest low.
+        anchor = members[0] if is_high else members[-1]
+        newest = max(members, key=lambda p: p.index)
+        out.append(
+            LiquidityLevel(
+                price=anchor.price,
+                is_high=is_high,
+                timeframe=timeframe,
+                equal_count=len(members),
+                timestamp=newest.timestamp,
+            )
+        )
+        i = j + 1
+    return out
+
+
+def find_liquidity(
+    candles: List[Candle], timeframe: str, tolerance: float
+) -> List[LiquidityLevel]:
+    """All unswept liquidity on this timeframe, singles and pools alike."""
+    unswept = [p for p in find_pivots(candles) if not _is_swept(candles, p, tolerance)]
+    return (
+        _cluster(unswept, True, timeframe, tolerance)
+        + _cluster(unswept, False, timeframe, tolerance)
+    )
+
+
+def nearest_liquidity(
+    levels: List[LiquidityLevel], direction: Direction, entry: float
+) -> Optional[LiquidityLevel]:
+    """Closest unswept pool beyond `entry` in the trade direction.
+
+    Equal distance is broken by pool size, then by timeframe — a pool of
+    three equal highs is a better objective than one lone swing.
+    """
+    if direction == Direction.LONG:
+        candidates = [lv for lv in levels if lv.is_high and lv.price > entry]
+        distance = lambda lv: lv.price - entry  # noqa: E731
+    else:
+        candidates = [lv for lv in levels if not lv.is_high and lv.price < entry]
+        distance = lambda lv: entry - lv.price  # noqa: E731
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda lv: (
+            distance(lv), -lv.equal_count, -_TF_RANK.get(lv.timeframe, 0)
+        )
+    )
+    return candidates[0]

--- a/app/services/smc/models.py
+++ b/app/services/smc/models.py
@@ -3,7 +3,12 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    # liquidity.py imports Candle/Direction/Pivot from this module, so a
+    # top-level import here would cycle — the annotation stays a string.
+    from app.services.smc.liquidity import LiquidityLevel
 
 
 class Direction(str, Enum):
@@ -105,6 +110,7 @@ class TradeSetup:
     fvg: FVG
     entry_is_market: bool = False
     lot_hint: Optional[str] = None
+    target: Optional["LiquidityLevel"] = None
 
 
 @dataclass

--- a/app/services/smc/notifier.py
+++ b/app/services/smc/notifier.py
@@ -191,8 +191,9 @@ def format_plan(plan, live_line: str = None, as_of: str = None) -> str:
 
     lines.append("")
     lines.append(
-        "⚠️ Preliminary plan: SL is beyond the H1 zone; the live 🚨 alert will "
-        "tighten it to the M5 pivot. Order lives only within its session."
+        "⚠️ SL is preliminary (beyond the H1 zone); the live 🚨 alert "
+        "re-anchors it to the swept extreme and it may be wider. Order "
+        "lives only within its session."
     )
     return "\n".join(lines)
 

--- a/app/services/smc/notifier.py
+++ b/app/services/smc/notifier.py
@@ -24,6 +24,15 @@ def escape_html(text: str) -> str:
     )
 
 
+def format_target(level, decimals: int) -> str:
+    """Name a liquidity objective: 'H1 swing high 3221.00 (EQH x2)'."""
+    kind = "swing high" if level.is_high else "swing low"
+    pool = ""
+    if level.equal_count > 1:
+        pool = f" (EQ{'H' if level.is_high else 'L'} x{level.equal_count})"
+    return f"{level.timeframe} {kind} {level.price:.{decimals}f}{pool}"
+
+
 URGENT_HEADER = (
     "🚨🚨🚨 <b>URGENT! SETUP FOUND — READY TO TRADE!</b> 🚨🚨🚨"
 )
@@ -96,7 +105,10 @@ def format_result(result: AnalysisResult) -> str:
         lines.append(
             f"🛑 SL: {setup.stop_loss:.{d}f} | 🎯 TP: {setup.take_profit:.{d}f}"
         )
-        lines.append(f"📐 RR: 1:{setup.rr:.1f}")
+        rr_line = f"📐 RR: 1:{setup.rr:.1f}"
+        if setup.target:
+            rr_line += "  →  " + escape_html(format_target(setup.target, d))
+        lines.append(rr_line)
         if setup.lot_hint:
             lines.append(f"⚖️ Size: {setup.lot_hint}")
         else:

--- a/app/services/smc/notifier.py
+++ b/app/services/smc/notifier.py
@@ -5,6 +5,7 @@ from typing import Optional
 import httpx
 import structlog
 
+from app.services.smc.liquidity import LiquidityLevel
 from app.services.smc.models import AnalysisResult, Direction, Trend, Verdict
 from app.services.smc.sessions import to_prague
 
@@ -24,7 +25,7 @@ def escape_html(text: str) -> str:
     )
 
 
-def format_target(level, decimals: int) -> str:
+def format_target(level: LiquidityLevel, decimals: int) -> str:
     """Name a liquidity objective: 'H1 swing high 3221.00 (EQH x2)'."""
     kind = "swing high" if level.is_high else "swing low"
     pool = ""

--- a/app/services/smc/plan.py
+++ b/app/services/smc/plan.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 from app.services.smc.instruments import Instrument
+from app.services.smc.liquidity import find_liquidity, nearest_liquidity
 from app.services.smc.models import Candle, Direction, Trend
 from app.services.smc.profiles import CONSERVATIVE, StrategyProfile
 from app.services.smc.structure import (
@@ -46,43 +47,69 @@ class PairPlan:
 def _scenario(
     instrument: Instrument,
     h1: List[Candle],
+    h4: List[Candle],
     direction: Direction,
     price: float,
     speculative: bool,
-    tp_rr: float,
+    min_rr: float,
     profile: StrategyProfile,
-) -> Optional[PlanScenario]:
-    """Project a conditional setup with the fixed take-profit (tp_rr × risk)."""
+) -> Tuple[Optional[PlanScenario], Optional[str]]:
+    """Project a conditional setup aimed at the nearest unswept liquidity.
+
+    Returns `(scenario, reason)` — exactly one is non-None. `reason` explains
+    a live zone whose nearest pool does not reach `min_rr`, so the plan can
+    say so instead of pretending no structure exists.
+
+    M5 is not scanned here: hours before the session its swings will have
+    been swept long before price reaches the zone.
+    """
     zone = find_h1_zone(h1, direction, max_touches=profile.max_zone_touches)
     if zone is None:
-        return None
+        return None, None
 
     if direction == Direction.LONG:
         # a pullback-to-demand plan: the zone must sit at/below current price
         if zone.top >= price:
-            return None
+            return None, None
         entry, stop = zone.top, zone.bottom - instrument.sl_buffer
     else:
         if zone.bottom <= price:
-            return None
+            return None, None
         entry, stop = zone.bottom, zone.top + instrument.sl_buffer
 
     risk = abs(entry - stop)
     if risk <= 0:
-        return None
+        return None, None
 
-    sign = 1 if direction == Direction.LONG else -1
+    tolerance = instrument.min_fvg
+    levels = (
+        find_liquidity(h1, "H1", tolerance) + find_liquidity(h4, "H4", tolerance)
+    )
+    target = nearest_liquidity(levels, direction, entry)
+    if target is None:
+        return None, None
+
+    sign = -1 if direction == Direction.LONG else 1
+    take_profit = target.price + sign * instrument.sl_buffer
+    rr = abs(take_profit - entry) / risk
     d = instrument.price_decimals
+    if rr < min_rr:
+        return None, (
+            f"Zone {'Demand' if direction == Direction.LONG else 'Supply'} "
+            f"{zone.bottom:.{d}f}-{zone.top:.{d}f} is live, but the nearest "
+            f"liquidity gives 1:{rr:.1f} — waiting for other structure"
+        )
+
     return PlanScenario(
         direction=direction,
         entry=round(entry, d),
         stop_loss=round(stop, d),
-        take_profit=round(entry + sign * tp_rr * risk, d),
-        rr=round(tp_rr, 2),
+        take_profit=round(take_profit, d),
+        rr=round(rr, 2),
         zone_bottom=round(zone.bottom, d),
         zone_top=round(zone.top, d),
         speculative=speculative,
-    )
+    ), None
 
 
 def build_plan(
@@ -90,11 +117,12 @@ def build_plan(
     h4: List[Candle],
     h1: List[Candle],
     m5: List[Candle],
-    tp_rr: float = 2.5,
+    min_rr: float = 1.0,
     profile: Optional[StrategyProfile] = None,
     market_closed: bool = False,
 ) -> PairPlan:
-    """Build the pre-market plan; TP is projected at the fixed tp_rr × risk."""
+    """Build the pre-market plan; only scenarios reaching min_rr to the
+    nearest unswept liquidity are shown."""
     profile = profile or CONSERVATIVE
     price = round(m5[-1].close, instrument.price_decimals) if m5 else 0.0
     trend = detect_trend(h4)
@@ -121,13 +149,18 @@ def build_plan(
     if not directions and trend == Trend.FLAT:
         directions = [(Direction.LONG, True), (Direction.SHORT, True)]
 
+    reasons = []
     for direction, speculative in directions:
-        scenario = _scenario(
-            instrument, h1, direction, price, speculative, tp_rr, profile,
+        scenario, reason = _scenario(
+            instrument, h1, h4, direction, price, speculative, min_rr, profile,
         )
         if scenario:
             plan.scenarios.append(scenario)
+        elif reason:
+            reasons.append(reason)
 
     if not plan.scenarios:
-        plan.note = "No clean H1 zone for a plan yet — wait for structure to form"
+        plan.note = reasons[0] if reasons else (
+            "No clean H1 zone for a plan yet — wait for structure to form"
+        )
     return plan

--- a/app/services/smc/plan.py
+++ b/app/services/smc/plan.py
@@ -4,7 +4,9 @@ H4/H1 structure before the session, for the 07:45 morning briefing.
 For a trending pair the plan is the with-trend scenario. For a flat pair both
 directions are projected as speculative brackets ("if it breaks up → long, if
 down → short"). No M5 trigger exists yet, so the stop is preliminary — beyond
-the H1 zone extremum (per Шаблон B), not the tighter live M5-pivot stop.
+the H1 zone extremum (per Шаблон B). The live alert re-anchors it to the
+swept extreme of the zone excursion (Rule 6), which is not necessarily
+tighter than this preliminary stop.
 """
 
 from dataclasses import dataclass, field

--- a/app/services/smc/plan.py
+++ b/app/services/smc/plan.py
@@ -46,8 +46,8 @@ class PairPlan:
 
 def _scenario(
     instrument: Instrument,
-    h1: List[Candle],
     h4: List[Candle],
+    h1: List[Candle],
     direction: Direction,
     price: float,
     speculative: bool,
@@ -91,8 +91,18 @@ def _scenario(
 
     sign = -1 if direction == Direction.LONG else 1
     take_profit = target.price + sign * instrument.sl_buffer
-    rr = abs(take_profit - entry) / risk
+    reward = (take_profit - entry) if direction == Direction.LONG else (entry - take_profit)
     d = instrument.price_decimals
+    # See engine.py's Rule 7 for why this can't be inferred from RR alone:
+    # a target inside one sl_buffer of the entry would put the TP on the
+    # wrong side while abs(take_profit - entry) still reads positive.
+    if reward <= 0:
+        return None, (
+            f"Zone {'Demand' if direction == Direction.LONG else 'Supply'} "
+            f"{zone.bottom:.{d}f}-{zone.top:.{d}f} is live, but the nearest "
+            "liquidity sits inside the SL buffer — no positive reward"
+        )
+    rr = reward / risk
     if rr < min_rr:
         return None, (
             f"Zone {'Demand' if direction == Direction.LONG else 'Supply'} "
@@ -152,7 +162,7 @@ def build_plan(
     reasons = []
     for direction, speculative in directions:
         scenario, reason = _scenario(
-            instrument, h1, h4, direction, price, speculative, min_rr, profile,
+            instrument, h4, h1, direction, price, speculative, min_rr, profile,
         )
         if scenario:
             plan.scenarios.append(scenario)

--- a/app/services/smc/structure.py
+++ b/app/services/smc/structure.py
@@ -214,14 +214,20 @@ def find_choch(
     return None
 
 
-def last_protective_pivot(
-    candles: List[Candle], direction: Direction, before_index: int
-) -> Optional[Pivot]:
-    """Rule 6: last confirmed M5 pivot to anchor the stop loss."""
-    pivots = find_pivots(candles)
-    want_high = direction == Direction.SHORT
-    candidates = [p for p in pivots if p.is_high == want_high and p.index <= before_index]
-    return candidates[-1] if candidates else None
+def sweep_extreme(
+    candles: List[Candle], direction: Direction, touch_index: int, choch_index: int
+) -> float:
+    """Rule 6: the extreme of the excursion that swept liquidity before the
+    CHoCH — the low of a long's pullback, the high of a short's.
+
+    Anchoring the stop here instead of at the last fractal pivot matters when
+    a shallower pivot forms after the sweep: the pivot stop would sit inside
+    the wick that took the stops, and get taken with them.
+    """
+    window = candles[touch_index:choch_index + 1] or [candles[choch_index]]
+    if direction == Direction.LONG:
+        return min(c.low for c in window)
+    return max(c.high for c in window)
 
 
 def zone_touch_span(

--- a/app/services/smc/structure.py
+++ b/app/services/smc/structure.py
@@ -155,35 +155,6 @@ def find_h1_zone(
     return None
 
 
-def find_target_zones(
-    candles: List[Candle], direction: Direction, entry: float
-) -> List[Zone]:
-    """Rule 7: all untested opposite zones beyond entry, nearest first."""
-    pivots = find_pivots(candles)
-    want_high = direction == Direction.LONG
-    out: List[Zone] = []
-    for pivot in (p for p in pivots if p.is_high == want_high):
-        zone = _mark_zone_state(candles, build_zone(candles, pivot))
-        if zone.invalidated or zone.tested:
-            continue
-        if direction == Direction.LONG and zone.bottom > entry:
-            out.append(zone)
-        elif direction == Direction.SHORT and zone.top < entry:
-            out.append(zone)
-    if direction == Direction.LONG:
-        out.sort(key=lambda z: z.bottom)          # nearest above entry first
-    else:
-        out.sort(key=lambda z: z.top, reverse=True)  # nearest below entry first
-    return out
-
-
-def find_target_zone(
-    candles: List[Candle], direction: Direction, entry: float
-) -> Optional[Zone]:
-    """Nearest untested opposite zone beyond entry (back-compat wrapper)."""
-    return next(iter(find_target_zones(candles, direction, entry)), None)
-
-
 def find_choch(
     candles: List[Candle], direction: Direction, from_index: int
 ) -> Optional[int]:

--- a/app/services/smc/structure.py
+++ b/app/services/smc/structure.py
@@ -195,7 +195,7 @@ def sweep_extreme(
     a shallower pivot forms after the sweep: the pivot stop would sit inside
     the wick that took the stops, and get taken with them.
     """
-    window = candles[touch_index:choch_index + 1] or [candles[choch_index]]
+    window = candles[touch_index:choch_index + 1]
     if direction == Direction.LONG:
         return min(c.low for c in window)
     return max(c.high for c in window)

--- a/docs/superpowers/plans/2026-08-05-liquidity-tp-sl.md
+++ b/docs/superpowers/plans/2026-08-05-liquidity-tp-sl.md
@@ -1,0 +1,997 @@
+# Liquidity-based TP and sweep-based SL — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the fixed 1:2.5 take-profit with the nearest unswept liquidity level, anchor the stop to the sweep extreme, and let any setup with a real RR ≥ 1:1 through.
+
+**Architecture:** A new pure module `app/services/smc/liquidity.py` turns the existing fractal pivots into unswept liquidity levels (single swings and EQH/EQL clusters). `TripleSyncEngine` consumes it at Rule 7 for the target and a new `structure.sweep_extreme` at Rule 6 for the stop. `plan.py` uses the same target search so `/plan` and live alerts agree. Everything stays pure and unit-testable on synthetic candles — no network in tests.
+
+**Tech Stack:** Python 3.13, dataclasses, pytest (`asyncio_mode=auto`), flake8. No new dependencies.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-05-liquidity-tp-sl-design.md`. Read it before Task 1.
+- Branch: `feat/liquidity-tp-sl` (already created, spec already committed).
+- All bot-facing text is **English**. Message timestamps are Prague time.
+- Every dynamic string embedded in a Telegram message MUST pass through `notifier.escape_html`.
+- Per-instrument parameters live in `instruments.py` only — never hardcode a pip, buffer or FVG size elsewhere.
+- Liquidity tolerance is the **raw** `Instrument.min_fvg`, never the profile-scaled `_effective_min_fvg`.
+- Quiet mode: Telegram receives found setups only. Low-RR skips go to logs, never to chat.
+- Tests must be network-free and build candles via `tests/test_smc/helpers.py`.
+- Run `pytest tests/ -v` and `flake8 app/ tests/ smc_watcher.py` before every commit.
+- Line length and style follow `.flake8`; match surrounding comment density.
+
+---
+
+### Task 1: Liquidity module
+
+**Files:**
+- Create: `app/services/smc/liquidity.py`
+- Test: `tests/test_smc/test_liquidity.py`
+
+**Interfaces:**
+- Consumes: `structure.find_pivots`, `models.Candle`, `models.Direction`.
+- Produces:
+  - `LiquidityLevel(price: float, is_high: bool, timeframe: str, equal_count: int, timestamp: datetime)` — frozen dataclass.
+  - `find_liquidity(candles: List[Candle], timeframe: str, tolerance: float) -> List[LiquidityLevel]`
+  - `nearest_liquidity(levels: List[LiquidityLevel], direction: Direction, entry: float) -> Optional[LiquidityLevel]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_smc/test_liquidity.py`:
+
+```python
+"""Liquidity levels: unswept swings and EQH/EQL clusters (Rule 7 targets)."""
+
+from app.services.smc.liquidity import (
+    LiquidityLevel,
+    find_liquidity,
+    nearest_liquidity,
+)
+from app.services.smc.models import Direction
+from tests.test_smc.helpers import candle
+
+# One high pivot at index 2 (3160) and one low pivot at index 5 (3140),
+# neither taken out by any later candle.
+_BASE = [
+    (3140.0, 3142.0, 3138.0, 3141.0),
+    (3141.0, 3148.0, 3140.0, 3147.0),
+    (3147.0, 3160.0, 3146.0, 3158.0),   # high pivot 3160
+    (3158.0, 3159.0, 3150.0, 3151.0),
+    (3151.0, 3152.0, 3144.0, 3145.0),
+    (3145.0, 3146.0, 3140.0, 3141.0),   # low pivot 3140
+    (3141.0, 3147.0, 3140.5, 3146.0),
+    (3146.0, 3150.0, 3145.0, 3149.0),
+    (3149.0, 3151.0, 3148.0, 3150.0),
+]
+
+
+def _series(spec):
+    return [candle(*row, index=i) for i, row in enumerate(spec)]
+
+
+class TestFindLiquidity:
+    def test_unswept_swings_become_levels(self):
+        levels = find_liquidity(_series(_BASE), "H1", tolerance=2.0)
+        highs = [lv for lv in levels if lv.is_high]
+        lows = [lv for lv in levels if not lv.is_high]
+        assert [lv.price for lv in highs] == [3160.0]
+        assert [lv.price for lv in lows] == [3140.0]
+        assert highs[0].timeframe == "H1"
+        assert highs[0].equal_count == 1
+
+    def test_wick_beyond_tolerance_sweeps_the_level(self):
+        # A later candle wicks to 3163 (> 3160 + 2.0) but closes far below:
+        # the pool is taken even though no body closed above it.
+        swept = _series(_BASE + [(3150.0, 3163.0, 3149.0, 3150.0)])
+        highs = [lv for lv in find_liquidity(swept, "H1", 2.0) if lv.is_high]
+        assert highs == []
+
+    def test_poke_inside_tolerance_does_not_sweep(self):
+        # 3161.5 is only 1.5 above 3160 — less than the 2.0 tolerance, so the
+        # pool survives. Without this, two "equal" highs could never coexist.
+        poked = _series(_BASE + [(3150.0, 3161.5, 3149.0, 3150.0)])
+        highs = [lv for lv in find_liquidity(poked, "H1", 2.0) if lv.is_high]
+        assert [lv.price for lv in highs] == [3160.0]
+
+
+class TestEqualHighsClustering:
+    # A second attempt at the same area stalls 0.5 short of the first high:
+    # two unswept highs 0.5 apart = one EQH pool.
+    _EQH = _BASE + [
+        (3150.0, 3159.5, 3149.0, 3158.0),   # high pivot 3159.5
+        (3158.0, 3157.0, 3150.0, 3151.0),
+        (3151.0, 3152.0, 3146.0, 3147.0),
+        (3147.0, 3148.0, 3145.0, 3146.0),
+        (3146.0, 3147.0, 3144.0, 3145.0),
+    ]
+
+    def test_two_close_highs_form_one_cluster(self):
+        highs = [lv for lv in find_liquidity(_series(self._EQH), "H1", 2.0)
+                 if lv.is_high]
+        assert len(highs) == 1
+        assert highs[0].equal_count == 2
+
+    def test_cluster_price_is_the_near_side(self):
+        # Price approaches highs from below, so the pool starts at the LOWER
+        # of the two equal highs.
+        highs = [lv for lv in find_liquidity(_series(self._EQH), "H1", 2.0)
+                 if lv.is_high]
+        assert highs[0].price == 3159.5
+
+    def test_highs_beyond_tolerance_stay_separate(self):
+        levels = find_liquidity(_series(self._EQH), "H1", tolerance=0.2)
+        highs = sorted(
+            (lv for lv in levels if lv.is_high), key=lambda lv: lv.price
+        )
+        assert [lv.price for lv in highs] == [3159.5, 3160.0]
+        assert all(lv.equal_count == 1 for lv in highs)
+
+
+class TestNearestLiquidity:
+    def _level(self, price, is_high=True, tf="H1", count=1):
+        return LiquidityLevel(
+            price=price, is_high=is_high, timeframe=tf,
+            equal_count=count, timestamp=None,
+        )
+
+    def test_long_ignores_levels_at_or_below_entry(self):
+        levels = [self._level(3100.0), self._level(3210.0), self._level(3180.0)]
+        best = nearest_liquidity(levels, Direction.LONG, entry=3150.0)
+        assert best.price == 3180.0
+
+    def test_long_ignores_lows(self):
+        levels = [self._level(3180.0, is_high=False), self._level(3210.0)]
+        best = nearest_liquidity(levels, Direction.LONG, entry=3150.0)
+        assert best.price == 3210.0
+
+    def test_short_takes_the_highest_low_below_entry(self):
+        levels = [
+            self._level(3100.0, is_high=False),
+            self._level(3140.0, is_high=False),
+        ]
+        best = nearest_liquidity(levels, Direction.SHORT, entry=3150.0)
+        assert best.price == 3140.0
+
+    def test_equal_distance_prefers_the_cluster(self):
+        levels = [
+            self._level(3180.0, tf="M5", count=1),
+            self._level(3180.0, tf="H1", count=3),
+        ]
+        best = nearest_liquidity(levels, Direction.LONG, entry=3150.0)
+        assert best.equal_count == 3
+        assert best.timeframe == "H1"
+
+    def test_no_level_beyond_entry_returns_none(self):
+        levels = [self._level(3100.0)]
+        assert nearest_liquidity(levels, Direction.LONG, entry=3150.0) is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_smc/test_liquidity.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.services.smc.liquidity'`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `app/services/smc/liquidity.py`:
+
+```python
+"""Liquidity levels: unswept swing highs/lows and EQH/EQL pools (Rule 7).
+
+A zone (structure.py) is an order block — an area price reacted from. A
+liquidity level is the resting stop-loss pool behind a swing extreme. They
+are different objects: the take-profit targets liquidity, the H1 entry
+targets a zone.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+from app.services.smc.models import Candle, Direction, Pivot
+from app.services.smc.structure import find_pivots
+
+# Higher timeframes break ties last; a pool on H4 outranks the same price on M5.
+_TF_RANK = {"M5": 0, "H1": 1, "H4": 2}
+
+
+@dataclass(frozen=True)
+class LiquidityLevel:
+    """An unswept swing extreme, or a pool of equal ones."""
+
+    price: float
+    is_high: bool
+    timeframe: str  # "M5" | "H1" | "H4"
+    equal_count: int  # 1 = single swing, 2+ = EQH/EQL pool
+    timestamp: Optional[datetime] = None
+
+
+def _is_swept(candles: List[Candle], pivot: Pivot, tolerance: float) -> bool:
+    """True once a later candle traded beyond the level by more than
+    `tolerance`.
+
+    Wick-based on purpose: liquidity is taken by the wick that runs the stops,
+    not by a body close (that is zone invalidation, a different rule). The
+    tolerance is what makes equal highs possible — a poke smaller than the
+    instrument's minimum FVG has not taken the pool.
+    """
+    later = candles[pivot.index + 1:]
+    if pivot.is_high:
+        return any(c.high > pivot.price + tolerance for c in later)
+    return any(c.low < pivot.price - tolerance for c in later)
+
+
+def _cluster(
+    pivots: List[Pivot], is_high: bool, timeframe: str, tolerance: float
+) -> List[LiquidityLevel]:
+    """Group same-side pivots within `tolerance` into single pools."""
+    group = sorted(
+        (p for p in pivots if p.is_high == is_high), key=lambda p: p.price
+    )
+    out: List[LiquidityLevel] = []
+    i = 0
+    while i < len(group):
+        j = i
+        while j + 1 < len(group) and group[j + 1].price - group[i].price <= tolerance:
+            j += 1
+        members = group[i:j + 1]
+        # Price meets the pool from one side: the lowest high, the highest low.
+        anchor = members[0] if is_high else members[-1]
+        newest = max(members, key=lambda p: p.index)
+        out.append(
+            LiquidityLevel(
+                price=anchor.price,
+                is_high=is_high,
+                timeframe=timeframe,
+                equal_count=len(members),
+                timestamp=newest.timestamp,
+            )
+        )
+        i = j + 1
+    return out
+
+
+def find_liquidity(
+    candles: List[Candle], timeframe: str, tolerance: float
+) -> List[LiquidityLevel]:
+    """All unswept liquidity on this timeframe, singles and pools alike."""
+    unswept = [p for p in find_pivots(candles) if not _is_swept(candles, p, tolerance)]
+    return (
+        _cluster(unswept, True, timeframe, tolerance)
+        + _cluster(unswept, False, timeframe, tolerance)
+    )
+
+
+def nearest_liquidity(
+    levels: List[LiquidityLevel], direction: Direction, entry: float
+) -> Optional[LiquidityLevel]:
+    """Closest unswept pool beyond `entry` in the trade direction.
+
+    Equal distance is broken by pool size, then by timeframe — a pool of
+    three equal highs is a better objective than one lone swing.
+    """
+    if direction == Direction.LONG:
+        candidates = [lv for lv in levels if lv.is_high and lv.price > entry]
+        distance = lambda lv: lv.price - entry  # noqa: E731
+    else:
+        candidates = [lv for lv in levels if not lv.is_high and lv.price < entry]
+        distance = lambda lv: entry - lv.price  # noqa: E731
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda lv: (
+            distance(lv), -lv.equal_count, -_TF_RANK.get(lv.timeframe, 0)
+        )
+    )
+    return candidates[0]
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pytest tests/test_smc/test_liquidity.py -v`
+Expected: PASS — 11 tests.
+
+Then run the whole suite and lint to be sure nothing else moved:
+Run: `pytest tests/ -q && flake8 app/ tests/ smc_watcher.py`
+Expected: 192 passed + 11 new = 203 passed, flake8 silent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/smc/liquidity.py tests/test_smc/test_liquidity.py
+git commit -m "Add liquidity levels: unswept swings and EQH/EQL pools"
+```
+
+---
+
+### Task 2: Rule 6 — stop behind the sweep extreme
+
+**Files:**
+- Modify: `app/services/smc/structure.py` (add `sweep_extreme`, delete `last_protective_pivot`)
+- Modify: `app/services/smc/engine.py:238-249`
+- Modify: `tests/test_smc/helpers.py` (add `m5_long_trigger_deep_sweep`)
+- Test: `tests/test_smc/test_engine.py`
+
+**Interfaces:**
+- Consumes: `zone_touch_span` (already used by the engine to produce `touch`), `find_choch` (produces `choch`).
+- Produces: `sweep_extreme(candles: List[Candle], direction: Direction, touch_index: int, choch_index: int) -> float`.
+
+- [ ] **Step 1: Add the test fixture**
+
+Append to `tests/test_smc/helpers.py`:
+
+```python
+def m5_long_trigger_deep_sweep() -> List[Candle]:
+    """M5 where the sweep low and the last fractal pivot DISAGREE.
+
+    Against the H1 demand zone 3131.0-3138.0 (built from H1_PULLBACK_CLOSES):
+    - lower-high pivot at index 6 (3148) is the CHoCH reference
+    - the excursion into the zone starts at index 8 and runs to index 14
+    - index 9 spikes down to 3126 — the real swept low
+    - a shallower fractal low forms later at index 12 (3132.5)
+    - bullish FVG between high[13]=3138.0 and low[15]=3140.5 (size 2.5)
+    - CHoCH at index 16 (close 3149 > 3148)
+
+    `last_protective_pivot` returned the LAST pivot at/before the CHoCH —
+    3132.5, above the sweep. `sweep_extreme` returns 3126.0.
+    """
+    spec = [
+        (3160.0, 3161.0, 3155.0, 3156.0),
+        (3156.0, 3157.0, 3151.0, 3152.0),
+        (3152.0, 3153.0, 3147.0, 3148.0),
+        (3148.0, 3149.0, 3143.0, 3144.0),
+        (3144.0, 3145.0, 3140.0, 3142.0),
+        (3142.0, 3146.0, 3141.0, 3145.0),
+        (3145.0, 3148.0, 3144.0, 3147.0),
+        (3147.0, 3147.5, 3141.0, 3142.0),
+        (3142.0, 3143.0, 3134.0, 3136.0),
+        (3136.0, 3137.0, 3126.0, 3135.0),
+        (3135.0, 3136.0, 3133.5, 3134.5),
+        (3134.5, 3135.5, 3133.0, 3135.0),
+        (3135.0, 3136.0, 3132.5, 3135.5),
+        (3135.5, 3138.0, 3135.0, 3137.5),
+        (3137.5, 3141.0, 3137.0, 3140.8),
+        (3140.8, 3144.0, 3140.5, 3143.5),
+        (3143.5, 3149.5, 3143.0, 3149.0),
+        (3149.0, 3151.0, 3147.0, 3150.0),
+        (3150.0, 3152.0, 3148.0, 3151.0),
+        (3151.0, 3152.0, 3149.0, 3150.0),
+    ]
+    return [candle(*row, index=i) for i, row in enumerate(spec)]
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `tests/test_smc/test_engine.py` (imports: add `m5_long_trigger_deep_sweep` to the existing `tests.test_smc.helpers` import):
+
+```python
+class TestSweepStop:
+    """Rule 6 (2026-08-05): SL sits behind the swept extreme, not behind the
+    last fractal pivot."""
+
+    def test_stop_is_below_the_sweep_not_the_later_pivot(self):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        result = _engine().evaluate(
+            h4=h4, h1=h1, m5=m5_long_trigger_deep_sweep(), result=_fresh_result()
+        )
+        assert result.setup is not None, result.reasons
+        # sweep low 3126.0 minus the $2 buffer, NOT 3132.5 - 2 = 3130.5
+        assert result.setup.stop_loss == 3124.0
+```
+
+`_engine()` and `_fresh_result()` are the existing module-level helpers at
+`tests/test_smc/test_engine.py:18-29`. Use them; do not add new ones.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `pytest tests/test_smc/test_engine.py::TestSweepStop -v`
+Expected: FAIL — `assert 3130.5 == 3124.0` (the old pivot-based stop).
+
+- [ ] **Step 4: Add `sweep_extreme` to structure.py**
+
+Replace `last_protective_pivot` (lines 217-224) with:
+
+```python
+def sweep_extreme(
+    candles: List[Candle], direction: Direction, touch_index: int, choch_index: int
+) -> float:
+    """Rule 6: the extreme of the excursion that swept liquidity before the
+    CHoCH — the low of a long's pullback, the high of a short's.
+
+    Anchoring the stop here instead of at the last fractal pivot matters when
+    a shallower pivot forms after the sweep: the pivot stop would sit inside
+    the wick that took the stops, and get taken with them.
+    """
+    window = candles[touch_index:choch_index + 1] or [candles[choch_index]]
+    if direction == Direction.LONG:
+        return min(c.low for c in window)
+    return max(c.high for c in window)
+```
+
+- [ ] **Step 5: Wire it into the engine**
+
+In `app/services/smc/engine.py`, replace the Rule 6 block (lines 238-249):
+
+```python
+        # Rule 6 — stop behind the swept extreme of the zone excursion
+        extreme = sweep_extreme(m5, direction, touch, choch)
+        if direction == Direction.LONG:
+            stop_loss = extreme - self.sl_buffer
+        else:
+            stop_loss = extreme + self.sl_buffer
+```
+
+Update the import block at the top of `engine.py`: drop `last_protective_pivot`, add `sweep_extreme` (keep the list alphabetised as it already is).
+
+Note the "No confirmed M5 pivot for the stop" SKIP branch disappears — an excursion always has an extreme. The `risk <= 0` guard immediately below stays.
+
+- [ ] **Step 6: Run the tests**
+
+Run: `pytest tests/test_smc/test_engine.py -v`
+Expected: `TestSweepStop` PASSES. Other tests in the file may now fail on stop/RR numbers — that is expected, they assert the old pivot stop. Fix each by recomputing the expected value from the fixture, not by loosening the assertion.
+
+Run: `pytest tests/ -q && flake8 app/ tests/ smc_watcher.py`
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/services/smc/structure.py app/services/smc/engine.py tests/test_smc/helpers.py tests/test_smc/test_engine.py
+git commit -m "Rule 6: anchor the stop to the sweep extreme, not the last pivot"
+```
+
+---
+
+### Task 3: Rule 7 — take-profit at the nearest unswept liquidity
+
+**Files:**
+- Modify: `app/core/config.py:64-68` (`tp_rr` → `min_rr`)
+- Modify: `app/services/smc/models.py` (`TradeSetup.target`)
+- Modify: `app/services/smc/engine.py` (constructor + Rule 7 block)
+- Test: `tests/test_smc/test_engine.py`, `tests/test_smc/test_improvements.py`
+
+**Interfaces:**
+- Consumes: `liquidity.find_liquidity`, `liquidity.nearest_liquidity`, `LiquidityLevel` (Task 1).
+- Produces:
+  - `TripleSyncEngine(..., min_rr: float = 1.0, ...)` — `tp_rr` is gone.
+  - `TradeSetup.target: Optional[LiquidityLevel] = None` — Task 4 renders it.
+  - `SMCSettings.min_rr: float = 1.0` (env `SMC_MIN_RR`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_smc/test_engine.py`:
+
+```python
+class TestLiquidityTarget:
+    """Rule 7 (2026-08-05): TP is the nearest unswept liquidity, one buffer
+    short of the level; RR is computed, not assigned."""
+
+    def _run(self, **kwargs):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        return _engine(**kwargs).evaluate(
+            h4=h4, h1=h1, m5=m5_long_trigger_deep_sweep(), result=_fresh_result()
+        )
+
+    def test_tp_is_the_nearest_unswept_liquidity_minus_buffer(self):
+        result = self._run()
+        assert result.setup is not None, result.reasons
+        # H1 swing high 3221.0 is the nearest unswept pool above entry 3140.5
+        assert result.setup.take_profit == 3219.0
+        assert result.setup.target.price == 3221.0
+        assert result.setup.target.timeframe == "H1"
+
+    def test_rr_is_computed_from_the_target(self):
+        result = self._run()
+        # entry 3140.5, SL 3124.0 -> risk 16.5; TP 3219.0 -> 78.5 / 16.5
+        assert result.setup.rr == 4.76
+
+    def test_rr_does_not_track_the_threshold(self):
+        # The old rule assigned rr = tp_rr, so the RR moved with the setting.
+        assert self._run(min_rr=1.0).setup.rr == self._run(min_rr=2.0).setup.rr
+
+    def test_setup_below_the_threshold_is_skipped(self):
+        result = self._run(min_rr=8.0)
+        assert result.verdict == Verdict.SKIP
+        assert result.setup is None
+        assert "1:4.8" in result.reasons[0]
+        assert "1:8" in result.reasons[0]
+```
+
+Also update the two module-level engine builders at `tests/test_smc/test_engine.py:26-34` — both carry `tp_rr=2.5` in their `defaults` dict:
+
+```python
+def _engine(**kwargs) -> TripleSyncEngine:
+    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, min_rr=1.0)
+    defaults.update(kwargs)
+    return TripleSyncEngine(**defaults)
+
+
+def _agg_engine(**kwargs) -> TripleSyncEngine:
+    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, min_rr=1.0, profile=AGGRESSIVE)
+    defaults.update(kwargs)
+    return TripleSyncEngine(**defaults)
+```
+
+Delete `test_tp_scales_with_configured_tp_rr` and `test_skip_when_no_zone_beyond_fixed_tp` (lines ~102-120) — they assert the removed rule. Rewrite the `tp_rr=2.5` case in `tests/test_smc/test_improvements.py:49-52` to construct the engine with no RR argument and assert `result.setup.target is not None`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_smc/test_engine.py::TestLiquidityTarget -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'min_rr'`
+
+- [ ] **Step 3: Add the config setting**
+
+In `app/core/config.py`, replace the `tp_rr` field (lines 64-68) with:
+
+```python
+    min_rr: float = Field(
+        default=1.0,
+        description="Minimum risk/reward to the nearest unswept liquidity; "
+        "setups below it are skipped (owner decision 2026-08-05)",
+    )
+```
+
+- [ ] **Step 4: Add the target field to the model**
+
+In `app/services/smc/models.py`, add to `TradeSetup` (after `lot_hint`):
+
+```python
+    target: Optional["LiquidityLevel"] = None
+```
+
+and at the top of the file:
+
+```python
+from app.services.smc.liquidity import LiquidityLevel
+```
+
+If that import creates a cycle (`liquidity` imports `structure`, which imports `models`), do NOT restructure the modules — keep the annotation as the string `Optional["LiquidityLevel"]` with `if TYPE_CHECKING:` guarding the import. Verify with `python -c "import app.services.smc.engine"`.
+
+- [ ] **Step 5: Rewrite Rule 7 in the engine**
+
+Constructor: rename the `tp_rr: float = 2.5` parameter to `min_rr: float = 1.0` and `self.tp_rr = tp_rr` to `self.min_rr = min_rr`.
+
+Replace the whole Rule 7 block (`engine.py`, from the `# Rule 7` comment through the `if not has_room:` branch) with:
+
+```python
+        # Rule 7 (owner decision 2026-08-05) — take-profit at the nearest
+        # unswept liquidity: the pool the move is actually reaching for. The
+        # TP sits one buffer short of the level so the trade is out before
+        # the sweep itself. Liquidity uses the raw per-instrument minimum FVG
+        # as its tolerance — it is a property of the chart, not of the
+        # profile the owner is trading.
+        tolerance = self.min_fvg_size
+        levels = (
+            find_liquidity(m5, "M5", tolerance)
+            + find_liquidity(h1, "H1", tolerance)
+            + find_liquidity(h4, "H4", tolerance)
+        )
+        target = nearest_liquidity(levels, direction, entry)
+        if target is None:
+            result.verdict = Verdict.SKIP
+            result.reasons.append(
+                "No unswept liquidity beyond the entry — nothing to aim at"
+            )
+            return result
+
+        if direction == Direction.LONG:
+            take_profit = target.price - self.sl_buffer
+        else:
+            take_profit = target.price + self.sl_buffer
+        rr = abs(take_profit - entry) / risk
+        if rr < self.min_rr:
+            result.verdict = Verdict.SKIP
+            result.reasons.append(
+                f"RR 1:{rr:.1f} < minimum 1:{self.min_rr:g} to the nearest "
+                f"liquidity ({target.timeframe} "
+                f"{'swing high' if target.is_high else 'swing low'} "
+                f"{target.price:.{self.instrument.price_decimals}f})"
+            )
+            return result
+```
+
+Add `target=target` to the `TradeSetup(...)` construction below it.
+
+Update the engine imports: add `from app.services.smc.liquidity import find_liquidity, nearest_liquidity`, and drop `find_target_zone` from the `structure` import (it keeps its other caller in `plan.py` until Task 5).
+
+- [ ] **Step 6: Run the tests**
+
+Run: `pytest tests/test_smc/test_engine.py tests/test_smc/test_improvements.py -v`
+Expected: PASS.
+
+Run: `pytest tests/ -q`
+Expected: failures only in `test_plan.py`, `test_funnel.py`, `test_multipair.py`, `test_visuals.py`, `test_zone_ping.py` on the removed `tp_rr` keyword — those are Tasks 5 and 6.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/core/config.py app/services/smc/models.py app/services/smc/engine.py tests/test_smc/test_engine.py tests/test_smc/test_improvements.py
+git commit -m "Rule 7: take-profit at the nearest unswept liquidity, RR >= SMC_MIN_RR"
+```
+
+---
+
+### Task 4: Alert names the objective
+
+**Files:**
+- Modify: `app/services/smc/notifier.py` (`format_result`, line ~99)
+- Test: `tests/test_smc/test_html_escaping.py` — the only module that exercises `format_result`
+
+**Interfaces:**
+- Consumes: `TradeSetup.target` (Task 3).
+- Produces: `notifier.format_target(level: LiquidityLevel, decimals: int) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_smc/test_html_escaping.py` (import `format_target` from `app.services.smc.notifier` and `LiquidityLevel` from `app.services.smc.liquidity`):
+
+```python
+class TestTargetLine:
+    def test_rr_line_names_the_liquidity(self):
+        level = LiquidityLevel(
+            price=3221.0, is_high=True, timeframe="H1",
+            equal_count=1, timestamp=None,
+        )
+        assert format_target(level, 2) == "H1 swing high 3221.00"
+
+    def test_pool_size_is_shown(self):
+        level = LiquidityLevel(
+            price=3221.0, is_high=True, timeframe="H1",
+            equal_count=3, timestamp=None,
+        )
+        assert format_target(level, 2) == "H1 swing high 3221.00 (EQH x3)"
+
+    def test_low_pool_uses_eql(self):
+        level = LiquidityLevel(
+            price=3050.0, is_high=False, timeframe="H4",
+            equal_count=2, timestamp=None,
+        )
+        assert format_target(level, 2) == "H4 swing low 3050.00 (EQL x2)"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_smc/ -k TargetLine -v`
+Expected: FAIL — `ImportError: cannot import name 'format_target'`
+
+- [ ] **Step 3: Implement**
+
+In `app/services/smc/notifier.py`:
+
+```python
+def format_target(level, decimals: int) -> str:
+    """Name a liquidity objective: 'H1 swing high 3221.00 (EQH x2)'."""
+    kind = "swing high" if level.is_high else "swing low"
+    pool = ""
+    if level.equal_count > 1:
+        pool = f" (EQ{'H' if level.is_high else 'L'} x{level.equal_count})"
+    return f"{level.timeframe} {kind} {level.price:.{decimals}f}{pool}"
+```
+
+Replace the RR line in `format_result` (currently `lines.append(f"📐 RR: 1:{setup.rr:.1f}")`):
+
+```python
+        rr_line = f"📐 RR: 1:{setup.rr:.1f}"
+        if setup.target:
+            rr_line += "  →  " + escape_html(format_target(setup.target, d))
+        lines.append(rr_line)
+```
+
+Plain ASCII `x` rather than `×` in the pool suffix: the alert already carries emoji, and `x` avoids any doubt about encoding on the Railway console. `escape_html` is applied because the string is dynamic — that rule has no exceptions in this codebase.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pytest tests/test_smc/ -k TargetLine -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/smc/notifier.py tests/
+git commit -m "Alert: name the liquidity objective on the RR line"
+```
+
+---
+
+### Task 5: Pre-market plan uses the same targets
+
+**Files:**
+- Modify: `app/services/smc/plan.py:46-133`
+- Test: `tests/test_smc/test_plan.py`
+
+**Interfaces:**
+- Consumes: `find_liquidity`, `nearest_liquidity` (Task 1).
+- Produces: `build_plan(instrument, h4, h1, m5, min_rr: float = 1.0, profile=None, market_closed=False) -> PairPlan`; `_scenario(instrument, h1, h4, direction, price, speculative, min_rr, profile) -> Tuple[Optional[PlanScenario], Optional[str]]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/test_smc/test_plan.py`, replace every `tp_rr=2.5` argument with `min_rr=1.0`, and add:
+
+```python
+    def test_scenario_targets_liquidity(self):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3150, 3152, 3151, 3153])
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
+        assert plan.scenarios
+        s = plan.scenarios[0]
+        # TP is a structural level, not a multiple of the risk
+        assert s.take_profit != round(s.entry + 2.5 * abs(s.entry - s.stop_loss), 2)
+        assert s.rr >= 1.0
+
+    def test_scenario_below_threshold_is_explained(self):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3150, 3152, 3151, 3153])
+        plan = build_plan(ETH, h4, h1, m5, min_rr=99.0)
+        assert plan.scenarios == []
+        assert "1:" in plan.note
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_smc/test_plan.py -v`
+Expected: FAIL — `TypeError: build_plan() got an unexpected keyword argument 'min_rr'`
+
+- [ ] **Step 3: Implement**
+
+In `app/services/smc/plan.py`, replace `_scenario` (lines 46-85) with:
+
+```python
+def _scenario(
+    instrument: Instrument,
+    h1: List[Candle],
+    h4: List[Candle],
+    direction: Direction,
+    price: float,
+    speculative: bool,
+    min_rr: float,
+    profile: StrategyProfile,
+) -> Tuple[Optional[PlanScenario], Optional[str]]:
+    """Project a conditional setup aimed at the nearest unswept liquidity.
+
+    Returns `(scenario, reason)` — exactly one is non-None. `reason` explains
+    a live zone whose nearest pool does not reach `min_rr`, so the plan can
+    say so instead of pretending no structure exists.
+
+    M5 is not scanned here: hours before the session its swings will have
+    been swept long before price reaches the zone.
+    """
+    zone = find_h1_zone(h1, direction, max_touches=profile.max_zone_touches)
+    if zone is None:
+        return None, None
+
+    if direction == Direction.LONG:
+        # a pullback-to-demand plan: the zone must sit at/below current price
+        if zone.top >= price:
+            return None, None
+        entry, stop = zone.top, zone.bottom - instrument.sl_buffer
+    else:
+        if zone.bottom <= price:
+            return None, None
+        entry, stop = zone.bottom, zone.top + instrument.sl_buffer
+
+    risk = abs(entry - stop)
+    if risk <= 0:
+        return None, None
+
+    tolerance = instrument.min_fvg
+    levels = (
+        find_liquidity(h1, "H1", tolerance) + find_liquidity(h4, "H4", tolerance)
+    )
+    target = nearest_liquidity(levels, direction, entry)
+    if target is None:
+        return None, None
+
+    sign = -1 if direction == Direction.LONG else 1
+    take_profit = target.price + sign * instrument.sl_buffer
+    rr = abs(take_profit - entry) / risk
+    d = instrument.price_decimals
+    if rr < min_rr:
+        return None, (
+            f"Zone {'Demand' if direction == Direction.LONG else 'Supply'} "
+            f"{zone.bottom:.{d}f}-{zone.top:.{d}f} is live, but the nearest "
+            f"liquidity gives 1:{rr:.1f} — waiting for other structure"
+        )
+
+    return PlanScenario(
+        direction=direction,
+        entry=round(entry, d),
+        stop_loss=round(stop, d),
+        take_profit=round(take_profit, d),
+        rr=round(rr, 2),
+        zone_bottom=round(zone.bottom, d),
+        zone_top=round(zone.top, d),
+        speculative=speculative,
+    ), None
+```
+
+In `build_plan`: rename the `tp_rr: float = 2.5` parameter to `min_rr: float = 1.0`, update the docstring to "only scenarios reaching min_rr to the nearest unswept liquidity are shown", and change the loop:
+
+```python
+    reasons = []
+    for direction, speculative in directions:
+        scenario, reason = _scenario(
+            instrument, h1, h4, direction, price, speculative, min_rr, profile,
+        )
+        if scenario:
+            plan.scenarios.append(scenario)
+        elif reason:
+            reasons.append(reason)
+
+    if not plan.scenarios:
+        plan.note = reasons[0] if reasons else (
+            "No clean H1 zone for a plan yet — wait for structure to form"
+        )
+    return plan
+```
+
+Imports: add `from app.services.smc.liquidity import find_liquidity, nearest_liquidity`, drop `find_target_zones` from the `structure` import if it is now unused, and make sure `Tuple` is imported from `typing`.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pytest tests/test_smc/test_plan.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/smc/plan.py tests/test_smc/test_plan.py
+git commit -m "Plan: project targets at the nearest unswept liquidity"
+```
+
+---
+
+### Task 6: Wire the watcher, funnel, env and docs
+
+**Files:**
+- Modify: `smc_watcher.py:103`, `smc_watcher.py:502`
+- Modify: `scripts/funnel.py:44-63` (`classify_result`), `scripts/funnel.py:81`, `scripts/funnel.py:100`
+- Modify: `env.example:31`
+- Modify: `CLAUDE.md`, `README.md`
+- Test: `tests/test_smc/test_funnel.py`, `tests/test_smc/test_multipair.py`, `tests/test_smc/test_visuals.py`, `tests/test_smc/test_zone_ping.py`
+
+**Interfaces:**
+- Consumes: `SMCSettings.min_rr` (Task 3), `build_plan(min_rr=...)` (Task 5).
+- Produces: nothing new — this task closes the remaining call sites.
+
+- [ ] **Step 1: Update the failing call sites**
+
+`smc_watcher.py:103`: `tp_rr=smc.tp_rr,` → `min_rr=smc.min_rr,`
+`smc_watcher.py:502`: `tp_rr=settings.smc.tp_rr,` → `min_rr=settings.smc.min_rr,`
+
+`scripts/funnel.py:81`: `tp_rr: float = 2.5,` → `min_rr: float = 1.0,`
+`scripts/funnel.py:100`: `instrument=instrument, tp_rr=tp_rr, ...` → `instrument=instrument, min_rr=min_rr, ...`
+`scripts/funnel.py` docstring of `replay_funnel`: replace the `tp_rr` mention with `min_rr`.
+
+`scripts/funnel.py` `classify_result`: replace the `no_room` branch
+
+```python
+    if "no room" in reason:
+        return "no_room"
+```
+
+with
+
+```python
+    if "no unswept liquidity" in reason:
+        return "no_liquidity"
+    if reason.startswith("rr 1:"):
+        return "rr_low"
+```
+
+and adjust the `no_zone` branch — `"no untested opposite"` no longer appears in any engine reason, so drop that clause and keep `"no valid untested"`.
+
+- [ ] **Step 2: Update the remaining test call sites**
+
+Run: `grep -rn "tp_rr" tests/ scripts/ smc_watcher.py app/`
+Every remaining hit must become `min_rr` with a sensible value (`1.0` unless the test is specifically forcing a skip). Expected files: `test_funnel.py`, `test_multipair.py`, `test_visuals.py`, `test_zone_ping.py`.
+
+Add to `tests/test_smc/test_funnel.py`:
+
+```python
+def test_classify_result_labels_low_rr():
+    result = AnalysisResult(
+        symbol="ETHUSD", verdict=Verdict.SKIP, checked_at=SESSION_BASE,
+    )
+    result.reasons.append(
+        "RR 1:0.6 < minimum 1:1 to the nearest liquidity (H1 swing high 3221.00)"
+    )
+    assert classify_result(result) == "rr_low"
+```
+
+Import `classify_result`, `AnalysisResult`, `Verdict` and `SESSION_BASE` as the file already does for its other cases.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `pytest tests/ -q && flake8 app/ tests/ smc_watcher.py`
+Expected: all green, no `tp_rr` left anywhere.
+
+- [ ] **Step 4: Update env.example**
+
+Replace line 31:
+
+```
+SMC_MIN_RR=1.0                    # minimum RR to the nearest unswept liquidity; below it the setup is skipped
+```
+
+- [ ] **Step 5: Update the docs**
+
+`CLAUDE.md`, Architecture block — add the new module under `app/services/smc/`:
+
+```
+├── liquidity.py          unswept swing highs/lows + EQH/EQL pools; Rule 7
+│                         targets and the sweep-extreme stop reference
+```
+
+and in "Conventions and gotchas" add:
+
+```
+- Liquidity (`liquidity.py`) and zones (`structure.py`) are different objects:
+  a zone is an order block price reacts from, a liquidity level is the stop
+  pool behind a swing extreme. Rule 7 aims at liquidity; Rule 2 enters at a
+  zone. Sweep detection is wick-based with a tolerance of the raw per-
+  instrument `min_fvg` — never the profile-scaled value.
+```
+
+`README.md` — replace any description of the fixed 2.5R take-profit with the liquidity rule and `SMC_MIN_RR`. Find them with `grep -n "2.5\|TP_RR" README.md`.
+
+- [ ] **Step 6: Verify nothing references the removed setting**
+
+Run: `grep -rn "TP_RR\|tp_rr" . --include="*.py" --include="*.md" --include="*.example" | grep -v docs/superpowers`
+Expected: no output.
+
+- [ ] **Step 7: Commit and open the PR**
+
+```bash
+git add -A
+git commit -m "Wire liquidity targets through watcher, funnel, env and docs"
+git push -u origin feat/liquidity-tp-sl
+gh pr create --fill
+```
+
+Follow `.github/pull_request_template.md`. In the PR body, state explicitly that `SMC_TP_RR` must be deleted from the Railway service variables after the merge — it is ignored by `extra="ignore"` but will otherwise sit there looking meaningful.
+
+---
+
+### Task 7: Replay the new rule and report the numbers
+
+**Files:**
+- No production code. Scratch scripts go in the session scratchpad, not the repo.
+
+**Interfaces:**
+- Consumes: everything above, on the merged branch.
+
+- [ ] **Step 1: Run the funnel on both profiles**
+
+```bash
+python -m scripts.funnel --pair ETHUSD --days 59
+```
+
+Record the per-stage counts, especially the new `rr_low` and `no_liquidity` stages, and `distinct_setups` per week. Compare against the pre-change baseline in the spec (~1.3 setups/wk conservative).
+
+- [ ] **Step 2: Run the outcome replay**
+
+Reuse the 2026-07-30 scratchpad replay methodology recorded in the `strategy-replay-findings` memory: point-in-time slicing, journal outcome semantics (entry fill = candle touch; TP and SL in the same candle counts as SL; pending orders expire with their session). Same ETHUSD window, 59 days.
+
+Report: alert count, win rate, total R, average R per closed trade, and the share of limit orders that expire unfilled — for `conservative` and `aggressive`.
+
+- [ ] **Step 3: Report to the owner**
+
+Present the numbers next to the 2026-07-30 baseline (conservative planned-TP 18% WR / −9.3R, fixed 2R 50% WR / +14.0R, fixed 2.5R +4.0R). State plainly whether the new rule beats or loses to them, and do not soften the result if it loses. The owner chose this rule knowing the old structural TP scored −9.3R; he is entitled to a straight answer on whether the liquidity version is different.
+
+- [ ] **Step 4: Update the memory file**
+
+Append the findings to `C:\Users\Dell\.claude\projects\C--Git-926-bot\memory\strategy-replay-findings.md` with the date, so the next session does not re-derive them.
+
+---
+
+## Notes for the implementer
+
+- **Fixture arithmetic is load-bearing.** The expected values in Tasks 2 and 3 (entry 3140.5, SL 3124.0, risk 16.5, TP 3219.0, RR 4.76) were derived by hand from `m5_long_trigger_deep_sweep`, `H1_PULLBACK_CLOSES` and `H4_UPTREND_CLOSES` with `min_fvg_size=2.0` and `sl_buffer=2.0`. If a number comes out different, recompute it from the fixture and find out why — do not adjust the assertion to match whatever the code printed. A test that agrees with a bug is worse than no test.
+- **`make_candles` wick convention:** bullish candles get `high = max(o,c) + 1.0`, `low = min(o,c) - 0.4`; bearish the mirror. Every pivot price in the H1/H4 fixtures comes from that rule, not from the close.
+- **`find_pivots` eligibility:** index range is `range(2, min(n - 2, n - 2))`, so the last two candles can never be pivots. A fixture must leave confirmation room after the extreme it wants detected.
+- **Do not touch** session windows, news blackouts, discipline rules, journal semantics, or the strategy profiles' four decision points. If a change seems to require it, stop and ask.

--- a/docs/superpowers/plans/2026-08-05-liquidity-tp-sl.md
+++ b/docs/superpowers/plans/2026-08-05-liquidity-tp-sl.md
@@ -966,3 +966,231 @@ Append the findings to `C:\Users\Dell\.claude\projects\C--Git-926-bot\memory\str
 - **`make_candles` wick convention:** bullish candles get `high = max(o,c) + 1.0`, `low = min(o,c) - 0.4`; bearish the mirror. Every pivot price in the H1/H4 fixtures comes from that rule, not from the close.
 - **`find_pivots` eligibility:** index range is `range(2, min(n - 2, n - 2))`, so the last two candles can never be pivots. A fixture must leave confirmation room after the extreme it wants detected.
 - **Do not touch** session windows, news blackouts, discipline rules, journal semantics, or the strategy profiles' four decision points. If a change seems to require it, stop and ask.
+
+---
+
+### Task 7: Rule 5.1 — the entry staleness gate
+
+Added 2026-08-05 after the Task 6 replay. See the spec's "Addendum — Rule 5.1"
+section for the reasoning and the measured numbers behind it.
+
+**Files:**
+- Modify: `app/core/config.py` (new `max_entry_gap_r` field)
+- Modify: `app/services/smc/engine.py` (constructor + a new gate between Rule 6 and Rule 7)
+- Modify: `smc_watcher.py:103` (`_build_engine` passes it)
+- Modify: `scripts/funnel.py` `classify_result` (new `entry_stale` stage)
+- Modify: `env.example`
+- Modify: `CLAUDE.md` (the strategy summary names the rules)
+- Test: `tests/test_smc/test_engine.py`, `tests/test_smc/test_funnel.py`
+
+**Interfaces:**
+- Consumes: `risk` and `entry` as computed by Rules 5 and 6; `result.price or m5[-1].close`.
+- Produces: `TripleSyncEngine(..., max_entry_gap_r: float = 0.5, ...)`; `SMCSettings.max_entry_gap_r: float = 0.5` (env `SMC_MAX_ENTRY_GAP_R`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_smc/test_engine.py`. `_engine`, `_agg_engine` and
+`_fresh_result` are the existing module-level helpers; add
+`max_entry_gap_r=99.0` to BOTH helper `defaults` dicts so every pre-existing
+test keeps its current behaviour and only the new tests exercise the gate.
+
+```python
+class TestEntryStalenessGate:
+    """Rule 5.1 (2026-08-05): a limit far below market never fills, so it is
+    not worth alerting on."""
+
+    def _long(self, price, **kwargs):
+        result = _fresh_result()
+        result.price = price
+        return _engine(**kwargs).evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger_deep_sweep(),
+            result=result,
+        )
+
+    def test_long_skipped_when_price_has_run_past_the_entry(self):
+        # entry 3140.5, risk 16.5 -> at 0.5R the limit may sit at most
+        # 8.25 above market; 3160.0 is 19.5 away (1.18R).
+        result = self._long(3160.0, max_entry_gap_r=0.5)
+        assert result.verdict == Verdict.SKIP
+        assert result.setup is None
+        assert "1.2R" in result.reasons[0]
+
+    def test_long_approved_when_price_is_still_near_the_entry(self):
+        result = self._long(3145.0, max_entry_gap_r=0.5)
+        assert result.verdict == Verdict.APPROVED_LIMIT
+        assert result.setup is not None
+
+    def test_gate_is_silent_for_a_market_entry(self):
+        # price inside the FVG (3138.0-3140.5) is at or below the entry, so
+        # the gap is never positive and the tightest gate cannot fire.
+        result = self._long(3139.0, max_entry_gap_r=0.0)
+        assert result.verdict == Verdict.APPROVED_MARKET
+
+    def test_threshold_is_configurable(self):
+        assert self._long(3160.0, max_entry_gap_r=2.0).verdict == (
+            Verdict.APPROVED_LIMIT
+        )
+
+    def test_short_gate_measures_the_other_direction(self):
+        # Mirror of the long case on the K=6270 reflected fixture: entry
+        # 3129.5, risk 16.5. Price BELOW the entry is the run-away side.
+        result = _fresh_result()
+        result.price = 3110.0
+        out = _engine(max_entry_gap_r=0.5).evaluate(
+            h4=make_candles(H4_DOWNTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_RALLY_INTO_SUPPLY_CLOSES, step_minutes=60),
+            m5=m5_short_trigger_deep_sweep(),
+            result=result,
+        )
+        assert out.verdict == Verdict.SKIP
+        assert out.setup is None
+```
+
+Import `H4_DOWNTREND_CLOSES`, `H1_RALLY_INTO_SUPPLY_CLOSES` and
+`m5_short_trigger_deep_sweep` from `tests.test_smc.helpers` — they exist
+already, added in Task 3's fix round. Use whichever engine helper
+(`_engine` or `_agg_engine`) the existing
+`test_short_tp_is_on_the_correct_side_of_entry` uses; do not assume.
+
+Add to `tests/test_smc/test_funnel.py`:
+
+```python
+def test_classify_result_labels_a_stale_entry():
+    result = AnalysisResult(
+        symbol="ETHUSD", verdict=Verdict.SKIP, checked_at=SESSION_BASE,
+    )
+    result.reasons.append(
+        "Price has run 1.2R past the entry 3140.50 (max 0.5R) — the limit "
+        "would sit too far from market"
+    )
+    assert classify_result(result) == "entry_stale"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pytest tests/test_smc/test_engine.py::TestEntryStalenessGate tests/test_smc/test_funnel.py -v`
+Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'max_entry_gap_r'`
+
+- [ ] **Step 3: Add the config field**
+
+In `app/core/config.py`, after `min_rr`:
+
+```python
+    max_entry_gap_r: float = Field(
+        default=0.5,
+        description="Skip a setup once price has run this many R past the "
+        "entry — the limit would sit too far from market to fill "
+        "(owner decision 2026-08-05). 0 = market entries only; a large "
+        "value disables the gate",
+    )
+```
+
+- [ ] **Step 4: Add the gate to the engine**
+
+Constructor: add `max_entry_gap_r: float = 0.5` beside `min_rr`, and
+`self.max_entry_gap_r = max_entry_gap_r`.
+
+Insert between the `risk <= 0` guard (currently `engine.py:246-249`) and the
+Rule 7 comment block:
+
+```python
+        # Rule 5.1 (owner decision 2026-08-05) — entry staleness. The Rule 7
+        # gate below can only pass once the near liquidity has been swept,
+        # which is to say once price has already left the entry; the entry
+        # itself stays anchored to an FVG formed hours earlier. Replaying the
+        # rule without this check, 80-90% of the limit orders never filled.
+        # A negative gap means price has not run past the entry (for a long
+        # that includes sitting inside the FVG), so market entries are never
+        # affected.
+        price = result.price or m5[-1].close
+        gap = price - entry if direction == Direction.LONG else entry - price
+        if gap > self.max_entry_gap_r * risk:
+            result.verdict = Verdict.SKIP
+            result.reasons.append(
+                f"Price has run {gap / risk:.1f}R past the entry "
+                f"{entry:.{self.instrument.price_decimals}f} "
+                f"(max {self.max_entry_gap_r:g}R) — the limit would sit too "
+                "far from market"
+            )
+            return result
+```
+
+Rule 8's market-entry test below already computes `price` the same way —
+reuse the variable you just bound rather than recomputing it, and delete the
+now-duplicate assignment there.
+
+- [ ] **Step 5: Wire the watcher**
+
+`smc_watcher.py:103` region, inside `_build_engine`'s `TripleSyncEngine(...)`
+call, beside `min_rr=smc.min_rr`:
+
+```python
+        max_entry_gap_r=smc.max_entry_gap_r,
+```
+
+- [ ] **Step 6: Add the funnel stage**
+
+In `scripts/funnel.py` `classify_result`, beside the other reason branches:
+
+```python
+    if "has run" in reason and "past the entry" in reason:
+        return "entry_stale"
+```
+
+Place it so it cannot shadow an existing branch, and confirm no existing
+branch shadows it.
+
+- [ ] **Step 7: Docs**
+
+`env.example` — beside `SMC_MIN_RR`:
+
+```
+SMC_MAX_ENTRY_GAP_R=0.5           # skip once price has run this many R past the entry (0 = market only)
+```
+
+`CLAUDE.md` — the "What this project is" paragraph lists the rule chain; add
+Rule 5.1 to it in the same terse style.
+
+- [ ] **Step 8: Verify**
+
+Run: `pytest tests/ -q && flake8 app/ tests/ smc_watcher.py scripts/`
+Expected: all green (222 existing + 6 new = 228).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "Rule 5.1: skip setups whose limit has run too far from market"
+```
+
+The default of 0.5 is provisional — Task 8 sweeps it and may change it.
+
+---
+
+### Task 8: Sweep the gate and pick the default
+
+**Files:** none in the repo. Scratch scripts go in the session scratchpad.
+
+- [ ] **Step 1: Re-run the outcome replay with the gate at several thresholds**
+
+Same methodology as Task 6 (point-in-time slicing by candle CLOSE time,
+rising-edge distinct-setup counting, production journal outcome semantics),
+same 59-day ETHUSD window, both profiles, at
+`max_entry_gap_r` in {0.25, 0.5, 0.75, 1.0, 99 (disabled)}.
+
+Report per threshold and profile: alerts, filled, unfilled share, win rate,
+total R, average R per closed trade, and median gap from market to the entry.
+
+- [ ] **Step 2: Pick the default**
+
+Choose the threshold on fill rate and alert count, not on total R — the
+sample is far too small for R to select a parameter, and picking the
+best-R threshold on the same window that produced it is overfitting. Say so
+explicitly when reporting. If the sweep does not support 0.5, change the
+default in `config.py` and `env.example` and commit that change.
+
+- [ ] **Step 3: Report to the owner**
+
+Numbers first, then the recommendation, then the caveat about sample size.

--- a/docs/superpowers/plans/2026-08-05-liquidity-tp-sl.md
+++ b/docs/superpowers/plans/2026-08-05-liquidity-tp-sl.md
@@ -446,11 +446,19 @@ git commit -m "Rule 6: anchor the stop to the sweep extreme, not the last pivot"
 
 ### Task 3: Rule 7 — take-profit at the nearest unswept liquidity
 
+This task carries the `tp_rr` → `min_rr` rename through every call site in one
+commit. Splitting it would leave the suite red between commits, which the
+Global Constraints forbid — the rename ripples through config, engine, plan,
+watcher, funnel and six test modules, and no reviewer could approve half of it.
+
 **Files:**
 - Modify: `app/core/config.py:64-68` (`tp_rr` → `min_rr`)
 - Modify: `app/services/smc/models.py` (`TradeSetup.target`)
 - Modify: `app/services/smc/engine.py` (constructor + Rule 7 block)
-- Test: `tests/test_smc/test_engine.py`, `tests/test_smc/test_improvements.py`
+- Modify: `app/services/smc/plan.py:46-133` (`_scenario`, `build_plan`)
+- Modify: `smc_watcher.py:103`, `smc_watcher.py:502`
+- Modify: `scripts/funnel.py:44-63` (`classify_result`), `:81`, `:100`
+- Test: `tests/test_smc/test_engine.py`, `test_improvements.py`, `test_plan.py`, `test_funnel.py`, `test_multipair.py`, `test_visuals.py`, `test_zone_ping.py`
 
 **Interfaces:**
 - Consumes: `liquidity.find_liquidity`, `liquidity.nearest_liquidity`, `LiquidityLevel` (Task 1).
@@ -458,8 +466,10 @@ git commit -m "Rule 6: anchor the stop to the sweep extreme, not the last pivot"
   - `TripleSyncEngine(..., min_rr: float = 1.0, ...)` — `tp_rr` is gone.
   - `TradeSetup.target: Optional[LiquidityLevel] = None` — Task 4 renders it.
   - `SMCSettings.min_rr: float = 1.0` (env `SMC_MIN_RR`).
+  - `build_plan(instrument, h4, h1, m5, min_rr: float = 1.0, profile=None, market_closed=False) -> PairPlan`
+  - `_scenario(instrument, h1, h4, direction, price, speculative, min_rr, profile) -> Tuple[Optional[PlanScenario], Optional[str]]`
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1: Write the failing engine tests**
 
 Add to `tests/test_smc/test_engine.py`:
 
@@ -517,12 +527,52 @@ def _agg_engine(**kwargs) -> TripleSyncEngine:
 
 Delete `test_tp_scales_with_configured_tp_rr` and `test_skip_when_no_zone_beyond_fixed_tp` (lines ~102-120) — they assert the removed rule. Rewrite the `tp_rr=2.5` case in `tests/test_smc/test_improvements.py:49-52` to construct the engine with no RR argument and assert `result.setup.target is not None`.
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [ ] **Step 2: Write the failing plan tests**
 
-Run: `pytest tests/test_smc/test_engine.py::TestLiquidityTarget -v`
+In `tests/test_smc/test_plan.py`, replace every `tp_rr=2.5` argument with `min_rr=1.0`, and add:
+
+```python
+    def test_scenario_targets_liquidity(self):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3150, 3152, 3151, 3153])
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
+        assert plan.scenarios
+        s = plan.scenarios[0]
+        # TP is a structural level, not a multiple of the risk
+        assert s.take_profit != round(s.entry + 2.5 * abs(s.entry - s.stop_loss), 2)
+        assert s.rr >= 1.0
+
+    def test_scenario_below_threshold_is_explained(self):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3150, 3152, 3151, 3153])
+        plan = build_plan(ETH, h4, h1, m5, min_rr=99.0)
+        assert plan.scenarios == []
+        assert "1:" in plan.note
+```
+
+Add to `tests/test_smc/test_funnel.py`:
+
+```python
+def test_classify_result_labels_low_rr():
+    result = AnalysisResult(
+        symbol="ETHUSD", verdict=Verdict.SKIP, checked_at=SESSION_BASE,
+    )
+    result.reasons.append(
+        "RR 1:0.6 < minimum 1:1 to the nearest liquidity (H1 swing high 3221.00)"
+    )
+    assert classify_result(result) == "rr_low"
+```
+
+Import `classify_result`, `AnalysisResult`, `Verdict` and `SESSION_BASE` as that file already does for its other cases.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `pytest tests/test_smc/test_engine.py::TestLiquidityTarget tests/test_smc/test_plan.py -v`
 Expected: FAIL — `TypeError: __init__() got an unexpected keyword argument 'min_rr'`
 
-- [ ] **Step 3: Add the config setting**
+- [ ] **Step 4: Add the config setting**
 
 In `app/core/config.py`, replace the `tp_rr` field (lines 64-68) with:
 
@@ -534,7 +584,7 @@ In `app/core/config.py`, replace the `tp_rr` field (lines 64-68) with:
     )
 ```
 
-- [ ] **Step 4: Add the target field to the model**
+- [ ] **Step 5: Add the target field to the model**
 
 In `app/services/smc/models.py`, add to `TradeSetup` (after `lot_hint`):
 
@@ -550,7 +600,7 @@ from app.services.smc.liquidity import LiquidityLevel
 
 If that import creates a cycle (`liquidity` imports `structure`, which imports `models`), do NOT restructure the modules — keep the annotation as the string `Optional["LiquidityLevel"]` with `if TYPE_CHECKING:` guarding the import. Verify with `python -c "import app.services.smc.engine"`.
 
-- [ ] **Step 5: Rewrite Rule 7 in the engine**
+- [ ] **Step 6: Rewrite Rule 7 in the engine**
 
 Constructor: rename the `tp_rr: float = 2.5` parameter to `min_rr: float = 1.0` and `self.tp_rr = tp_rr` to `self.min_rr = min_rr`.
 
@@ -595,148 +645,9 @@ Replace the whole Rule 7 block (`engine.py`, from the `# Rule 7` comment through
 
 Add `target=target` to the `TradeSetup(...)` construction below it.
 
-Update the engine imports: add `from app.services.smc.liquidity import find_liquidity, nearest_liquidity`, and drop `find_target_zone` from the `structure` import (it keeps its other caller in `plan.py` until Task 5).
+Update the engine imports: add `from app.services.smc.liquidity import find_liquidity, nearest_liquidity`, and drop `find_target_zone` from the `structure` import (it keeps its other caller in `plan.py` until Step 7 removes that too — check with `grep -rn find_target_zone app/` after Step 7 and drop the now-dead function from `structure.py` if nothing calls it).
 
-- [ ] **Step 6: Run the tests**
-
-Run: `pytest tests/test_smc/test_engine.py tests/test_smc/test_improvements.py -v`
-Expected: PASS.
-
-Run: `pytest tests/ -q`
-Expected: failures only in `test_plan.py`, `test_funnel.py`, `test_multipair.py`, `test_visuals.py`, `test_zone_ping.py` on the removed `tp_rr` keyword — those are Tasks 5 and 6.
-
-- [ ] **Step 7: Commit**
-
-```bash
-git add app/core/config.py app/services/smc/models.py app/services/smc/engine.py tests/test_smc/test_engine.py tests/test_smc/test_improvements.py
-git commit -m "Rule 7: take-profit at the nearest unswept liquidity, RR >= SMC_MIN_RR"
-```
-
----
-
-### Task 4: Alert names the objective
-
-**Files:**
-- Modify: `app/services/smc/notifier.py` (`format_result`, line ~99)
-- Test: `tests/test_smc/test_html_escaping.py` — the only module that exercises `format_result`
-
-**Interfaces:**
-- Consumes: `TradeSetup.target` (Task 3).
-- Produces: `notifier.format_target(level: LiquidityLevel, decimals: int) -> str`.
-
-- [ ] **Step 1: Write the failing test**
-
-Add to `tests/test_smc/test_html_escaping.py` (import `format_target` from `app.services.smc.notifier` and `LiquidityLevel` from `app.services.smc.liquidity`):
-
-```python
-class TestTargetLine:
-    def test_rr_line_names_the_liquidity(self):
-        level = LiquidityLevel(
-            price=3221.0, is_high=True, timeframe="H1",
-            equal_count=1, timestamp=None,
-        )
-        assert format_target(level, 2) == "H1 swing high 3221.00"
-
-    def test_pool_size_is_shown(self):
-        level = LiquidityLevel(
-            price=3221.0, is_high=True, timeframe="H1",
-            equal_count=3, timestamp=None,
-        )
-        assert format_target(level, 2) == "H1 swing high 3221.00 (EQH x3)"
-
-    def test_low_pool_uses_eql(self):
-        level = LiquidityLevel(
-            price=3050.0, is_high=False, timeframe="H4",
-            equal_count=2, timestamp=None,
-        )
-        assert format_target(level, 2) == "H4 swing low 3050.00 (EQL x2)"
-```
-
-- [ ] **Step 2: Run the test to verify it fails**
-
-Run: `pytest tests/test_smc/ -k TargetLine -v`
-Expected: FAIL — `ImportError: cannot import name 'format_target'`
-
-- [ ] **Step 3: Implement**
-
-In `app/services/smc/notifier.py`:
-
-```python
-def format_target(level, decimals: int) -> str:
-    """Name a liquidity objective: 'H1 swing high 3221.00 (EQH x2)'."""
-    kind = "swing high" if level.is_high else "swing low"
-    pool = ""
-    if level.equal_count > 1:
-        pool = f" (EQ{'H' if level.is_high else 'L'} x{level.equal_count})"
-    return f"{level.timeframe} {kind} {level.price:.{decimals}f}{pool}"
-```
-
-Replace the RR line in `format_result` (currently `lines.append(f"📐 RR: 1:{setup.rr:.1f}")`):
-
-```python
-        rr_line = f"📐 RR: 1:{setup.rr:.1f}"
-        if setup.target:
-            rr_line += "  →  " + escape_html(format_target(setup.target, d))
-        lines.append(rr_line)
-```
-
-Plain ASCII `x` rather than `×` in the pool suffix: the alert already carries emoji, and `x` avoids any doubt about encoding on the Railway console. `escape_html` is applied because the string is dynamic — that rule has no exceptions in this codebase.
-
-- [ ] **Step 4: Run the tests**
-
-Run: `pytest tests/test_smc/ -k TargetLine -v`
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add app/services/smc/notifier.py tests/
-git commit -m "Alert: name the liquidity objective on the RR line"
-```
-
----
-
-### Task 5: Pre-market plan uses the same targets
-
-**Files:**
-- Modify: `app/services/smc/plan.py:46-133`
-- Test: `tests/test_smc/test_plan.py`
-
-**Interfaces:**
-- Consumes: `find_liquidity`, `nearest_liquidity` (Task 1).
-- Produces: `build_plan(instrument, h4, h1, m5, min_rr: float = 1.0, profile=None, market_closed=False) -> PairPlan`; `_scenario(instrument, h1, h4, direction, price, speculative, min_rr, profile) -> Tuple[Optional[PlanScenario], Optional[str]]`.
-
-- [ ] **Step 1: Write the failing tests**
-
-In `tests/test_smc/test_plan.py`, replace every `tp_rr=2.5` argument with `min_rr=1.0`, and add:
-
-```python
-    def test_scenario_targets_liquidity(self):
-        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
-        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
-        m5 = make_candles([3150, 3152, 3151, 3153])
-        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
-        assert plan.scenarios
-        s = plan.scenarios[0]
-        # TP is a structural level, not a multiple of the risk
-        assert s.take_profit != round(s.entry + 2.5 * abs(s.entry - s.stop_loss), 2)
-        assert s.rr >= 1.0
-
-    def test_scenario_below_threshold_is_explained(self):
-        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
-        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
-        m5 = make_candles([3150, 3152, 3151, 3153])
-        plan = build_plan(ETH, h4, h1, m5, min_rr=99.0)
-        assert plan.scenarios == []
-        assert "1:" in plan.note
-```
-
-- [ ] **Step 2: Run the tests to verify they fail**
-
-Run: `pytest tests/test_smc/test_plan.py -v`
-Expected: FAIL — `TypeError: build_plan() got an unexpected keyword argument 'min_rr'`
-
-- [ ] **Step 3: Implement**
+- [ ] **Step 7: Convert the pre-market plan to the same targets**
 
 In `app/services/smc/plan.py`, replace `_scenario` (lines 46-85) with:
 
@@ -829,36 +740,9 @@ In `build_plan`: rename the `tp_rr: float = 2.5` parameter to `min_rr: float = 1
     return plan
 ```
 
-Imports: add `from app.services.smc.liquidity import find_liquidity, nearest_liquidity`, drop `find_target_zones` from the `structure` import if it is now unused, and make sure `Tuple` is imported from `typing`.
+Imports: add `from app.services.smc.liquidity import find_liquidity, nearest_liquidity`, drop `find_target_zones` from the `structure` import if now unused, and make sure `Tuple` is imported from `typing`.
 
-- [ ] **Step 4: Run the tests**
-
-Run: `pytest tests/test_smc/test_plan.py -v`
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add app/services/smc/plan.py tests/test_smc/test_plan.py
-git commit -m "Plan: project targets at the nearest unswept liquidity"
-```
-
----
-
-### Task 6: Wire the watcher, funnel, env and docs
-
-**Files:**
-- Modify: `smc_watcher.py:103`, `smc_watcher.py:502`
-- Modify: `scripts/funnel.py:44-63` (`classify_result`), `scripts/funnel.py:81`, `scripts/funnel.py:100`
-- Modify: `env.example:31`
-- Modify: `CLAUDE.md`, `README.md`
-- Test: `tests/test_smc/test_funnel.py`, `tests/test_smc/test_multipair.py`, `tests/test_smc/test_visuals.py`, `tests/test_smc/test_zone_ping.py`
-
-**Interfaces:**
-- Consumes: `SMCSettings.min_rr` (Task 3), `build_plan(min_rr=...)` (Task 5).
-- Produces: nothing new — this task closes the remaining call sites.
-
-- [ ] **Step 1: Update the failing call sites**
+- [ ] **Step 8: Close the remaining call sites**
 
 `smc_watcher.py:103`: `tp_rr=smc.tp_rr,` → `min_rr=smc.min_rr,`
 `smc_watcher.py:502`: `tp_rr=settings.smc.tp_rr,` → `min_rr=settings.smc.min_rr,`
@@ -885,32 +769,114 @@ with
 
 and adjust the `no_zone` branch — `"no untested opposite"` no longer appears in any engine reason, so drop that clause and keep `"no valid untested"`.
 
-- [ ] **Step 2: Update the remaining test call sites**
+Then run `grep -rn "tp_rr" tests/ scripts/ smc_watcher.py app/` and convert every remaining hit to `min_rr` with a sensible value (`1.0` unless the test is specifically forcing a skip). Expected remaining files: `test_multipair.py`, `test_visuals.py`, `test_zone_ping.py`.
 
-Run: `grep -rn "tp_rr" tests/ scripts/ smc_watcher.py app/`
-Every remaining hit must become `min_rr` with a sensible value (`1.0` unless the test is specifically forcing a skip). Expected files: `test_funnel.py`, `test_multipair.py`, `test_visuals.py`, `test_zone_ping.py`.
-
-Add to `tests/test_smc/test_funnel.py`:
-
-```python
-def test_classify_result_labels_low_rr():
-    result = AnalysisResult(
-        symbol="ETHUSD", verdict=Verdict.SKIP, checked_at=SESSION_BASE,
-    )
-    result.reasons.append(
-        "RR 1:0.6 < minimum 1:1 to the nearest liquidity (H1 swing high 3221.00)"
-    )
-    assert classify_result(result) == "rr_low"
-```
-
-Import `classify_result`, `AnalysisResult`, `Verdict` and `SESSION_BASE` as the file already does for its other cases.
-
-- [ ] **Step 3: Run the full suite**
+- [ ] **Step 9: Run the full suite**
 
 Run: `pytest tests/ -q && flake8 app/ tests/ smc_watcher.py`
-Expected: all green, no `tp_rr` left anywhere.
+Expected: all green, zero `tp_rr` left in `app/`, `tests/`, `scripts/`, `smc_watcher.py`.
 
-- [ ] **Step 4: Update env.example**
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "Rule 7: take-profit at the nearest unswept liquidity, RR >= SMC_MIN_RR"
+```
+
+---
+
+### Task 4: Alert names the objective
+
+**Files:**
+- Modify: `app/services/smc/notifier.py` (`format_result`, line ~99)
+- Test: `tests/test_smc/test_html_escaping.py` — the only module that exercises `format_result`
+
+**Interfaces:**
+- Consumes: `TradeSetup.target` (Task 3).
+- Produces: `notifier.format_target(level: LiquidityLevel, decimals: int) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_smc/test_html_escaping.py` (import `format_target` from `app.services.smc.notifier` and `LiquidityLevel` from `app.services.smc.liquidity`):
+
+```python
+class TestTargetLine:
+    def test_rr_line_names_the_liquidity(self):
+        level = LiquidityLevel(
+            price=3221.0, is_high=True, timeframe="H1",
+            equal_count=1, timestamp=None,
+        )
+        assert format_target(level, 2) == "H1 swing high 3221.00"
+
+    def test_pool_size_is_shown(self):
+        level = LiquidityLevel(
+            price=3221.0, is_high=True, timeframe="H1",
+            equal_count=3, timestamp=None,
+        )
+        assert format_target(level, 2) == "H1 swing high 3221.00 (EQH x3)"
+
+    def test_low_pool_uses_eql(self):
+        level = LiquidityLevel(
+            price=3050.0, is_high=False, timeframe="H4",
+            equal_count=2, timestamp=None,
+        )
+        assert format_target(level, 2) == "H4 swing low 3050.00 (EQL x2)"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_smc/ -k TargetLine -v`
+Expected: FAIL — `ImportError: cannot import name 'format_target'`
+
+- [ ] **Step 3: Implement**
+
+In `app/services/smc/notifier.py`:
+
+```python
+def format_target(level, decimals: int) -> str:
+    """Name a liquidity objective: 'H1 swing high 3221.00 (EQH x2)'."""
+    kind = "swing high" if level.is_high else "swing low"
+    pool = ""
+    if level.equal_count > 1:
+        pool = f" (EQ{'H' if level.is_high else 'L'} x{level.equal_count})"
+    return f"{level.timeframe} {kind} {level.price:.{decimals}f}{pool}"
+```
+
+Replace the RR line in `format_result` (currently `lines.append(f"📐 RR: 1:{setup.rr:.1f}")`):
+
+```python
+        rr_line = f"📐 RR: 1:{setup.rr:.1f}"
+        if setup.target:
+            rr_line += "  →  " + escape_html(format_target(setup.target, d))
+        lines.append(rr_line)
+```
+
+Plain ASCII `x` rather than `×` in the pool suffix: the alert already carries emoji, and `x` avoids any doubt about encoding on the Railway console. `escape_html` is applied because the string is dynamic — that rule has no exceptions in this codebase.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `pytest tests/test_smc/ -k TargetLine -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/services/smc/notifier.py tests/
+git commit -m "Alert: name the liquidity objective on the RR line"
+```
+
+---
+
+### Task 5: env, docs and the PR
+
+**Files:**
+- Modify: `env.example:31`
+- Modify: `CLAUDE.md`, `README.md`
+
+**Interfaces:**
+- Consumes: `SMCSettings.min_rr` (Task 3). No code changes — docs only, so the suite is unaffected.
+
+- [ ] **Step 1: Update env.example**
 
 Replace line 31:
 
@@ -918,16 +884,16 @@ Replace line 31:
 SMC_MIN_RR=1.0                    # minimum RR to the nearest unswept liquidity; below it the setup is skipped
 ```
 
-- [ ] **Step 5: Update the docs**
+- [ ] **Step 2: Update CLAUDE.md**
 
-`CLAUDE.md`, Architecture block — add the new module under `app/services/smc/`:
+In the Architecture block, add the new module under `app/services/smc/` in file order:
 
 ```
 ├── liquidity.py          unswept swing highs/lows + EQH/EQL pools; Rule 7
 │                         targets and the sweep-extreme stop reference
 ```
 
-and in "Conventions and gotchas" add:
+In "Conventions and gotchas", add:
 
 ```
 - Liquidity (`liquidity.py`) and zones (`structure.py`) are different objects:
@@ -937,18 +903,23 @@ and in "Conventions and gotchas" add:
   instrument `min_fvg` — never the profile-scaled value.
 ```
 
-`README.md` — replace any description of the fixed 2.5R take-profit with the liquidity rule and `SMC_MIN_RR`. Find them with `grep -n "2.5\|TP_RR" README.md`.
+- [ ] **Step 3: Update README.md**
 
-- [ ] **Step 6: Verify nothing references the removed setting**
+Run `grep -n "2.5\|TP_RR\|take-profit" README.md` and replace every description of the fixed 2.5R take-profit with the liquidity rule and `SMC_MIN_RR`.
+
+- [ ] **Step 4: Verify nothing references the removed setting**
 
 Run: `grep -rn "TP_RR\|tp_rr" . --include="*.py" --include="*.md" --include="*.example" | grep -v docs/superpowers`
 Expected: no output.
 
-- [ ] **Step 7: Commit and open the PR**
+Run: `pytest tests/ -q && flake8 app/ tests/ smc_watcher.py`
+Expected: all green (docs changes cannot break it, but confirm before the PR).
+
+- [ ] **Step 5: Commit and open the PR**
 
 ```bash
 git add -A
-git commit -m "Wire liquidity targets through watcher, funnel, env and docs"
+git commit -m "Document the liquidity take-profit rule and SMC_MIN_RR"
 git push -u origin feat/liquidity-tp-sl
 gh pr create --fill
 ```
@@ -957,7 +928,7 @@ Follow `.github/pull_request_template.md`. In the PR body, state explicitly that
 
 ---
 
-### Task 7: Replay the new rule and report the numbers
+### Task 6: Replay the new rule and report the numbers
 
 **Files:**
 - No production code. Scratch scripts go in the session scratchpad, not the repo.

--- a/docs/superpowers/specs/2026-08-05-liquidity-tp-sl-design.md
+++ b/docs/superpowers/specs/2026-08-05-liquidity-tp-sl-design.md
@@ -251,9 +251,11 @@ inside or below the FVG — so the gate is silent there and market entries are
 never affected.
 
 `SMCSettings.max_entry_gap_r`, env `SMC_MAX_ENTRY_GAP_R`. Every value is
-meaningful: `0` admits market entries only, a large value disables the gate.
-There is no off sentinel. The default is chosen by a replay sweep (see below),
-not by intuition.
+meaningful: `0` forbids price from having run past the entry at all (a limit
+price has not yet reached — long: not above the FVG top; short: not below
+the FVG bottom — still passes, since its gap is zero or negative), a large
+value disables the gate. There is no off sentinel. The default is chosen by
+a replay sweep (see below), not by intuition.
 
 ### What the gate does NOT apply to
 

--- a/docs/superpowers/specs/2026-08-05-liquidity-tp-sl-design.md
+++ b/docs/superpowers/specs/2026-08-05-liquidity-tp-sl-design.md
@@ -1,0 +1,220 @@
+# Liquidity-based take-profit and sweep-based stop — design
+
+Date: 2026-08-05. Approved by the owner in chat.
+
+## Why
+
+The bot currently sends a setup only when a fixed 1:2.5 take-profit fits
+(`SMC_TP_RR`, engine.py Rule 7, PR #45 of 2026-07-30). The RR in an alert is
+never computed — it is assigned. The owner wants the opposite: a structural
+take-profit at the nearest **unswept liquidity**, a stop behind the **swept**
+liquidity, and any setup whose real RR reaches at least 1:1.
+
+Owner decisions taken in chat on 2026-08-05:
+
+- TP = nearest unswept liquidity level; RR computed from it, threshold ≥ 1:1.
+- Liquidity = unswept swing high/low **and** equal highs/lows (EQH/EQL).
+- Liquidity scanned on M5, H1 and H4 — nearest level wins.
+- EQH/EQL tolerance is per-instrument, equal to `Instrument.min_fvg`.
+- SL = extreme of the sweep excursion, not the last fractal pivot.
+- Below the RR threshold the setup is skipped (no alert).
+- Limit vs market alerts stay exactly as they are.
+
+The owner was shown the 2026-07-30 replay (ETHUSD, 59 days): structural
+zone-chain TP produced −9.3R while a fixed 2R cap produced +14.0R, and the
+"untested opposite zone beyond TP" requirement was worth about +13R on its
+own. He chose the structural rule with full knowledge of those numbers. The
+strategy spec is law; this document records the decision, not a debate.
+
+## 1. New module: `app/services/smc/liquidity.py`
+
+The project has no concept of liquidity — only "untested zone" (an order
+block built from a pivot candle). This module introduces it.
+
+```python
+@dataclass(frozen=True)
+class LiquidityLevel:
+    price: float
+    is_high: bool
+    timeframe: str    # "M5" | "H1" | "H4"
+    equal_count: int  # 1 = single swing, 2+ = EQH/EQL cluster
+    timestamp: datetime
+```
+
+### Detection
+
+1. Swings come from the existing `structure.find_pivots` (fractal-5, two
+   closed confirmation candles). No new swing logic is written.
+2. **Sweep test is wick-based, not body-based.** A pivot high is swept when
+   any later candle prints `high > pivot.price`; a pivot low is swept when
+   any later candle prints `low < pivot.price`. This deliberately differs
+   from zone invalidation (which requires a body close) — liquidity is taken
+   by a wick.
+3. **EQH/EQL clustering.** Unswept pivots of the same kind whose prices sit
+   within `tolerance` of each other form one cluster. `tolerance` is the raw
+   `Instrument.min_fvg` (ETH $2, forex 5 pips) — no new per-instrument
+   constant is introduced. It is deliberately **not** the profile-scaled
+   `_effective_min_fvg`: liquidity is a property of the chart, not of how
+   aggressively the owner is trading it.
+4. **Cluster price is the near side** — the edge price will meet first. For a
+   cluster of highs that is the lowest high in the cluster; for a cluster of
+   lows, the highest low. `equal_count` records the cluster size and is shown
+   in the alert.
+
+### Public API
+
+```python
+def find_liquidity(
+    candles: List[Candle], timeframe: str, tolerance: float
+) -> List[LiquidityLevel]: ...
+
+def nearest_liquidity(
+    levels: List[LiquidityLevel], direction: Direction, entry: float
+) -> Optional[LiquidityLevel]: ...
+```
+
+`nearest_liquidity` keeps only levels strictly beyond `entry` in the trade
+direction (highs above entry for a long, lows below for a short) and returns
+the closest one. Ties between timeframes are broken by the larger
+`equal_count`, then by the higher timeframe — a cluster is the better target.
+
+## 2. Rule 6 — stop behind the sweep extreme
+
+`engine.py` currently anchors the stop to `last_protective_pivot` — the last
+confirmed M5 fractal pivot at or before the CHoCH. When another, shallower
+fractal forms after the sweep, the stop lands above the real swept low.
+
+New rule: the stop is anchored to the **extreme of the zone excursion** — for
+a long, `min(low)` over `m5[touch : choch + 1]` where `touch` is the start of
+the last contiguous excursion into the H1 zone (`zone_touch_span`) and
+`choch` is the CHoCH candle index. Then `SL = extreme − sl_buffer` (long) or
+`extreme + sl_buffer` (short).
+
+Consequences, accepted:
+
+- Stops get wider, so RR values get lower.
+- The "no confirmed M5 pivot → SKIP" branch disappears: an excursion always
+  has an extreme. `last_protective_pivot` loses its only caller and is
+  removed together with its tests.
+
+## 3. Rule 7 — take-profit at the nearest unswept liquidity
+
+```
+levels = find_liquidity(m5, "M5", tol)
+       + find_liquidity(h1, "H1", tol)
+       + find_liquidity(h4, "H4", tol)
+target = nearest_liquidity(levels, direction, entry)
+
+target is None  -> SKIP "No unswept liquidity beyond the entry"
+TP  = target.price - sl_buffer   (long)   /   + sl_buffer   (short)
+rr  = abs(TP - entry) / risk
+rr < min_rr     -> SKIP "RR 1:0.6 < minimum 1:1 to the nearest liquidity
+                         (H1 swing high 3002.00)"
+```
+
+The take-profit sits one `sl_buffer` **short of** the level so the trade is
+out before the sweep itself.
+
+`TradeSetup` gains a `target: Optional[LiquidityLevel]` field so the alert can
+name the objective.
+
+### Removed
+
+- `SMCSettings.tp_rr` and the `tp_rr` engine argument.
+- The `has_room` check (an untested opposite zone at/beyond the fixed TP). It
+  existed only to compensate for the arithmetic TP; the structural TP is its
+  own room check.
+
+### Restored
+
+- `SMCSettings.min_rr`, **default 1.0**, env `SMC_MIN_RR`. `env.example` is
+  updated. A stale `SMC_TP_RR` left in Railway is ignored (`extra="ignore"`),
+  it will not crash the watcher, but it must be deleted from the service
+  variables so nobody later believes it still does something.
+
+## 4. Alert text
+
+`format_result` shows the real RR and names the objective:
+
+```
+🛑 SL: 2951.40 | 🎯 TP: 3000.00
+📐 RR: 1:1.4  →  H1 swing high 3002.00 (EQH ×2)
+```
+
+The `EQH ×N` suffix appears only when `equal_count > 1`. The whole objective
+string is dynamic and goes through `escape_html`. Verdict selection
+(`APPROVED_MARKET` when price is inside the FVG, otherwise `APPROVED_LIMIT`)
+is untouched — the owner confirmed the current behaviour is what he wants.
+
+Skips caused by low RR stay in the logs. Quiet mode is unchanged: Telegram
+still receives found setups only.
+
+## 5. Pre-market plan
+
+`plan.py` projects targets with `find_target_zones` and its own `min_rr`
+walk. Left as-is, `/plan` and the live alerts would name different objectives
+for the same pair.
+
+`_scenario` switches to the same liquidity search: `nearest_liquidity` over
+H1+H4 (M5 is meaningless hours before the session — its swings will have been
+swept by the time the zone is reached), TP one buffer short of the level,
+scenario shown only when `rr >= min_rr`. The preliminary stop stays beyond the
+H1 zone extreme per Шаблон B — the live alert still tightens it, and the
+existing footnote in `format_plan` already says so.
+
+## 6. Charts
+
+`chart.py` keeps rendering the TP line unchanged — the price is what matters
+and the alert text names the level. No new drawing code. Chart rendering must
+stay non-blocking for alerts.
+
+## 7. Funnel
+
+`scripts/funnel.py` loses the fixed-TP stage and regains an `rr_low` stage.
+`replay_funnel` takes `min_rr` again instead of `tp_rr`.
+
+## Testing
+
+New `tests/test_smc/test_liquidity.py`:
+
+- a pivot high with a later wick above it is swept; a later *body* close
+  below an unrelated level does not sweep it
+- two highs within `min_fvg` cluster with `equal_count == 2`; two highs
+  further apart stay separate
+- a cluster's price is its near side (lowest high / highest low)
+- `nearest_liquidity` ignores levels on the wrong side of entry and returns
+  the closest of the remaining
+- tie between an M5 single swing and an H1 cluster at the same price goes to
+  the cluster
+
+Engine regressions in `tests/test_smc/test_engine.py`:
+
+- SL sits below the excursion extreme even when a shallower fractal formed
+  after the sweep (this is the bug the change fixes — the test must fail on
+  the old `last_protective_pivot` code)
+- TP equals the nearest unswept liquidity minus the buffer
+- a setup whose nearest liquidity gives RR < 1:1 is `SKIP` with the RR reason
+- `setup.rr` is computed, not assigned — two different fixtures produce two
+  different RR values
+
+Plan tests updated to `min_rr` and liquidity targets. Existing `tp_rr` tests
+across `test_engine.py`, `test_improvements.py`, `test_plan.py`,
+`test_funnel.py`, `test_multipair.py`, `test_visuals.py`, `test_zone_ping.py`
+are rewritten, not deleted — they are callers, not rules.
+
+All tests stay network-free and build candles via `tests/test_smc/helpers.py`.
+
+## Validation before the owner trusts it with money
+
+After implementation, re-run `scripts/funnel.py` and the outcome replay on the
+new rule and report the numbers to the owner. This is a separate step and does
+not block the deploy — but the owner should see how the new rule scores on the
+same ETHUSD window that produced −9.3R for the old structural TP, before
+sizing up.
+
+## Out of scope
+
+- Session windows, news blackouts, discipline rules, journal semantics.
+- Strategy profiles: `conservative` / `aggressive` keep their four decision
+  points untouched. Liquidity detection is profile-independent.
+- Partial take-profits / TP1+TP2. The owner chose the single structural TP.

--- a/docs/superpowers/specs/2026-08-05-liquidity-tp-sl-design.md
+++ b/docs/superpowers/specs/2026-08-05-liquidity-tp-sl-design.md
@@ -216,6 +216,69 @@ not block the deploy — but the owner should see how the new rule scores on the
 same ETHUSD window that produced −9.3R for the old structural TP, before
 sizing up.
 
+## Addendum, 2026-08-05 — Rule 5.1, the entry staleness gate
+
+The outcome replay of the rule above (ETHUSD, 59 days ending 2026-08-05, a
++14.1% window; the shipped fixed-2.5R rule re-run on the same candles as a
+control) found the planned-RR problem fixed — median 1:1.2 conservative /
+1:1.9 aggressive against roughly 1:6 before, and 57–67% of filled trades
+reaching their target — but **80–90% of the limit orders never filled**,
+against 21–25% under the fixed rule.
+
+The cause is structural, not a defect. The gate "is there RR ≥ 1:1 left to the
+*nearest* unswept pool?" can only pass once the near pools have been swept —
+which is to say, once price has already left the entry. The entry meanwhile
+stays anchored to an FVG formed hours earlier. Median distance from market
+price to the limit entry at alert time: **$19.60–23.40, against $1.50–5.30**
+under the fixed rule.
+
+Owner decision: keep the liquidity rule, remove the dead-limit mechanism.
+
+### The gate
+
+After Rule 6 has produced `risk`, and before Rule 7 spends anything on the
+liquidity scan:
+
+```
+gap = price - entry   (long)   /   entry - price   (short)
+gap > max_entry_gap_r * risk  ->  SKIP
+```
+
+`price` is the same close Rule 8 already uses for the market-entry test
+(`result.price or m5[-1].close`). A negative or zero gap means price has not
+run past the entry — for a long that includes every case where price is still
+inside or below the FVG — so the gate is silent there and market entries are
+never affected.
+
+`SMCSettings.max_entry_gap_r`, env `SMC_MAX_ENTRY_GAP_R`. Every value is
+meaningful: `0` admits market entries only, a large value disables the gate.
+There is no off sentinel. The default is chosen by a replay sweep (see below),
+not by intuition.
+
+### What the gate does NOT apply to
+
+`plan.py` keeps no such gate, and this asymmetry is deliberate — do not
+"fix" it later. The pre-market plan projects a pullback that has not happened
+yet: `_scenario` returns `None` unless the zone sits below current price for a
+long, so its entry is *always* far below market by construction. That is a
+plan, not a stale limit. The gate exists only for a live setup whose FVG has
+already formed and which price has since abandoned.
+
+### Choosing the default
+
+Implement the gate with the threshold configurable, then sweep it over the
+same 59-day ETHUSD window at 0.25 / 0.5 / 0.75 / 1.0 / disabled, for both
+profiles, reporting alert count, fill rate, win rate and total R at each. The
+default ships as whatever that sweep supports. Prior expectation from the
+replay: the fixed rule's median gap was 0.13–0.47R with a 75–79% fill rate,
+so something near 0.5R is the plausible region — but the sweep decides.
+
+A tighter gate trades alert count for fill rate and cannot create edge on its
+own. The honest framing is that it stops the bot from posting orders it has
+no reason to believe will fill; whether the surviving trades are profitable is
+a separate question this window is far too small to answer — every per-trade
+mean measured, under either rule, sits within ~1.5 standard errors of zero.
+
 ## Out of scope
 
 - Session windows, news blackouts, discipline rules, journal semantics.

--- a/docs/superpowers/specs/2026-08-05-liquidity-tp-sl-design.md
+++ b/docs/superpowers/specs/2026-08-05-liquidity-tp-sl-design.md
@@ -45,11 +45,15 @@ class LiquidityLevel:
 
 1. Swings come from the existing `structure.find_pivots` (fractal-5, two
    closed confirmation candles). No new swing logic is written.
-2. **Sweep test is wick-based, not body-based.** A pivot high is swept when
-   any later candle prints `high > pivot.price`; a pivot low is swept when
-   any later candle prints `low < pivot.price`. This deliberately differs
-   from zone invalidation (which requires a body close) — liquidity is taken
-   by a wick.
+2. **Sweep test is wick-based, not body-based, and carries the same
+   tolerance as clustering.** A pivot high is swept when any later candle
+   prints `high > pivot.price + tolerance`; a pivot low is swept when any
+   later candle prints `low < pivot.price - tolerance`. Two reasons:
+   liquidity is taken by a wick, not a body close (so this deliberately
+   differs from zone invalidation); and a bare `>` would make EQH/EQL
+   impossible to detect — a second high 20 cents above the first would
+   "sweep" it and leave a lone level instead of a pool. A poke smaller than
+   the instrument's minimum FVG has not taken the pool.
 3. **EQH/EQL clustering.** Unswept pivots of the same kind whose prices sit
    within `tolerance` of each other form one cluster. `tolerance` is the raw
    `Instrument.min_fvg` (ETH $2, forex 5 pips) — no new per-instrument

--- a/env.example
+++ b/env.example
@@ -29,7 +29,7 @@ SMC_PAIRS=ETHUSD,USDJPY           # default pairs; change at runtime via /pairs
 SMC_SESSION_INTERVAL_MINUTES=5    # check cadence inside session windows
 SMC_INTERVAL_MINUTES=15           # check cadence outside sessions
 SMC_MIN_RR=1.0                    # minimum RR to the nearest unswept liquidity; skip below it
-SMC_MAX_ENTRY_GAP_R=0.5           # skip once price has run this many R past the entry (0 = market only)
+SMC_MAX_ENTRY_GAP_R=0.5           # skip once price has run this many R past the entry (0 = no run past the entry at all)
 SMC_RISK_PCT=2.0
 # SMC_DEPOSIT=1000                # deposit in USD for automatic lot hints
 SMC_ENFORCE_SESSIONS=true

--- a/env.example
+++ b/env.example
@@ -28,7 +28,7 @@ SMC_FOREX_SOURCE=auto             # auto | twelvedata | oanda | yahoo
 SMC_PAIRS=ETHUSD,USDJPY           # default pairs; change at runtime via /pairs
 SMC_SESSION_INTERVAL_MINUTES=5    # check cadence inside session windows
 SMC_INTERVAL_MINUTES=15           # check cadence outside sessions
-SMC_TP_RR=2.5                     # fixed take-profit distance in R (TP = entry ± 2.5×risk)
+SMC_MIN_RR=1.0                    # minimum RR to the nearest unswept liquidity; skip below it
 SMC_RISK_PCT=2.0
 # SMC_DEPOSIT=1000                # deposit in USD for automatic lot hints
 SMC_ENFORCE_SESSIONS=true

--- a/env.example
+++ b/env.example
@@ -29,7 +29,7 @@ SMC_PAIRS=ETHUSD,USDJPY           # default pairs; change at runtime via /pairs
 SMC_SESSION_INTERVAL_MINUTES=5    # check cadence inside session windows
 SMC_INTERVAL_MINUTES=15           # check cadence outside sessions
 SMC_MIN_RR=1.0                    # minimum RR to the nearest unswept liquidity; skip below it
-SMC_MAX_ENTRY_GAP_R=0.5           # skip once price has run this many R past the entry (0 = no run past the entry at all)
+SMC_MAX_ENTRY_GAP_R=0.75          # skip once price has run this many R past the entry (0 = no run past the entry at all)
 SMC_RISK_PCT=2.0
 # SMC_DEPOSIT=1000                # deposit in USD for automatic lot hints
 SMC_ENFORCE_SESSIONS=true

--- a/env.example
+++ b/env.example
@@ -29,6 +29,7 @@ SMC_PAIRS=ETHUSD,USDJPY           # default pairs; change at runtime via /pairs
 SMC_SESSION_INTERVAL_MINUTES=5    # check cadence inside session windows
 SMC_INTERVAL_MINUTES=15           # check cadence outside sessions
 SMC_MIN_RR=1.0                    # minimum RR to the nearest unswept liquidity; skip below it
+SMC_MAX_ENTRY_GAP_R=0.5           # skip once price has run this many R past the entry (0 = market only)
 SMC_RISK_PCT=2.0
 # SMC_DEPOSIT=1000                # deposit in USD for automatic lot hints
 SMC_ENFORCE_SESSIONS=true

--- a/scripts/funnel.py
+++ b/scripts/funnel.py
@@ -59,6 +59,8 @@ def classify_result(result: AnalysisResult) -> str:
         return "fvg_small"
     if "no unswept liquidity" in reason:
         return "no_liquidity"
+    if "inside the sl buffer" in reason:
+        return "no_liquidity"
     if reason.startswith("rr 1:"):
         return "rr_low"
     return "other"

--- a/scripts/funnel.py
+++ b/scripts/funnel.py
@@ -61,6 +61,8 @@ def classify_result(result: AnalysisResult) -> str:
         return "no_liquidity"
     if "inside the sl buffer" in reason:
         return "no_liquidity"
+    if "has run" in reason and "past the entry" in reason:
+        return "entry_stale"
     if reason.startswith("rr 1:"):
         return "rr_low"
     return "other"
@@ -83,6 +85,7 @@ def replay_funnel(
     m5: List[Candle],
     profile: StrategyProfile,
     min_rr: float = 1.0,
+    max_entry_gap_r: float = 99.0,
     warmup: int = 60,
 ) -> Dict[str, int]:
     """Replay evaluate() at each M5 close (after `warmup` candles).
@@ -99,9 +102,14 @@ def replay_funnel(
     persisting setup was re-counted on) and "session_days" (the number of
     distinct Prague trading days spanned by the replayed M5 candles, for
     turning distinct_setups into a setups-per-week rate).
+
+    `max_entry_gap_r` defaults to 99.0 (Rule 5.1 effectively disabled) so
+    existing callers replay unaffected; pass the real threshold to measure
+    its effect on fill rate (see the spec's addendum sweep).
     """
     engine = TripleSyncEngine(
-        instrument=instrument, min_rr=min_rr, enforce_sessions=True,
+        instrument=instrument, min_rr=min_rr,
+        max_entry_gap_r=max_entry_gap_r, enforce_sessions=True,
         profile=profile, fetcher=None,
     )
     counts: Counter = Counter()

--- a/scripts/funnel.py
+++ b/scripts/funnel.py
@@ -85,7 +85,7 @@ def replay_funnel(
     m5: List[Candle],
     profile: StrategyProfile,
     min_rr: float = 1.0,
-    max_entry_gap_r: float = 99.0,
+    max_entry_gap_r: float = 0.5,
     warmup: int = 60,
 ) -> Dict[str, int]:
     """Replay evaluate() at each M5 close (after `warmup` candles).
@@ -103,9 +103,10 @@ def replay_funnel(
     distinct Prague trading days spanned by the replayed M5 candles, for
     turning distinct_setups into a setups-per-week rate).
 
-    `max_entry_gap_r` defaults to 99.0 (Rule 5.1 effectively disabled) so
-    existing callers replay unaffected; pass the real threshold to measure
-    its effect on fill rate (see the spec's addendum sweep).
+    `max_entry_gap_r` defaults to 0.5, matching `SMCSettings.max_entry_gap_r`
+    — this tool measures what the bot would actually alert on, so its
+    default must track production, not disable the gate. Pass a different
+    value (e.g. a large one) to measure a threshold the bot isn't shipping.
     """
     engine = TripleSyncEngine(
         instrument=instrument, min_rr=min_rr,

--- a/scripts/funnel.py
+++ b/scripts/funnel.py
@@ -49,7 +49,7 @@ def classify_result(result: AnalysisResult) -> str:
     reason = (result.reasons[0] if result.reasons else "").lower()
     if result.h4_trend == Trend.FLAT and "no direction" in reason:
         return "h4_flat"
-    if "no valid untested" in reason or "no untested opposite" in reason:
+    if "no valid untested" in reason:
         return "no_zone"
     if "has not reached" in reason or "pullback phase" in reason:
         return "no_touch"
@@ -57,8 +57,10 @@ def classify_result(result: AnalysisResult) -> str:
         return "no_choch"
     if "no valid fvg" in reason:
         return "fvg_small"
-    if "no room" in reason:
-        return "no_room"
+    if "no unswept liquidity" in reason:
+        return "no_liquidity"
+    if reason.startswith("rr 1:"):
+        return "rr_low"
     return "other"
 
 
@@ -78,7 +80,7 @@ def replay_funnel(
     h1: List[Candle],
     m5: List[Candle],
     profile: StrategyProfile,
-    tp_rr: float = 2.5,
+    min_rr: float = 1.0,
     warmup: int = 60,
 ) -> Dict[str, int]:
     """Replay evaluate() at each M5 close (after `warmup` candles).
@@ -97,7 +99,7 @@ def replay_funnel(
     turning distinct_setups into a setups-per-week rate).
     """
     engine = TripleSyncEngine(
-        instrument=instrument, tp_rr=tp_rr, enforce_sessions=True,
+        instrument=instrument, min_rr=min_rr, enforce_sessions=True,
         profile=profile, fetcher=None,
     )
     counts: Counter = Counter()

--- a/scripts/funnel.py
+++ b/scripts/funnel.py
@@ -85,7 +85,7 @@ def replay_funnel(
     m5: List[Candle],
     profile: StrategyProfile,
     min_rr: float = 1.0,
-    max_entry_gap_r: float = 0.5,
+    max_entry_gap_r: float = 0.75,
     warmup: int = 60,
 ) -> Dict[str, int]:
     """Replay evaluate() at each M5 close (after `warmup` candles).
@@ -103,7 +103,7 @@ def replay_funnel(
     distinct Prague trading days spanned by the replayed M5 candles, for
     turning distinct_setups into a setups-per-week rate).
 
-    `max_entry_gap_r` defaults to 0.5, matching `SMCSettings.max_entry_gap_r`
+    `max_entry_gap_r` defaults to 0.75, matching `SMCSettings.max_entry_gap_r`
     — this tool measures what the bot would actually alert on, so its
     default must track production, not disable the gate. Pass a different
     value (e.g. a large one) to measure a threshold the bot isn't shipping.

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -101,6 +101,7 @@ def _build_engine(instrument: Instrument, profile=None) -> TripleSyncEngine:
     return TripleSyncEngine(
         instrument=instrument,
         min_rr=smc.min_rr,
+        max_entry_gap_r=smc.max_entry_gap_r,
         risk_pct=smc.risk_pct,
         deposit=smc.deposit,
         enforce_sessions=smc.enforce_sessions,

--- a/smc_watcher.py
+++ b/smc_watcher.py
@@ -100,7 +100,7 @@ def _build_engine(instrument: Instrument, profile=None) -> TripleSyncEngine:
     smc = settings.smc
     return TripleSyncEngine(
         instrument=instrument,
-        tp_rr=smc.tp_rr,
+        min_rr=smc.min_rr,
         risk_pct=smc.risk_pct,
         deposit=smc.deposit,
         enforce_sessions=smc.enforce_sessions,
@@ -499,7 +499,7 @@ class Watcher:
         )
         plan = build_plan(
             instrument, data["h4"], data["h1"], data["m5"],
-            tp_rr=settings.smc.tp_rr, profile=profile, market_closed=stale,
+            min_rr=settings.smc.min_rr, profile=profile, market_closed=stale,
         )
         live_line = None if stale else self._live_status(instrument, data, now)
         as_of = to_prague(data["m5"][-1].timestamp).strftime("%H:%M")

--- a/tests/test_smc/helpers.py
+++ b/tests/test_smc/helpers.py
@@ -110,6 +110,45 @@ def m5_long_trigger() -> List[Candle]:
     return [candle(*row, index=i) for i, row in enumerate(spec)]
 
 
+def m5_long_trigger_deep_sweep() -> List[Candle]:
+    """M5 where the sweep low and the last fractal pivot DISAGREE.
+
+    Against the H1 demand zone 3131.0-3138.0 (built from H1_PULLBACK_CLOSES):
+    - lower-high pivot at index 6 (3148) is the CHoCH reference
+    - the excursion into the zone starts at index 8 and runs to index 14
+    - index 9 spikes down to 3126 — the real swept low
+    - a shallower fractal low forms later at index 12 (3132.5)
+    - bullish FVG between high[13]=3138.0 and low[15]=3140.5 (size 2.5)
+    - CHoCH at index 16 (close 3149 > 3148)
+
+    `last_protective_pivot` returned the LAST pivot at/before the CHoCH —
+    3132.5, above the sweep. `sweep_extreme` returns 3126.0.
+    """
+    spec = [
+        (3160.0, 3161.0, 3155.0, 3156.0),
+        (3156.0, 3157.0, 3151.0, 3152.0),
+        (3152.0, 3153.0, 3147.0, 3148.0),
+        (3148.0, 3149.0, 3143.0, 3144.0),
+        (3144.0, 3145.0, 3140.0, 3142.0),
+        (3142.0, 3146.0, 3141.0, 3145.0),
+        (3145.0, 3148.0, 3144.0, 3147.0),
+        (3147.0, 3147.5, 3141.0, 3142.0),
+        (3142.0, 3143.0, 3134.0, 3136.0),
+        (3136.0, 3137.0, 3126.0, 3135.0),
+        (3135.0, 3136.0, 3133.5, 3134.5),
+        (3134.5, 3135.5, 3133.0, 3135.0),
+        (3135.0, 3136.0, 3132.5, 3135.5),
+        (3135.5, 3138.0, 3135.0, 3137.5),
+        (3137.5, 3141.0, 3137.0, 3140.8),
+        (3140.8, 3144.0, 3140.5, 3143.5),
+        (3143.5, 3149.5, 3143.0, 3149.0),
+        (3149.0, 3151.0, 3147.0, 3150.0),
+        (3150.0, 3152.0, 3148.0, 3151.0),
+        (3151.0, 3152.0, 3149.0, 3150.0),
+    ]
+    return [candle(*row, index=i) for i, row in enumerate(spec)]
+
+
 def m5_choch_still_in_zone() -> List[Candle]:
     """M5 where the bullish CHoCH forms and price STAYS inside the demand zone
     to the end of the series — the exact case the touch-span fix targets.

--- a/tests/test_smc/helpers.py
+++ b/tests/test_smc/helpers.py
@@ -76,6 +76,35 @@ H1_PULLBACK_CLOSES = [
     3210, 3195, 3180, 3165,
 ]
 
+# SHORT-side mirrors of H4_UPTREND_CLOSES / H1_PULLBACK_CLOSES, built by
+# reflecting every close around K=6270 (close' = K - close). find_pivots,
+# detect_trend, build_zone etc. are pure relational comparisons on price
+# differences, so this reflection is an exact structural mirror: every
+# bullish candle becomes bearish (and vice versa) at the same indices, every
+# HH+HL uptrend becomes a LL+LH downtrend, every high pivot becomes a low
+# pivot at the mirrored price. Verified by running TripleSyncEngine against
+# both the reflected-closes version and this hand-transcribed literal list
+# and confirming identical output (see task-3-report.md finding 1).
+#
+# H4 downtrend: LL (3170 -> 3070 -> 2970) + LH (3220 -> 3150)
+H4_DOWNTREND_CLOSES = [
+    3270, 3250, 3230, 3210, 3190, 3170,  # down leg
+    3180, 3195, 3210, 3220,              # pullback (LH at 3220)
+    3200, 3170, 3130, 3100, 3070,        # down leg (LL)
+    3085, 3110, 3130, 3150,              # pullback (LH)
+    3120, 3070, 3020, 2970,              # down leg (LL)
+    2980, 2990,                          # confirmation candles
+]
+
+# H1: decline, pullback forming a supply pivot at 3138 (zone ~3132-3139),
+# decline to 3050 (untested demand ~3049-3070), drift up.
+H1_RALLY_INTO_SUPPLY_CLOSES = [
+    3170, 3160, 3150, 3135, 3120,
+    3125, 3132, 3138,
+    3125, 3110, 3090, 3070, 3050,
+    3060, 3075, 3090, 3105,
+]
+
 
 def m5_long_trigger() -> List[Candle]:
     """M5: decline into the H1 demand zone, bullish CHoCH + FVG.
@@ -145,6 +174,51 @@ def m5_long_trigger_deep_sweep() -> List[Candle]:
         (3149.0, 3151.0, 3147.0, 3150.0),
         (3150.0, 3152.0, 3148.0, 3151.0),
         (3151.0, 3152.0, 3149.0, 3150.0),
+    ]
+    return [candle(*row, index=i) for i, row in enumerate(spec)]
+
+
+def m5_short_trigger_deep_sweep() -> List[Candle]:
+    """SHORT mirror of m5_long_trigger_deep_sweep (each OHLC reflected
+    around K=6270: open'=K-open, high'=K-low, low'=K-high, close'=K-close —
+    see the comment above H4_DOWNTREND_CLOSES).
+
+    Against the H1 supply zone 3132.0-3139.0 (built from
+    H1_RALLY_INTO_SUPPLY_CLOSES):
+    - higher-low pivot at index 6 (3122) is the CHoCH reference
+    - the excursion into the zone starts at index 8 and runs to index 14
+    - index 9 spikes up to 3144 — the real swept high
+    - a shallower fractal high forms later at index 12 (3137.5)
+    - bearish FVG between low[13]=3132.0 and high[15]=3129.5 (size 2.5)
+    - CHoCH at index 16 (close below the 3122 higher-low)
+
+    `sweep_extreme` returns 3144.0, above the shallower pivot at 3137.5 —
+    the SHORT-side analogue of the LONG fixture's sweep/pivot disagreement.
+    Independently confirmed by running the engine against this fixture:
+    entry 3129.5, stop_loss 3146.0, target H1 swing low 3049.0,
+    take_profit 3051.0, rr 4.76 (see task-3-report.md finding 1).
+    """
+    spec = [
+        (3110.0, 3115.0, 3109.0, 3114.0),
+        (3114.0, 3119.0, 3113.0, 3118.0),
+        (3118.0, 3123.0, 3117.0, 3122.0),
+        (3122.0, 3127.0, 3121.0, 3126.0),
+        (3126.0, 3130.0, 3125.0, 3128.0),
+        (3128.0, 3129.0, 3124.0, 3125.0),
+        (3125.0, 3126.0, 3122.0, 3123.0),
+        (3123.0, 3129.0, 3122.5, 3128.0),
+        (3128.0, 3136.0, 3127.0, 3134.0),
+        (3134.0, 3144.0, 3133.0, 3135.0),
+        (3135.0, 3136.5, 3134.0, 3135.5),
+        (3135.5, 3137.0, 3134.5, 3135.0),
+        (3135.0, 3137.5, 3134.0, 3134.5),
+        (3134.5, 3135.0, 3132.0, 3132.5),
+        (3132.5, 3133.0, 3129.0, 3129.2),
+        (3129.2, 3129.5, 3126.0, 3126.5),
+        (3126.5, 3127.0, 3120.5, 3121.0),
+        (3121.0, 3123.0, 3119.0, 3120.0),
+        (3120.0, 3122.0, 3118.0, 3119.0),
+        (3119.0, 3121.0, 3118.0, 3120.0),
     ]
     return [candle(*row, index=i) for i, row in enumerate(spec)]
 

--- a/tests/test_smc/test_engine.py
+++ b/tests/test_smc/test_engine.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timezone
 
+from app.core.config import SMCSettings
 from app.services.smc.engine import TripleSyncEngine
 from app.services.smc.instruments import get_instrument
 from app.services.smc.models import AnalysisResult, Direction, Trend, Verdict
@@ -341,6 +342,8 @@ class TestEntryStalenessGate:
     def test_short_gate_measures_the_other_direction(self):
         # Mirror of the long case on the K=6270 reflected fixture: entry
         # 3129.5, risk 16.5. Price BELOW the entry is the run-away side.
+        # gap = 3129.5 - 3110.0 = 19.5 -> 19.5 / 16.5 = 1.18 -> "1.2R",
+        # same arithmetic as the long case above.
         result = _fresh_result()
         result.price = 3110.0
         out = _engine(max_entry_gap_r=0.5).evaluate(
@@ -351,3 +354,12 @@ class TestEntryStalenessGate:
         )
         assert out.verdict == Verdict.SKIP
         assert out.setup is None
+        assert "1.2R" in out.reasons[0]
+
+    def test_shipped_default_is_0_5r(self):
+        # Pins the production default (config.py's SMCSettings and the
+        # engine constructor both ship 0.5) against a future edit silently
+        # moving it — every other test in this class passes an explicit
+        # value, so nothing else would catch that.
+        assert TripleSyncEngine().max_entry_gap_r == 0.5
+        assert SMCSettings().max_entry_gap_r == 0.5

--- a/tests/test_smc/test_engine.py
+++ b/tests/test_smc/test_engine.py
@@ -25,13 +25,13 @@ def _fresh_result() -> AnalysisResult:
 
 
 def _engine(**kwargs) -> TripleSyncEngine:
-    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, tp_rr=2.5)
+    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, min_rr=1.0)
     defaults.update(kwargs)
     return TripleSyncEngine(**defaults)
 
 
 def _agg_engine(**kwargs) -> TripleSyncEngine:
-    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, tp_rr=2.5, profile=AGGRESSIVE)
+    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, min_rr=1.0, profile=AGGRESSIVE)
     defaults.update(kwargs)
     return TripleSyncEngine(**defaults)
 
@@ -50,9 +50,11 @@ class TestApprovedSetup:
         assert setup.direction == Direction.LONG
         assert setup.entry == 3139.5  # top of the bullish FVG
         assert setup.stop_loss == 3128.0  # pivot low 3130 - $2 buffer
-        # fixed TP: entry + 2.5 × risk (risk = 3139.5 - 3128.0 = 11.5)
-        assert setup.take_profit == 3168.25
-        assert setup.rr == 2.5
+        # TP one buffer short of the H1 swing high liquidity at 3221.0
+        # (risk = 3139.5 - 3128.0 = 11.5; rr = (3219.0-3139.5)/11.5 = 6.91)
+        assert setup.take_profit == 3219.0
+        assert setup.target.price == 3221.0
+        assert setup.rr == 6.91
         assert not setup.entry_is_market  # last close 3150 is above the FVG
 
     def test_lot_hint_computed_from_deposit(self):
@@ -99,31 +101,6 @@ class TestSkipsAndWatch:
             result=_fresh_result(),
         )
         assert result.verdict == Verdict.WATCH
-
-    def test_tp_scales_with_configured_tp_rr(self):
-        # tp_rr=4: TP 3139.5 + 4 × 11.5 = 3185.5, still inside the H1 supply
-        # at 3200 -> the room check passes and the TP scales.
-        result = _engine(tp_rr=4.0).evaluate(
-            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
-            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
-            m5=m5_long_trigger(),
-            result=_fresh_result(),
-        )
-        setup = result.setup
-        assert setup.rr == 4.0
-        assert setup.take_profit == 3185.5
-
-    def test_skip_when_no_room_to_the_opposite_zone(self):
-        # tp_rr=10: TP 3254.5 lies beyond both the H1 supply (3200) and the
-        # H4 supply (3250) -> no untested zone at/beyond the TP, SKIP.
-        result = _engine(tp_rr=10.0).evaluate(
-            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
-            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
-            m5=m5_long_trigger(),
-            result=_fresh_result(),
-        )
-        assert result.verdict == Verdict.SKIP
-        assert any("no room" in r for r in result.reasons)
 
 
 class TestProfiles:
@@ -240,3 +217,39 @@ class TestSweepStop:
         assert result.setup is not None, result.reasons
         # sweep low 3126.0 minus the $2 buffer, NOT 3132.5 - 2 = 3130.5
         assert result.setup.stop_loss == 3124.0
+
+
+class TestLiquidityTarget:
+    """Rule 7 (2026-08-05): TP is the nearest unswept liquidity, one buffer
+    short of the level; RR is computed, not assigned."""
+
+    def _run(self, **kwargs):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        return _engine(**kwargs).evaluate(
+            h4=h4, h1=h1, m5=m5_long_trigger_deep_sweep(), result=_fresh_result()
+        )
+
+    def test_tp_is_the_nearest_unswept_liquidity_minus_buffer(self):
+        result = self._run()
+        assert result.setup is not None, result.reasons
+        # H1 swing high 3221.0 is the nearest unswept pool above entry 3140.5
+        assert result.setup.take_profit == 3219.0
+        assert result.setup.target.price == 3221.0
+        assert result.setup.target.timeframe == "H1"
+
+    def test_rr_is_computed_from_the_target(self):
+        result = self._run()
+        # entry 3140.5, SL 3124.0 -> risk 16.5; TP 3219.0 -> 78.5 / 16.5
+        assert result.setup.rr == 4.76
+
+    def test_rr_does_not_track_the_threshold(self):
+        # The old rule assigned rr = tp_rr, so the RR moved with the setting.
+        assert self._run(min_rr=1.0).setup.rr == self._run(min_rr=2.0).setup.rr
+
+    def test_setup_below_the_threshold_is_skipped(self):
+        result = self._run(min_rr=8.0)
+        assert result.verdict == Verdict.SKIP
+        assert result.setup is None
+        assert "1:4.8" in result.reasons[0]
+        assert "1:8" in result.reasons[0]

--- a/tests/test_smc/test_engine.py
+++ b/tests/test_smc/test_engine.py
@@ -11,6 +11,7 @@ from tests.test_smc.helpers import (
     H4_UPTREND_CLOSES,
     candle,
     m5_long_trigger,
+    m5_long_trigger_deep_sweep,
     make_candles,
 )
 
@@ -224,3 +225,18 @@ class TestCryptoSameDayFallbackSurvivesProfileWiring:
         assert result.verdict == Verdict.APPROVED_LIMIT
         assert result.setup.entry == 3139.5  # earliest FVG (index 15), only
         # reachable via same_trading_day scope, not same_session
+
+
+class TestSweepStop:
+    """Rule 6 (2026-08-05): SL sits behind the swept extreme, not behind the
+    last fractal pivot."""
+
+    def test_stop_is_below_the_sweep_not_the_later_pivot(self):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        result = _engine().evaluate(
+            h4=h4, h1=h1, m5=m5_long_trigger_deep_sweep(), result=_fresh_result()
+        )
+        assert result.setup is not None, result.reasons
+        # sweep low 3126.0 minus the $2 buffer, NOT 3132.5 - 2 = 3130.5
+        assert result.setup.stop_loss == 3124.0

--- a/tests/test_smc/test_engine.py
+++ b/tests/test_smc/test_engine.py
@@ -8,10 +8,13 @@ from app.services.smc.models import AnalysisResult, Direction, Trend, Verdict
 from app.services.smc.profiles import AGGRESSIVE, CONSERVATIVE
 from tests.test_smc.helpers import (
     H1_PULLBACK_CLOSES,
+    H1_RALLY_INTO_SUPPLY_CLOSES,
+    H4_DOWNTREND_CLOSES,
     H4_UPTREND_CLOSES,
     candle,
     m5_long_trigger,
     m5_long_trigger_deep_sweep,
+    m5_short_trigger_deep_sweep,
     make_candles,
 )
 
@@ -244,7 +247,8 @@ class TestLiquidityTarget:
         assert result.setup.rr == 4.76
 
     def test_rr_does_not_track_the_threshold(self):
-        # The old rule assigned rr = tp_rr, so the RR moved with the setting.
+        # The old rule assigned rr = the configured multiple, so the RR
+        # moved with the setting.
         assert self._run(min_rr=1.0).setup.rr == self._run(min_rr=2.0).setup.rr
 
     def test_setup_below_the_threshold_is_skipped(self):
@@ -253,3 +257,39 @@ class TestLiquidityTarget:
         assert result.setup is None
         assert "1:4.8" in result.reasons[0]
         assert "1:8" in result.reasons[0]
+
+    def test_short_tp_is_on_the_correct_side_of_entry(self):
+        # SHORT mirror of m5_long_trigger_deep_sweep (see helpers.py and
+        # task-3-report.md finding 1 for the K=6270 reflection and the
+        # independent re-derivation): entry 3129.5, SL 3146.0, target the H1
+        # swing low at 3049.0, TP = 3049.0 + $2 buffer = 3051.0,
+        # rr = (3129.5 - 3051.0) / (3146.0 - 3129.5) = 78.5 / 16.5 = 4.76.
+        h4 = make_candles(H4_DOWNTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_RALLY_INTO_SUPPLY_CLOSES, step_minutes=60)
+        result = _engine().evaluate(
+            h4=h4, h1=h1, m5=m5_short_trigger_deep_sweep(), result=_fresh_result()
+        )
+        assert result.setup is not None, result.reasons
+        setup = result.setup
+        assert setup.direction == Direction.SHORT
+        assert setup.take_profit < setup.entry < setup.stop_loss
+        assert setup.take_profit == 3051.0
+        assert setup.entry == 3129.5
+        assert setup.stop_loss == 3146.0
+        assert setup.target.price == 3049.0
+        assert setup.target.is_high is False
+        assert setup.rr == 4.76
+
+    def test_skip_when_target_is_inside_the_sl_buffer(self):
+        # An inflated sl_buffer pulls the target within one buffer of entry:
+        # TP = 3221.0 - 100 = 3121.0, BELOW entry 3140.5 for a LONG — a
+        # negative reward that abs() alone would report as a positive RR.
+        # min_rr=0.1 proves the skip does not depend on the threshold.
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        result = _engine(sl_buffer=100.0, min_rr=0.1).evaluate(
+            h4=h4, h1=h1, m5=m5_long_trigger_deep_sweep(), result=_fresh_result()
+        )
+        assert result.verdict == Verdict.SKIP
+        assert result.setup is None
+        assert "no positive reward" in result.reasons[0]

--- a/tests/test_smc/test_engine.py
+++ b/tests/test_smc/test_engine.py
@@ -356,10 +356,14 @@ class TestEntryStalenessGate:
         assert out.setup is None
         assert "1.2R" in out.reasons[0]
 
-    def test_shipped_default_is_0_5r(self):
+    def test_shipped_default_is_0_75r(self):
         # Pins the production default (config.py's SMCSettings and the
-        # engine constructor both ship 0.5) against a future edit silently
+        # engine constructor both ship 0.75) against a future edit silently
         # moving it — every other test in this class passes an explicit
         # value, so nothing else would catch that.
-        assert TripleSyncEngine().max_entry_gap_r == 0.5
-        assert SMCSettings().max_entry_gap_r == 0.5
+        # 0.75 was picked by the 59-day ETHUSD threshold sweep
+        # (.superpowers/sdd/2026-08-05-liquidity-tp-sl/gate-sweep-report.md):
+        # it is the knee of the fill-rate/alert-count curve, and the
+        # provisional 0.5 produced zero conservative alerts in 59 days.
+        assert TripleSyncEngine().max_entry_gap_r == 0.75
+        assert SMCSettings().max_entry_gap_r == 0.75

--- a/tests/test_smc/test_engine.py
+++ b/tests/test_smc/test_engine.py
@@ -28,13 +28,18 @@ def _fresh_result() -> AnalysisResult:
 
 
 def _engine(**kwargs) -> TripleSyncEngine:
-    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, min_rr=1.0)
+    defaults = dict(
+        min_fvg_size=2.0, sl_buffer=2.0, min_rr=1.0, max_entry_gap_r=99.0
+    )
     defaults.update(kwargs)
     return TripleSyncEngine(**defaults)
 
 
 def _agg_engine(**kwargs) -> TripleSyncEngine:
-    defaults = dict(min_fvg_size=2.0, sl_buffer=2.0, min_rr=1.0, profile=AGGRESSIVE)
+    defaults = dict(
+        min_fvg_size=2.0, sl_buffer=2.0, min_rr=1.0, max_entry_gap_r=99.0,
+        profile=AGGRESSIVE,
+    )
     defaults.update(kwargs)
     return TripleSyncEngine(**defaults)
 
@@ -293,3 +298,56 @@ class TestLiquidityTarget:
         assert result.verdict == Verdict.SKIP
         assert result.setup is None
         assert "no positive reward" in result.reasons[0]
+
+
+class TestEntryStalenessGate:
+    """Rule 5.1 (2026-08-05): a limit far below market never fills, so it is
+    not worth alerting on."""
+
+    def _long(self, price, **kwargs):
+        result = _fresh_result()
+        result.price = price
+        return _engine(**kwargs).evaluate(
+            h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
+            m5=m5_long_trigger_deep_sweep(),
+            result=result,
+        )
+
+    def test_long_skipped_when_price_has_run_past_the_entry(self):
+        # entry 3140.5, risk 16.5 -> at 0.5R the limit may sit at most
+        # 8.25 above market; 3160.0 is 19.5 away (1.18R).
+        result = self._long(3160.0, max_entry_gap_r=0.5)
+        assert result.verdict == Verdict.SKIP
+        assert result.setup is None
+        assert "1.2R" in result.reasons[0]
+
+    def test_long_approved_when_price_is_still_near_the_entry(self):
+        result = self._long(3145.0, max_entry_gap_r=0.5)
+        assert result.verdict == Verdict.APPROVED_LIMIT
+        assert result.setup is not None
+
+    def test_gate_is_silent_for_a_market_entry(self):
+        # price inside the FVG (3138.0-3140.5) is at or below the entry, so
+        # the gap is never positive and the tightest gate cannot fire.
+        result = self._long(3139.0, max_entry_gap_r=0.0)
+        assert result.verdict == Verdict.APPROVED_MARKET
+
+    def test_threshold_is_configurable(self):
+        assert self._long(3160.0, max_entry_gap_r=2.0).verdict == (
+            Verdict.APPROVED_LIMIT
+        )
+
+    def test_short_gate_measures_the_other_direction(self):
+        # Mirror of the long case on the K=6270 reflected fixture: entry
+        # 3129.5, risk 16.5. Price BELOW the entry is the run-away side.
+        result = _fresh_result()
+        result.price = 3110.0
+        out = _engine(max_entry_gap_r=0.5).evaluate(
+            h4=make_candles(H4_DOWNTREND_CLOSES, step_minutes=240),
+            h1=make_candles(H1_RALLY_INTO_SUPPLY_CLOSES, step_minutes=60),
+            m5=m5_short_trigger_deep_sweep(),
+            result=result,
+        )
+        assert out.verdict == Verdict.SKIP
+        assert out.setup is None

--- a/tests/test_smc/test_funnel.py
+++ b/tests/test_smc/test_funnel.py
@@ -30,6 +30,16 @@ def test_classify_flat_h4():
     assert classify_result(r) == "h4_flat"
 
 
+def test_classify_result_labels_low_rr():
+    result = AnalysisResult(
+        symbol="ETHUSD", verdict=Verdict.SKIP, checked_at=SESSION_BASE,
+    )
+    result.reasons.append(
+        "RR 1:0.6 < minimum 1:1 to the nearest liquidity (H1 swing high 3221.00)"
+    )
+    assert classify_result(result) == "rr_low"
+
+
 def test_replay_counts_at_least_one_approved_on_the_trigger_fixture():
     # H4/H1 are shifted so their history is fully closed at/before
     # SESSION_BASE (the m5 fixture's start) — a realistic point-in-time

--- a/tests/test_smc/test_funnel.py
+++ b/tests/test_smc/test_funnel.py
@@ -86,6 +86,10 @@ def test_replay_counts_at_least_one_approved_on_the_trigger_fixture():
         h1,
         m5_long_trigger(),
         profile=get_profile("conservative"),
+        # m5_long_trigger's live price sits further than the shipped 0.5R
+        # from its FVG entry (see task-7-report.md); this test is about
+        # point-in-time h4/h1 slicing, not Rule 5.1, so disable the gate.
+        max_entry_gap_r=99.0,
     )
     assert counts["approved"] >= 1
 

--- a/tests/test_smc/test_funnel.py
+++ b/tests/test_smc/test_funnel.py
@@ -51,6 +51,17 @@ def test_classify_result_labels_reward_inside_sl_buffer_as_no_liquidity():
     assert classify_result(result) == "no_liquidity"
 
 
+def test_classify_result_labels_a_stale_entry():
+    result = AnalysisResult(
+        symbol="ETHUSD", verdict=Verdict.SKIP, checked_at=SESSION_BASE,
+    )
+    result.reasons.append(
+        "Price has run 1.2R past the entry 3140.50 (max 0.5R) — the limit "
+        "would sit too far from market"
+    )
+    assert classify_result(result) == "entry_stale"
+
+
 def test_replay_counts_at_least_one_approved_on_the_trigger_fixture():
     # H4/H1 are shifted so their history is fully closed at/before
     # SESSION_BASE (the m5 fixture's start) — a realistic point-in-time

--- a/tests/test_smc/test_funnel.py
+++ b/tests/test_smc/test_funnel.py
@@ -86,7 +86,7 @@ def test_replay_counts_at_least_one_approved_on_the_trigger_fixture():
         h1,
         m5_long_trigger(),
         profile=get_profile("conservative"),
-        # m5_long_trigger's live price sits further than the shipped 0.5R
+        # m5_long_trigger's live price sits further than the shipped 0.75R
         # from its FVG entry (see task-7-report.md); this test is about
         # point-in-time h4/h1 slicing, not Rule 5.1, so disable the gate.
         max_entry_gap_r=99.0,

--- a/tests/test_smc/test_funnel.py
+++ b/tests/test_smc/test_funnel.py
@@ -40,6 +40,17 @@ def test_classify_result_labels_low_rr():
     assert classify_result(result) == "rr_low"
 
 
+def test_classify_result_labels_reward_inside_sl_buffer_as_no_liquidity():
+    result = AnalysisResult(
+        symbol="ETHUSD", verdict=Verdict.SKIP, checked_at=SESSION_BASE,
+    )
+    result.reasons.append(
+        "Nearest liquidity sits inside the SL buffer — no positive "
+        "reward to aim at"
+    )
+    assert classify_result(result) == "no_liquidity"
+
+
 def test_replay_counts_at_least_one_approved_on_the_trigger_fixture():
     # H4/H1 are shifted so their history is fully closed at/before
     # SESSION_BASE (the m5 fixture's start) — a realistic point-in-time

--- a/tests/test_smc/test_html_escaping.py
+++ b/tests/test_smc/test_html_escaping.py
@@ -9,7 +9,9 @@ import re
 from datetime import datetime, timezone
 
 from app.services.smc.liquidity import LiquidityLevel
-from app.services.smc.models import AnalysisResult, Verdict
+from app.services.smc.models import (
+    AnalysisResult, Direction, FVG, TradeSetup, Trend, Verdict,
+)
 from app.services.smc.news import NewsCalendar, parse_feed
 from app.services.smc.notifier import escape_html, format_no_setup, format_result, format_target
 
@@ -105,3 +107,65 @@ class TestTargetLine:
             equal_count=2, timestamp=None,
         )
         assert format_target(level, 2) == "H4 swing low 3050.00 (EQL x2)"
+
+    def test_format_result_rr_line_without_target(self):
+        """RR line with target=None stays unchanged (backward compat for old signals)."""
+        result = AnalysisResult(
+            symbol="ETHUSD",
+            verdict=Verdict.APPROVED_LIMIT,
+            checked_at=datetime(2026, 7, 16, 7, 12, tzinfo=timezone.utc),
+            price=3200.0,
+            h4_trend=Trend.UP,
+            price_decimals=2,
+        )
+        fvg = FVG(
+            index=10, bottom=3100.0, top=3150.0, is_bullish=True,
+            timestamp=datetime(2026, 7, 16, 7, 5, tzinfo=timezone.utc),
+        )
+        result.setup = TradeSetup(
+            direction=Direction.LONG,
+            entry=3125.0,
+            stop_loss=3050.0,
+            take_profit=3300.0,
+            rr=2.0,
+            fvg=fvg,
+            target=None,
+        )
+        text = format_result(result)
+        _assert_valid_telegram_html(text)
+        assert "📐 RR: 1:2.0" in text
+        # Should NOT have the arrow or target info
+        assert "→" not in text
+
+    def test_format_result_rr_line_with_target(self):
+        """RR line with target shows the liquidity objective."""
+        result = AnalysisResult(
+            symbol="ETHUSD",
+            verdict=Verdict.APPROVED_LIMIT,
+            checked_at=datetime(2026, 7, 16, 7, 12, tzinfo=timezone.utc),
+            price=3200.0,
+            h4_trend=Trend.UP,
+            price_decimals=2,
+        )
+        fvg = FVG(
+            index=10, bottom=3100.0, top=3150.0, is_bullish=True,
+            timestamp=datetime(2026, 7, 16, 7, 5, tzinfo=timezone.utc),
+        )
+        target_level = LiquidityLevel(
+            price=3221.0, is_high=True, timeframe="H1",
+            equal_count=3, timestamp=None,
+        )
+        result.setup = TradeSetup(
+            direction=Direction.LONG,
+            entry=3125.0,
+            stop_loss=3050.0,
+            take_profit=3300.0,
+            rr=2.0,
+            fvg=fvg,
+            target=target_level,
+        )
+        text = format_result(result)
+        _assert_valid_telegram_html(text)
+        assert "📐 RR: 1:2.0" in text
+        assert "→" in text
+        assert "H1 swing high 3221.00 (EQH x3)" in text

--- a/tests/test_smc/test_html_escaping.py
+++ b/tests/test_smc/test_html_escaping.py
@@ -8,9 +8,10 @@ start tag` because `<` was sent unescaped in parse_mode=HTML.
 import re
 from datetime import datetime, timezone
 
+from app.services.smc.liquidity import LiquidityLevel
 from app.services.smc.models import AnalysisResult, Verdict
 from app.services.smc.news import NewsCalendar, parse_feed
-from app.services.smc.notifier import escape_html, format_no_setup, format_result
+from app.services.smc.notifier import escape_html, format_no_setup, format_result, format_target
 
 
 def _assert_valid_telegram_html(text: str):
@@ -81,3 +82,26 @@ class TestEscaping:
         )
         _assert_valid_telegram_html(text)
         assert "S&amp;P" in text
+
+
+class TestTargetLine:
+    def test_rr_line_names_the_liquidity(self):
+        level = LiquidityLevel(
+            price=3221.0, is_high=True, timeframe="H1",
+            equal_count=1, timestamp=None,
+        )
+        assert format_target(level, 2) == "H1 swing high 3221.00"
+
+    def test_pool_size_is_shown(self):
+        level = LiquidityLevel(
+            price=3221.0, is_high=True, timeframe="H1",
+            equal_count=3, timestamp=None,
+        )
+        assert format_target(level, 2) == "H1 swing high 3221.00 (EQH x3)"
+
+    def test_low_pool_uses_eql(self):
+        level = LiquidityLevel(
+            price=3050.0, is_high=False, timeframe="H4",
+            equal_count=2, timestamp=None,
+        )
+        assert format_target(level, 2) == "H4 swing low 3050.00 (EQL x2)"

--- a/tests/test_smc/test_improvements.py
+++ b/tests/test_smc/test_improvements.py
@@ -46,20 +46,18 @@ class TestH4Reclaim:
 
 
 class TestFixedTp:
-    """Rule 7 (2026-07-30): TP is fixed at tp_rr × risk beyond the entry."""
+    """Rule 7 (2026-08-05): TP is the nearest unswept liquidity, not a fixed
+    multiple of risk."""
 
     def test_tp_is_fixed_multiple_of_risk(self):
-        result = TripleSyncEngine(tp_rr=2.5).evaluate(
+        result = TripleSyncEngine().evaluate(
             h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
             h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
             m5=m5_long_trigger(),
             result=_fresh_result(),
         )
         assert result.verdict == Verdict.APPROVED_LIMIT
-        setup = result.setup
-        risk = setup.entry - setup.stop_loss
-        assert setup.take_profit == round(setup.entry + 2.5 * risk, 2)
-        assert setup.rr == 2.5
+        assert result.setup.target is not None
 
 
 class TestCryptoSessionScope:

--- a/tests/test_smc/test_improvements.py
+++ b/tests/test_smc/test_improvements.py
@@ -45,11 +45,11 @@ class TestH4Reclaim:
         assert detect_trend(make_candles(closes)) == Trend.FLAT
 
 
-class TestFixedTp:
+class TestLiquidityTp:
     """Rule 7 (2026-08-05): TP is the nearest unswept liquidity, not a fixed
     multiple of risk."""
 
-    def test_tp_is_fixed_multiple_of_risk(self):
+    def test_tp_targets_nearest_liquidity(self):
         result = TripleSyncEngine().evaluate(
             h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
             h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),

--- a/tests/test_smc/test_improvements.py
+++ b/tests/test_smc/test_improvements.py
@@ -211,7 +211,12 @@ class TestJournal:
         )
         signal = journal.record(result)
         assert signal["status"] == "pending"
-        assert "Signals: 1" in journal.stats_text()
+        # `_fresh_result()` is pinned to SESSION_BASE (2026-07-06) so the
+        # session filters resolve deterministically, but `stats_text` defaults
+        # to a rolling 30-day window — leaving it implicit made this test start
+        # failing on 2026-08-05, the day the fixture date fell out of range.
+        # Pin the window too so the assertion does not expire with the calendar.
+        assert "Signals: 1" in journal.stats_text(days=36500)
 
         reloaded = SignalJournal(Database(str(tmp_path / "smc.db")))
         assert len(reloaded.signals) == 1

--- a/tests/test_smc/test_improvements.py
+++ b/tests/test_smc/test_improvements.py
@@ -50,7 +50,7 @@ class TestLiquidityTp:
     multiple of risk."""
 
     def test_tp_targets_nearest_liquidity(self):
-        result = TripleSyncEngine().evaluate(
+        result = TripleSyncEngine(max_entry_gap_r=99.0).evaluate(
             h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
             h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
             m5=m5_long_trigger(),
@@ -202,7 +202,7 @@ class TestJournal:
         journal = SignalJournal(db)
         result = _fresh_result()
         result.session_name = "New York"
-        engine = TripleSyncEngine()
+        engine = TripleSyncEngine(max_entry_gap_r=99.0)
         result = engine.evaluate(
             h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
             h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),

--- a/tests/test_smc/test_liquidity.py
+++ b/tests/test_smc/test_liquidity.py
@@ -1,0 +1,124 @@
+"""Liquidity levels: unswept swings and EQH/EQL clusters (Rule 7 targets)."""
+
+from app.services.smc.liquidity import (
+    LiquidityLevel,
+    find_liquidity,
+    nearest_liquidity,
+)
+from app.services.smc.models import Direction
+from tests.test_smc.helpers import candle
+
+# One high pivot at index 2 (3160) and one low pivot at index 5 (3140),
+# neither taken out by any later candle.
+_BASE = [
+    (3140.0, 3142.0, 3138.0, 3141.0),
+    (3141.0, 3148.0, 3140.0, 3147.0),
+    (3147.0, 3160.0, 3146.0, 3158.0),   # high pivot 3160
+    (3158.0, 3159.0, 3150.0, 3151.0),
+    (3151.0, 3152.0, 3144.0, 3145.0),
+    (3145.0, 3146.0, 3140.0, 3141.0),   # low pivot 3140
+    (3141.0, 3147.0, 3140.5, 3146.0),
+    (3146.0, 3150.0, 3145.0, 3149.0),
+    (3149.0, 3151.0, 3148.0, 3150.0),
+]
+
+
+def _series(spec):
+    return [candle(*row, index=i) for i, row in enumerate(spec)]
+
+
+class TestFindLiquidity:
+    def test_unswept_swings_become_levels(self):
+        levels = find_liquidity(_series(_BASE), "H1", tolerance=2.0)
+        highs = [lv for lv in levels if lv.is_high]
+        lows = [lv for lv in levels if not lv.is_high]
+        assert [lv.price for lv in highs] == [3160.0]
+        assert [lv.price for lv in lows] == [3140.0]
+        assert highs[0].timeframe == "H1"
+        assert highs[0].equal_count == 1
+
+    def test_wick_beyond_tolerance_sweeps_the_level(self):
+        # A later candle wicks to 3163 (> 3160 + 2.0) but closes far below:
+        # the pool is taken even though no body closed above it.
+        swept = _series(_BASE + [(3150.0, 3163.0, 3149.0, 3150.0)])
+        highs = [lv for lv in find_liquidity(swept, "H1", 2.0) if lv.is_high]
+        assert highs == []
+
+    def test_poke_inside_tolerance_does_not_sweep(self):
+        # 3161.5 is only 1.5 above 3160 — less than the 2.0 tolerance, so the
+        # pool survives. Without this, two "equal" highs could never coexist.
+        poked = _series(_BASE + [(3150.0, 3161.5, 3149.0, 3150.0)])
+        highs = [lv for lv in find_liquidity(poked, "H1", 2.0) if lv.is_high]
+        assert [lv.price for lv in highs] == [3160.0]
+
+
+class TestEqualHighsClustering:
+    # A second attempt at the same area stalls 0.5 short of the first high:
+    # two unswept highs 0.5 apart = one EQH pool.
+    _EQH = _BASE + [
+        (3150.0, 3159.5, 3149.0, 3158.0),   # high pivot 3159.5
+        (3158.0, 3157.0, 3150.0, 3151.0),
+        (3151.0, 3152.0, 3146.0, 3147.0),
+        (3147.0, 3148.0, 3145.0, 3146.0),
+        (3146.0, 3147.0, 3144.0, 3145.0),
+    ]
+
+    def test_two_close_highs_form_one_cluster(self):
+        highs = [lv for lv in find_liquidity(_series(self._EQH), "H1", 2.0)
+                 if lv.is_high]
+        assert len(highs) == 1
+        assert highs[0].equal_count == 2
+
+    def test_cluster_price_is_the_near_side(self):
+        # Price approaches highs from below, so the pool starts at the LOWER
+        # of the two equal highs.
+        highs = [lv for lv in find_liquidity(_series(self._EQH), "H1", 2.0)
+                 if lv.is_high]
+        assert highs[0].price == 3159.5
+
+    def test_highs_beyond_tolerance_stay_separate(self):
+        levels = find_liquidity(_series(self._EQH), "H1", tolerance=0.2)
+        highs = sorted(
+            (lv for lv in levels if lv.is_high), key=lambda lv: lv.price
+        )
+        assert [lv.price for lv in highs] == [3159.5, 3160.0]
+        assert all(lv.equal_count == 1 for lv in highs)
+
+
+class TestNearestLiquidity:
+    def _level(self, price, is_high=True, tf="H1", count=1):
+        return LiquidityLevel(
+            price=price, is_high=is_high, timeframe=tf,
+            equal_count=count, timestamp=None,
+        )
+
+    def test_long_ignores_levels_at_or_below_entry(self):
+        levels = [self._level(3100.0), self._level(3210.0), self._level(3180.0)]
+        best = nearest_liquidity(levels, Direction.LONG, entry=3150.0)
+        assert best.price == 3180.0
+
+    def test_long_ignores_lows(self):
+        levels = [self._level(3180.0, is_high=False), self._level(3210.0)]
+        best = nearest_liquidity(levels, Direction.LONG, entry=3150.0)
+        assert best.price == 3210.0
+
+    def test_short_takes_the_highest_low_below_entry(self):
+        levels = [
+            self._level(3100.0, is_high=False),
+            self._level(3140.0, is_high=False),
+        ]
+        best = nearest_liquidity(levels, Direction.SHORT, entry=3150.0)
+        assert best.price == 3140.0
+
+    def test_equal_distance_prefers_the_cluster(self):
+        levels = [
+            self._level(3180.0, tf="M5", count=1),
+            self._level(3180.0, tf="H1", count=3),
+        ]
+        best = nearest_liquidity(levels, Direction.LONG, entry=3150.0)
+        assert best.equal_count == 3
+        assert best.timeframe == "H1"
+
+    def test_no_level_beyond_entry_returns_none(self):
+        levels = [self._level(3100.0)]
+        assert nearest_liquidity(levels, Direction.LONG, entry=3150.0) is None

--- a/tests/test_smc/test_liquidity.py
+++ b/tests/test_smc/test_liquidity.py
@@ -85,6 +85,70 @@ class TestEqualHighsClustering:
         assert all(lv.equal_count == 1 for lv in highs)
 
 
+class TestEqualLowsClustering:
+    # A second attempt at the same area stalls 0.5 above the first low:
+    # two unswept lows 0.5 apart = one EQL pool.
+    _EQL = _BASE + [
+        (3150.0, 3151.0, 3140.5, 3141.0),   # low pivot 3140.5
+        (3141.0, 3147.0, 3140.6, 3146.0),
+        (3146.0, 3150.0, 3145.0, 3149.0),
+        (3149.0, 3151.0, 3148.0, 3150.0),
+        (3150.0, 3152.0, 3149.0, 3151.0),
+    ]
+
+    def test_two_close_lows_form_one_cluster(self):
+        lows = [lv for lv in find_liquidity(_series(self._EQL), "H1", 2.0)
+                if not lv.is_high]
+        assert len(lows) == 1
+        assert lows[0].equal_count == 2
+
+    def test_cluster_price_is_the_near_side(self):
+        # Price approaches lows from above, so the pool starts at the HIGHER
+        # of the two equal lows — a SHORT meets the highest low first.
+        lows = [lv for lv in find_liquidity(_series(self._EQL), "H1", 2.0)
+                if not lv.is_high]
+        assert lows[0].price == 3140.5
+
+
+class TestClusterSpanExceedsTolerance:
+    # Three successive attempts at resistance, each stalling a bit short of
+    # the last: 3163.0 -> 3161.5 -> 3160.0. Each neighbor pair is within the
+    # 2.0 tolerance (1.5 apart), but the span from the lowest (3160.0) to the
+    # highest (3163.0) is 3.0 > tolerance. _cluster groups from the first
+    # (lowest-price) member outward, so this must split into a pair
+    # (3160.0/3161.5) plus a singleton (3163.0), not one pool of 3.
+    _SPAN3 = [
+        (3140.0, 3142.0, 3138.0, 3141.0),
+        (3141.0, 3148.0, 3140.0, 3147.0),
+        (3147.0, 3163.0, 3146.0, 3161.0),   # high pivot 3163.0
+        (3161.0, 3162.0, 3150.0, 3151.0),
+        (3151.0, 3152.0, 3144.0, 3145.0),
+        (3145.0, 3146.0, 3140.0, 3141.0),
+        (3141.0, 3147.0, 3140.5, 3146.0),
+        (3146.0, 3161.5, 3145.0, 3160.0),   # high pivot 3161.5
+        (3160.0, 3161.0, 3150.0, 3151.0),
+        (3151.0, 3152.0, 3144.0, 3145.0),
+        (3145.0, 3146.0, 3140.0, 3141.0),
+        (3141.0, 3147.0, 3140.5, 3146.0),
+        (3146.0, 3160.0, 3145.0, 3159.0),   # high pivot 3160.0
+        (3159.0, 3159.5, 3150.0, 3151.0),
+        (3151.0, 3152.0, 3144.0, 3145.0),
+        (3145.0, 3146.0, 3140.0, 3141.0),
+        (3141.0, 3147.0, 3140.5, 3146.0),
+        (3146.0, 3150.0, 3145.0, 3149.0),
+    ]
+
+    def test_span_beyond_tolerance_splits_into_pair_and_singleton(self):
+        highs = sorted(
+            (lv for lv in find_liquidity(_series(self._SPAN3), "H1", 2.0)
+             if lv.is_high),
+            key=lambda lv: lv.price,
+        )
+        assert len(highs) == 2
+        assert highs[0].price == 3160.0 and highs[0].equal_count == 2
+        assert highs[1].price == 3163.0 and highs[1].equal_count == 1
+
+
 class TestNearestLiquidity:
     def _level(self, price, is_high=True, tf="H1", count=1):
         return LiquidityLevel(
@@ -118,6 +182,17 @@ class TestNearestLiquidity:
         best = nearest_liquidity(levels, Direction.LONG, entry=3150.0)
         assert best.equal_count == 3
         assert best.timeframe == "H1"
+
+    def test_equal_distance_and_equal_count_breaks_on_timeframe(self):
+        # equal_count ties too, so this only resolves via the timeframe rank
+        # (H4 > H1 > M5) — exercised on its own, not shadowed by cluster size.
+        levels = [
+            self._level(3180.0, tf="M5", count=2),
+            self._level(3180.0, tf="H4", count=2),
+            self._level(3180.0, tf="H1", count=2),
+        ]
+        best = nearest_liquidity(levels, Direction.LONG, entry=3150.0)
+        assert best.timeframe == "H4"
 
     def test_no_level_beyond_entry_returns_none(self):
         levels = [self._level(3100.0)]

--- a/tests/test_smc/test_plan.py
+++ b/tests/test_smc/test_plan.py
@@ -1,5 +1,7 @@
 """Tests for the Pre-Market Plan builder, formatter and H1 chart."""
 
+import dataclasses
+
 from app.services.smc.chart import render_plan_chart
 from app.services.smc.instruments import get_instrument
 from app.services.smc.models import Direction, Trend
@@ -66,6 +68,24 @@ class TestBuildPlan:
         assert s.take_profit != round(s.entry + 2.5 * abs(s.entry - s.stop_loss), 2)
         assert s.rr >= 1.0
 
+    def test_scenario_tp_is_the_exact_nearest_liquidity(self):
+        # entry = H1 demand zone top = 3138.0, stop = zone bottom (3131.0) -
+        # sl_buffer (2.0) = 3129.0 -> risk = 9.0. Nearest unswept liquidity
+        # above entry is the H1 swing high at 3221.0 (same pool as
+        # TestLiquidityTarget in test_engine.py); TP = 3221.0 - 2.0 = 3219.0.
+        # rr = (3219.0 - 3138.0) / 9.0 = 81.0 / 9.0 = 9.0 exactly.
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3140, 3142, 3145])
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0, profile=CONSERVATIVE)
+        assert len(plan.scenarios) == 1
+        s = plan.scenarios[0]
+        assert s.direction == Direction.LONG
+        assert s.entry == 3138.0
+        assert s.stop_loss == 3129.0
+        assert s.take_profit == 3219.0
+        assert s.rr == 9.0
+
     def test_scenario_below_threshold_is_explained(self):
         h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
         h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
@@ -73,6 +93,19 @@ class TestBuildPlan:
         plan = build_plan(ETH, h4, h1, m5, min_rr=99.0)
         assert plan.scenarios == []
         assert "1:" in plan.note
+
+    def test_scenario_skipped_when_target_is_inside_the_sl_buffer(self):
+        # An inflated sl_buffer pulls the target within one buffer of entry:
+        # TP = 3221.0 - 100 = 3121.0, BELOW entry 3138.0 for a LONG scenario
+        # -- a negative reward that abs() alone would report as a positive
+        # RR. min_rr=0.1 proves the skip does not depend on the threshold.
+        big_buffer = dataclasses.replace(ETH, sl_buffer=100.0)
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3160.0], step_minutes=5)
+        plan = build_plan(big_buffer, h4, h1, m5, min_rr=0.1, profile=CONSERVATIVE)
+        assert plan.scenarios == []
+        assert "no positive reward" in plan.note
 
 
 class TestFormatAndChart:
@@ -102,7 +135,7 @@ class TestFormatAndChart:
         assert render_plan_chart(plan, h1) is None
 
 
-class TestFixedTpAndProfile:
+class TestLiquidityTpAndProfile:
     def test_aggressive_profile_takes_h4_choch_direction_when_flat(self):
         # H4 uptrend then a decisive, unreclaimed break of the last HL: trend
         # downgrades to FLAT but an aggressive trader can take the CHoCH
@@ -121,6 +154,8 @@ class TestFixedTpAndProfile:
         assert s.direction == Direction.SHORT
         assert not s.speculative
         assert s.rr >= 2.0
+        # SHORT: TP below entry below stop, never the LONG-side ordering.
+        assert s.take_profit < s.entry < s.stop_loss
 
     def test_conservative_profile_ignores_h4_choch_when_flat(self):
         # same fixture, but conservative never reads the CHoCH: it falls back

--- a/tests/test_smc/test_plan.py
+++ b/tests/test_smc/test_plan.py
@@ -23,7 +23,7 @@ class TestBuildPlan:
     def test_uptrend_projects_long(self):
         # price above the H1 demand zone (top 3138) so the plan is a pullback long
         h4, h1, m5 = _uptrend_data(3160.0)
-        plan = build_plan(ETH, h4, h1, m5, tp_rr=2.5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
         assert plan.h4_trend == Trend.UP
         assert len(plan.scenarios) == 1
         s = plan.scenarios[0]
@@ -37,7 +37,7 @@ class TestBuildPlan:
         h4 = make_candles(flat, step_minutes=240)
         h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
         m5 = make_candles([3165.0], step_minutes=5)
-        plan = build_plan(ETH, h4, h1, m5, tp_rr=2.5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
         assert plan.h4_trend == Trend.FLAT
         # a demand zone below and a supply zone above -> up to two brackets
         assert all(s.speculative for s in plan.scenarios)
@@ -46,20 +46,39 @@ class TestBuildPlan:
 
     def test_market_closed_note(self):
         h4, h1, m5 = _uptrend_data(3160.0)
-        plan = build_plan(ETH, h4, h1, m5, tp_rr=2.5, market_closed=True)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0, market_closed=True)
         assert plan.scenarios == [] and "closed" in plan.note.lower()
 
     def test_long_skipped_when_zone_above_price(self):
         # price below the demand zone -> not a clean pullback-long plan
         h4, h1, m5 = _uptrend_data(3120.0)
-        plan = build_plan(ETH, h4, h1, m5, tp_rr=2.5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
         assert plan.scenarios == [] and plan.note
+
+    def test_scenario_targets_liquidity(self):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3150, 3152, 3151, 3153])
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
+        assert plan.scenarios
+        s = plan.scenarios[0]
+        # TP is a structural level, not a multiple of the risk
+        assert s.take_profit != round(s.entry + 2.5 * abs(s.entry - s.stop_loss), 2)
+        assert s.rr >= 1.0
+
+    def test_scenario_below_threshold_is_explained(self):
+        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
+        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
+        m5 = make_candles([3150, 3152, 3151, 3153])
+        plan = build_plan(ETH, h4, h1, m5, min_rr=99.0)
+        assert plan.scenarios == []
+        assert "1:" in plan.note
 
 
 class TestFormatAndChart:
     def test_format_plan_html(self):
         h4, h1, m5 = _uptrend_data(3160.0)
-        plan = build_plan(ETH, h4, h1, m5, tp_rr=2.5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
         text = format_plan(plan)
         assert "Pre-Market Plan" in text and "LONG" in text
         assert "Buy Limit" in text and "SL" in text and "TP" in text
@@ -67,37 +86,23 @@ class TestFormatAndChart:
 
     def test_note_only_message(self):
         h4, h1, m5 = _uptrend_data(3120.0)  # produces a note, no scenarios
-        plan = build_plan(ETH, h4, h1, m5, tp_rr=2.5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
         text = format_plan(plan)
         assert "ℹ️" in text
 
     def test_render_plan_chart_png(self):
         h4, h1, m5 = _uptrend_data(3160.0)
-        plan = build_plan(ETH, h4, h1, m5, tp_rr=2.5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
         png = render_plan_chart(plan, h1)
         assert png is not None and png[:4] == b"\x89PNG"
 
     def test_chart_none_without_scenarios(self):
         h4, h1, m5 = _uptrend_data(3120.0)
-        plan = build_plan(ETH, h4, h1, m5, tp_rr=2.5)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
         assert render_plan_chart(plan, h1) is None
 
 
 class TestFixedTpAndProfile:
-    def test_plan_tp_is_fixed_multiple_of_risk(self):
-        inst = get_instrument("ETHUSD")
-        h4 = make_candles(H4_UPTREND_CLOSES, step_minutes=240)
-        h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
-        m5 = make_candles([3140, 3142, 3145])
-        plan = build_plan(inst, h4, h1, m5, tp_rr=2.5, profile=CONSERVATIVE)
-        assert plan.scenarios
-        for s in plan.scenarios:
-            risk = abs(s.entry - s.stop_loss)
-            assert s.rr == 2.5
-            assert s.take_profit == round(
-                s.entry + (2.5 if s.direction == Direction.LONG else -2.5) * risk, 2
-            )
-
     def test_aggressive_profile_takes_h4_choch_direction_when_flat(self):
         # H4 uptrend then a decisive, unreclaimed break of the last HL: trend
         # downgrades to FLAT but an aggressive trader can take the CHoCH
@@ -108,7 +113,7 @@ class TestFixedTpAndProfile:
         m5 = make_candles([3150.0], step_minutes=5)
 
         plan = build_plan(
-            get_instrument("ETHUSD"), h4, h1, m5, tp_rr=2.5, profile=AGGRESSIVE
+            get_instrument("ETHUSD"), h4, h1, m5, min_rr=1.0, profile=AGGRESSIVE
         )
         assert plan.h4_trend == Trend.FLAT
         assert len(plan.scenarios) == 1
@@ -126,7 +131,7 @@ class TestFixedTpAndProfile:
         m5 = make_candles([3150.0], step_minutes=5)
 
         plan = build_plan(
-            get_instrument("ETHUSD"), h4, h1, m5, tp_rr=2.5, profile=CONSERVATIVE
+            get_instrument("ETHUSD"), h4, h1, m5, min_rr=1.0, profile=CONSERVATIVE
         )
         assert plan.h4_trend == Trend.FLAT
         assert all(s.speculative for s in plan.scenarios)

--- a/tests/test_smc/test_plan.py
+++ b/tests/test_smc/test_plan.py
@@ -123,6 +123,20 @@ class TestFormatAndChart:
         text = format_plan(plan)
         assert "ℹ️" in text
 
+    def test_footnote_reflects_the_liquidity_stop_reanchor(self):
+        # The old footnote claimed the live alert "tightens" the SL to an M5
+        # pivot; Rule 6 now anchors to the swept extreme, which can be wider
+        # than the plan's preliminary zone-bottom stop. The footnote must not
+        # promise a tighten, and must not still mention the M5 pivot.
+        h4, h1, m5 = _uptrend_data(3160.0)
+        plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)
+        text = format_plan(plan)
+        assert "re-anchors it to the swept extreme" in text
+        assert "may be wider" in text
+        assert "M5 pivot" not in text
+        assert "tighten" not in text.lower()
+        assert "Order lives only within its session." in text
+
     def test_render_plan_chart_png(self):
         h4, h1, m5 = _uptrend_data(3160.0)
         plan = build_plan(ETH, h4, h1, m5, min_rr=1.0)

--- a/tests/test_smc/test_structure.py
+++ b/tests/test_smc/test_structure.py
@@ -8,8 +8,6 @@ from app.services.smc.structure import (
     find_choch,
     find_h1_zone,
     find_pivots,
-    find_target_zone,
-    find_target_zones,
     h4_choch_direction,
     zone_touch_span,
 )
@@ -27,13 +25,6 @@ def test_find_h1_zone_untested_only_by_default():
     zone = find_h1_zone(h1, Direction.LONG)  # max_touches=0
     assert zone is not None
     assert zone.touches == 0
-
-
-def test_find_target_zones_sorted_nearest_first():
-    h1 = make_candles(H1_PULLBACK_CLOSES, step_minutes=60)
-    zones = find_target_zones(h1, Direction.LONG, entry=3138.0)
-    tops = [z.bottom for z in zones]
-    assert tops == sorted(tops)  # nearest (smallest bottom above entry) first
 
 
 def test_h4_choch_direction_none_on_clean_uptrend():
@@ -113,14 +104,6 @@ class TestZones:
         assert zone.bottom == 3131.0  # pivot candle low
         assert zone.top == 3138.0  # pivot candle body high
         assert not zone.tested and not zone.invalidated
-
-    def test_target_supply_zone_above_entry(self):
-        target = find_target_zone(
-            make_candles(H1_PULLBACK_CLOSES), Direction.LONG, entry=3139.5
-        )
-        assert target is not None
-        assert not target.is_demand
-        assert target.bottom == 3200.0  # pivot candle body low
 
     def test_no_zone_when_structure_missing(self):
         flat = make_candles([3000] * 12)

--- a/tests/test_smc/test_structure.py
+++ b/tests/test_smc/test_structure.py
@@ -11,7 +11,6 @@ from app.services.smc.structure import (
     find_target_zone,
     find_target_zones,
     h4_choch_direction,
-    last_protective_pivot,
     zone_touch_span,
 )
 from tests.test_smc.helpers import (
@@ -158,9 +157,3 @@ class TestM5Trigger:
         assert find_choch(m5, Direction.LONG, span[1]) is None
         # NEW behaviour (excursion start): CHoCH at index 8 is found.
         assert find_choch(m5, Direction.LONG, span[0]) == 8
-
-    def test_protective_pivot_for_stop_loss(self):
-        m5 = m5_long_trigger()
-        pivot = last_protective_pivot(m5, Direction.LONG, before_index=16)
-        assert pivot is not None
-        assert pivot.price == 3130.0

--- a/tests/test_smc/test_visuals.py
+++ b/tests/test_smc/test_visuals.py
@@ -122,9 +122,11 @@ class TestLiveCardEvents:
         result = _approved_result()
         signal = journal.record(result)
         start = datetime(2026, 7, 6, 15, 45, tzinfo=timezone.utc)
+        # TP is now the nearest unswept liquidity: H1 swing high 3221.0 minus
+        # the $2 buffer = 3219.0 (see TestLiquidityTarget for the arithmetic).
         candles = [
             candle(3142, 3143, 3139.0, 3141, start=start, index=0),  # fills 3139.5
-            candle(3141, 3205, 3140, 3201, start=start, index=1),  # hits TP 3200
+            candle(3141, 3225, 3140, 3222, start=start, index=1),  # hits TP 3219.0
         ]
         events = journal.update_pair("ETHUSD", candles)
         assert [e for _, e in events] == ["filled", "tp"]

--- a/tests/test_smc/test_visuals.py
+++ b/tests/test_smc/test_visuals.py
@@ -26,7 +26,7 @@ def _approved_result() -> AnalysisResult:
         checked_at=datetime(2026, 7, 6, 15, 40, tzinfo=timezone.utc),
     )
     result.session_name = "New York"
-    result = TripleSyncEngine().evaluate(
+    result = TripleSyncEngine(max_entry_gap_r=99.0).evaluate(
         h4=make_candles(H4_UPTREND_CLOSES, step_minutes=240),
         h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
         m5=m5_long_trigger(),

--- a/tests/test_smc/test_visuals.py
+++ b/tests/test_smc/test_visuals.py
@@ -147,6 +147,72 @@ class TestChart:
         result.m5_candles = None
         assert render_setup_chart(result) is None
 
+    def test_far_away_take_profit_does_not_blow_out_the_ylim(self, monkeypatch):
+        """A liquidity TP can sit an H4 pool away from price (hundreds of
+        points); the y-axis must stay clamped to the candle range instead of
+        autoscaling out to include it (Important finding 1)."""
+        import app.services.smc.chart as chart_mod
+
+        result = _approved_result()
+        candles = result.m5_candles[-chart_mod.CHART_CANDLES:]
+        candle_hi = max(c.high for c in candles)
+        candle_lo = min(c.low for c in candles)
+        candle_span = candle_hi - candle_lo
+
+        # Push the take-profit far outside the candle range, like a distant
+        # H4 liquidity pool the old fixed-RR rule could never produce.
+        result.setup.take_profit = candle_hi + 200.0
+
+        captured = {}
+        real_subplots = chart_mod.plt.subplots
+
+        def spy_subplots(*args, **kwargs):
+            fig, ax = real_subplots(*args, **kwargs)
+            real_set_ylim = ax.set_ylim
+
+            def spy_set_ylim(*a, **kw):
+                out = real_set_ylim(*a, **kw)
+                captured["ylim"] = ax.get_ylim()
+                return out
+
+            ax.set_ylim = spy_set_ylim
+            return fig, ax
+
+        monkeypatch.setattr(chart_mod.plt, "subplots", spy_subplots)
+
+        png = chart_mod.render_setup_chart(result)
+
+        assert png is not None and png[:4] == b"\x89PNG"
+        assert "ylim" in captured
+        ylo, yhi = captured["ylim"]
+        # The window still brackets the candle range tightly — nowhere near
+        # the take-profit 200 points above it.
+        assert ylo <= candle_lo
+        assert yhi < candle_hi + candle_span
+        assert yhi - ylo < candle_span * 1.5
+
+    def test_far_take_profit_draws_edge_annotation_not_axhline(self):
+        """A level outside the y-window gets a fixed edge annotation, never
+        an autoscaling axhline (the mechanism behind the blowout): no Line2D
+        is added at the far price, and the axis limits are untouched."""
+        import matplotlib.pyplot as plt
+
+        from app.services.smc.chart import _level, _price_ylim
+
+        candles = _approved_result().m5_candles[-50:]
+        ylim = _price_ylim(candles, (3140.0, 3130.0))
+        fig, ax = plt.subplots()
+        try:
+            ax.set_ylim(*ylim)
+            far_price = ylim[1] + 500.0
+            _level(ax, far_price, "#089981", "TP 9999.00", 10, y_bounds=ylim)
+            assert ax.get_ylim() == ylim  # unaffected by drawing the level
+            assert ax.get_lines() == []  # no axhline drawn for the far price
+            assert len(ax.texts) == 1  # the edge annotation itself
+            assert "↑" in ax.texts[0].get_text()
+        finally:
+            plt.close(fig)
+
 
 class TestPrettyStats:
     def test_stats_contains_bars_and_sparkline(self, tmp_path):

--- a/tests/test_smc/test_zone_ping.py
+++ b/tests/test_smc/test_zone_ping.py
@@ -77,10 +77,6 @@ def _watcher(monkeypatch):
     from smc_watcher import Watcher
 
     monkeypatch.setattr(settings.smc, "zone_ping", True)
-    # Rule 5.1's default gate (0.5R) is unrelated to what these tests cover
-    # and m5_long_trigger's live price sits further than that from its
-    # entry; disable it so _live_status keeps reporting the setup.
-    monkeypatch.setattr(settings.smc, "max_entry_gap_r", 99.0)
     w = Watcher.__new__(Watcher)
     w.state = _State()
     w.notifier = _Notifier()
@@ -150,6 +146,12 @@ class TestZonePing:
 class TestLiveStatus:
     def test_reports_live_setup(self, monkeypatch):
         w = _watcher(monkeypatch)
+        # Rule 5.1's default gate (0.5R) is unrelated to what this test
+        # covers and m5_long_trigger's live price sits further than that
+        # from its entry; disable it so _live_status keeps reporting the
+        # setup. Only this test runs the engine through _build_engine, so
+        # only it needs the override.
+        monkeypatch.setattr(settings.smc, "max_entry_gap_r", 99.0)
         data = {
             "h4": make_candles(H4_UPTREND_CLOSES, step_minutes=240),
             "h1": make_candles(H1_PULLBACK_CLOSES, step_minutes=60),

--- a/tests/test_smc/test_zone_ping.py
+++ b/tests/test_smc/test_zone_ping.py
@@ -26,7 +26,7 @@ def _fresh():
 
 
 def _eval(m5, h4=None):
-    return TripleSyncEngine().evaluate(
+    return TripleSyncEngine(max_entry_gap_r=99.0).evaluate(
         h4=h4 or make_candles(H4_UPTREND_CLOSES, step_minutes=240),
         h1=make_candles(H1_PULLBACK_CLOSES, step_minutes=60),
         m5=m5,
@@ -77,6 +77,10 @@ def _watcher(monkeypatch):
     from smc_watcher import Watcher
 
     monkeypatch.setattr(settings.smc, "zone_ping", True)
+    # Rule 5.1's default gate (0.5R) is unrelated to what these tests cover
+    # and m5_long_trigger's live price sits further than that from its
+    # entry; disable it so _live_status keeps reporting the setup.
+    monkeypatch.setattr(settings.smc, "max_entry_gap_r", 99.0)
     w = Watcher.__new__(Watcher)
     w.state = _State()
     w.notifier = _Notifier()


### PR DESCRIPTION
## 📝 Pull Request Description

### What does this PR do?

Replaces two strategy rules and adds a third, per the owner's decision of 2026-08-05.

- **Rule 7 — take-profit.** Was a fixed `SMC_TP_RR × risk` (2.5), with the RR *assigned* rather than computed, so every alert read `1:2.5`. Now the TP is the nearest **unswept liquidity** level — an unswept swing high/low or an EQH/EQL pool — scanned across M5, H1 and H4, placed one `sl_buffer` short of the level so the trade exits before the sweep. RR is computed from it and the setup is skipped below `SMC_MIN_RR` (default 1.0).
- **Rule 6 — stop.** Was the last confirmed M5 fractal pivot at or before the CHoCH. Now the extreme of the zone excursion (`structure.sweep_extreme`). This fixes a real defect: when a shallower fractal formed after the sweep, the stop landed *inside* the wick that had just run the stops.
- **Rule 5.1 — entry staleness (new).** Skips a setup once price has run more than `SMC_MAX_ENTRY_GAP_R × risk` (default 0.75) past the entry, because the limit order would sit too far from market to fill.

New module `app/services/smc/liquidity.py` introduces the liquidity concept the codebase lacked: unswept swing extremes and EQH/EQL pools, built on the existing `structure.find_pivots`. Sweep detection is wick-based (liquidity is taken by a wick, not a body close) and carries the same per-instrument tolerance as clustering — without that tolerance, two near-equal highs could never form a pool because the higher one would "sweep" the lower.

Alerts now name the objective: `📐 RR: 1:1.4  →  H1 swing high 3002.00 (EQH x2)`.

`plan.py` moved to the same target search so `/plan` and live alerts stop naming different objectives for the same pair. The alert chart's y-axis is now clamped — a liquidity target can sit hundreds of points away and matplotlib's autoscaling was squashing the candles into a third of the frame.

### Why is this change needed?

The fixed take-profit made the RR in every alert a constant rather than a measurement. The owner wants a structural target: stop behind the swept liquidity, take-profit at the nearest unswept liquidity, and any setup whose real RR reaches 1:1.

Rule 5.1 exists because the first replay of the new rule showed **80–90% of limit orders never filling**. The mechanism: Rule 7's gate can only pass once the near pools have been swept — i.e. once price has already left an entry still anchored to an hours-old FVG. Median distance from market to the limit at alert time was $19.60–23.40, against $1.50–5.30 under the fixed rule.

### How was this tested?

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Performance testing (if applicable)

229 tests pass, `flake8 app/ tests/ smc_watcher.py scripts/` clean. New `tests/test_smc/test_liquidity.py` covers sweep detection, the tolerance boundary in both directions, EQH/EQL clustering and near-side anchoring, and target selection. Engine regressions pin the sweep-extreme stop against the old pivot stop on a fixture built so the two disagree, and pin the SHORT side of both the TP sign and the staleness gate on a mirrored fixture.

**Offline validation** (analysis only, nothing in the repo): the rules were replayed over **a year of five instruments** — ETHUSD from Binance (105k M5 bars) and USDJPY/EURUSD/GBPUSD/USDCAD from TwelveData (~91k M5 each), 2025-08-05 → 2026-08-05 — with point-in-time higher-timeframe slicing, rising-edge *and* unique-idea counting, and production journal outcome semantics.

| | unfilled, gate off | unfilled, gate 0.75 |
|---|---|---|
| ETHUSD conservative | 53.5% | **31.4%** |
| ETHUSD aggressive | 59.8% | **30.7%** |
| Forex pooled, conservative | 63.3% | **35.0%** |
| Forex pooled, aggressive | 67.7% | **38.3%** |

The take-profit rule itself is **not** distinguishable from the fixed 2.5R it replaces (Welch t 0.56–2.22 across every comparison), and on ETHUSD a flat 2.0–2.5R exit on the *same* entries beat the liquidity exit in all eight paired cells — so the measurable improvement here comes from Rules 5.1 and 6, not Rule 7. What is significant: the incumbent fixed-2.5R rule *loses* on pooled forex, −96.50R over 513 closed trades, t −2.88.

Separating a 0.1R/trade difference would need roughly 2000 closed trades per arm — three to six more years. Rule 7 is an owner conviction call, not a statistical one, and this PR does not claim otherwise.

Two candidate changes were tested and **rejected on the data**: excluding M5 from the target scan (fill rate unchanged at 31.4→31.5% on ETH, four forex cells better and four worse, alert count merely doubles), and a tighter staleness gate (0.25/0.5 silenced the conservative profile entirely — zero alerts in 59 days).

### Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the code has been performed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] Corresponding changes to documentation have been made
- [x] Changes generate no new warnings
- [x] Tests pass locally
- [x] New and existing unit tests pass locally
- [x] Any dependent changes have been merged and published

### Breaking Changes

- [x] This PR contains breaking changes
- [x] Migration guide provided (if applicable)

**`SMC_TP_RR` is removed.** It is ignored rather than fatal if left set (`extra="ignore"`, verified by loading `Settings()` with it present), but **it must be deleted from the Railway service variables** — otherwise it sits there looking meaningful while doing nothing.

Two new variables, both with working defaults, so no action is required to deploy:

```
SMC_MIN_RR=1.0            # minimum RR to the nearest unswept liquidity
SMC_MAX_ENTRY_GAP_R=0.75  # skip once price has run this many R past the entry
```

`structure.last_protective_pivot`, `structure.find_target_zone` and `find_target_zones` are deleted along with their tests — they lost their last callers.

### Additional Notes

The commit `dfd66e1` fixes an **unrelated pre-existing failure**: `test_journal_records_and_reports` asserted against `stats_text()`'s rolling 30-day window while recording a signal pinned to the fixture date 2026-07-06. It began failing on 2026-08-05 — verified failing on `master` at `f14f327` too — because that date fell out of the window. The window is now explicit so the assertion does not expire with the calendar. Without this, CI on master is red from today regardless of this PR.

`key.env` was added to `.gitignore`: TwelveData keys were supplied through it during the offline validation and the existing `.env` rule did not cover it.

---

## 🔍 Review Guidelines

### Testing Instructions

1. Checkout this branch
2. `pip install -r requirements.txt`
3. `pytest tests/ -v` and `flake8 app/ tests/ smc_watcher.py scripts/`
4. `python -m scripts.funnel --pair ETHUSD --days 59 --legacy` — the funnel now defaults the staleness gate to production (0.75), so its stage histogram reflects what the bot would actually alert; `entry_stale` should appear as a late-stage rejection.
